### PR TITLE
Add snapshot tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["@babel/preset-env", { "targets": { "node": "current" } }],
+    "@babel/preset-typescript",
+    ["@babel/preset-react", { "runtime": "automatic" }]
+  ]
+}

--- a/docs/testing/implementation/snapshot-tests.md
+++ b/docs/testing/implementation/snapshot-tests.md
@@ -1,0 +1,118 @@
+# Snapshot-Tests für Smolitux UI
+
+Dieses Dokument beschreibt die Implementierung von Snapshot-Tests für die Smolitux UI-Bibliothek.
+
+## Überblick
+
+Snapshot-Tests sind eine Form von Regressionstests, die sicherstellen, dass die UI-Komponenten konsistent bleiben und keine unbeabsichtigten Änderungen auftreten. Sie erstellen eine "Momentaufnahme" des Komponentenbaums und vergleichen diese bei zukünftigen Tests mit der aktuellen Ausgabe.
+
+Die folgenden Komponenten wurden mit Snapshot-Tests abgedeckt:
+
+- Button
+- Card
+- Input
+
+## Vorteile von Snapshot-Tests
+
+- **Schnelle Erstellung**: Snapshot-Tests sind einfach zu erstellen und erfordern wenig Code.
+- **Umfassende Abdeckung**: Sie testen die gesamte Ausgabe einer Komponente, einschließlich aller Kinder.
+- **Visuelle Regressionserkennung**: Sie erkennen unbeabsichtigte Änderungen an der Komponente.
+- **Dokumentation**: Sie dienen als Dokumentation für das erwartete Verhalten der Komponente.
+
+## Implementierung
+
+Die Snapshot-Tests wurden mit Jest und react-test-renderer implementiert. Für jede Komponente wurden Tests für verschiedene Zustände und Konfigurationen erstellt.
+
+### Button-Komponente
+
+Die Button-Komponente wurde mit Snapshot-Tests für verschiedene Varianten, Größen und Zustände abgedeckt.
+
+```tsx
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Button } from '../Button';
+
+describe('Button Snapshots', () => {
+  test('renders correctly with default props', () => {
+    const tree = renderer.create(<Button>Click me</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  // Weitere Tests...
+});
+```
+
+### Card-Komponente
+
+Die Card-Komponente wurde mit Snapshot-Tests für verschiedene Varianten, Größen und Zustände abgedeckt.
+
+```tsx
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Card } from '../Card';
+
+describe('Card Snapshots', () => {
+  test('renders correctly with default props', () => {
+    const tree = renderer.create(<Card>Card Content</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  // Weitere Tests...
+});
+```
+
+### Input-Komponente
+
+Die Input-Komponente wurde mit Snapshot-Tests für verschiedene Varianten, Größen und Zustände abgedeckt.
+
+```tsx
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Input } from '../Input';
+
+describe('Input Snapshots', () => {
+  test('renders correctly with default props', () => {
+    const tree = renderer.create(<Input />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  // Weitere Tests...
+});
+```
+
+## Ausführung der Tests
+
+Die Snapshot-Tests können mit dem folgenden Befehl ausgeführt werden:
+
+```bash
+npm test
+```
+
+Um die Snapshots zu aktualisieren, wenn sich die Komponenten absichtlich geändert haben:
+
+```bash
+npm run test:update-snapshots
+```
+
+## Wartung der Snapshots
+
+Snapshots sollten regelmäßig überprüft und aktualisiert werden, wenn sich die Komponenten absichtlich ändern. Wenn ein Snapshot-Test fehlschlägt, gibt es zwei Möglichkeiten:
+
+1. **Die Änderung ist unbeabsichtigt**: In diesem Fall sollte der Code überprüft und korrigiert werden.
+2. **Die Änderung ist beabsichtigt**: In diesem Fall sollten die Snapshots aktualisiert werden.
+
+## Integration in CI/CD
+
+Die Snapshot-Tests sind in die CI/CD-Pipeline integriert und werden bei jedem Pull Request ausgeführt. Wenn ein Snapshot-Test fehlschlägt, wird der Pull Request blockiert, bis das Problem behoben ist.
+
+## Nächste Schritte
+
+Die folgenden Schritte sind als Nächstes geplant:
+
+1. **Implementierung von Snapshot-Tests für weitere Komponenten**: Checkbox, Radio, Select, TabView, etc.
+2. **Integration mit Chromatic**: Für visuelle Regressionstests mit Storybook
+3. **Automatisierte Snapshot-Updates**: Bei absichtlichen Änderungen
+
+## Fazit
+
+Die implementierten Snapshot-Tests bieten eine solide Grundlage für die Qualitätssicherung der Smolitux UI-Bibliothek. Sie stellen sicher, dass die Komponenten konsistent bleiben und keine unbeabsichtigten Änderungen auftreten.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,47 @@
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    // CSS-Module-Mocking
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    // SVG und andere Assets
+    '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/src/__mocks__/fileMock.js',
+    // Alias-Auflösung für '@smolitux/'
+    '^@smolitux/(.*)$': '<rootDir>/packages/@smolitux/$1',
+    // Mock für y18n
+    '^y18n$': '<rootDir>/src/__mocks__/node_modules/y18n.js',
+  },
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  collectCoverageFrom: [
+    'packages/@smolitux/**/*.{ts,tsx}',
+    '!packages/@smolitux/**/*.stories.{ts,tsx}',
+    '!packages/@smolitux/**/*.d.ts',
+    '!**/node_modules/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 70,
+      lines: 70,
+      statements: 70,
+    },
+  },
+  testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/__tests__/**/*.spec.{ts,tsx}'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['babel-jest', { presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'] }],
+  },
+  transformIgnorePatterns: [
+    '/node_modules/(?!y18n)/'
+  ],
+  reporters: [
+    'default',
+    ['jest-junit', {
+      outputDirectory: './reports/jest',
+      outputName: 'jest-junit.xml',
+    }],
+  ],
+  snapshotSerializers: [],
+};
+
+module.exports = config;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom';
+
+// Globale Mock-Funktionen
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
+// Mock für window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/package.json
+++ b/package.json
@@ -9,12 +9,34 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "build": "lerna run build",
-    "test": "lerna run test",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "test:ci": "jest --ci --coverage",
+    "test:update-snapshots": "jest --updateSnapshot",
+    "test:e2e": "playwright test",
+    "test:visual": "chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}",
     "lint": "lerna run lint",
     "storybook": "cd packages/docs && npm run storybook",
+    "build-storybook": "cd packages/docs && npm run build-storybook",
     "dev": "cd packages/playground && npm run dev"
   },
   "devDependencies": {
-    "lerna": "^6.6.2"
+    "@babel/core": "^7.26.10",
+    "@babel/preset-env": "^7.26.9",
+    "@babel/preset-react": "^7.26.3",
+    "@babel/preset-typescript": "^7.27.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react-test-renderer": "^19.0.0",
+    "babel-jest": "^29.7.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-junit": "^16.0.0",
+    "jest-snapshot": "^29.7.0",
+    "lerna": "^6.6.2",
+    "react-test-renderer": "^18.3.1"
   }
 }

--- a/packages/@smolitux/core/src/components/Button/__tests__/Button.spec.tsx
+++ b/packages/@smolitux/core/src/components/Button/__tests__/Button.spec.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Button } from '../Button';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Button Snapshots', () => {
+  test('renders correctly with default props', () => {
+    const tree = renderer.create(<Button>Click me</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with primary variant', () => {
+    const tree = renderer.create(<Button variant="primary">Primary Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with secondary variant', () => {
+    const tree = renderer.create(<Button variant="secondary">Secondary Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with outline variant', () => {
+    const tree = renderer.create(<Button variant="outline">Outline Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with ghost variant', () => {
+    const tree = renderer.create(<Button variant="ghost">Ghost Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with link variant', () => {
+    const tree = renderer.create(<Button variant="link">Link Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with small size', () => {
+    const tree = renderer.create(<Button size="sm">Small Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with medium size', () => {
+    const tree = renderer.create(<Button size="md">Medium Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with large size', () => {
+    const tree = renderer.create(<Button size="lg">Large Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with extra small size', () => {
+    const tree = renderer.create(<Button size="xs">Extra Small Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly when disabled', () => {
+    const tree = renderer.create(<Button disabled>Disabled Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly when loading', () => {
+    const tree = renderer.create(<Button loading>Loading Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with left icon', () => {
+    const leftIcon = <span data-testid="left-icon">←</span>;
+    const tree = renderer.create(<Button leftIcon={leftIcon}>Button with Left Icon</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with right icon', () => {
+    const rightIcon = <span data-testid="right-icon">→</span>;
+    const tree = renderer.create(<Button rightIcon={rightIcon}>Button with Right Icon</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with both icons', () => {
+    const leftIcon = <span data-testid="left-icon">←</span>;
+    const rightIcon = <span data-testid="right-icon">→</span>;
+    const tree = renderer.create(
+      <Button leftIcon={leftIcon} rightIcon={rightIcon}>
+        Button with Both Icons
+      </Button>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with full width', () => {
+    const tree = renderer.create(<Button fullWidth>Full Width Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with custom class name', () => {
+    const tree = renderer.create(<Button className="custom-class">Button with Custom Class</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with type submit', () => {
+    const tree = renderer.create(<Button type="submit">Submit Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with type reset', () => {
+    const tree = renderer.create(<Button type="reset">Reset Button</Button>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/Card/__tests__/Card.spec.tsx
+++ b/packages/@smolitux/core/src/components/Card/__tests__/Card.spec.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Card } from '../Card';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Card Snapshots', () => {
+  test('renders correctly with default props', () => {
+    const tree = renderer.create(<Card>Card Content</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with custom className', () => {
+    const tree = renderer.create(<Card className="custom-class">Card Content</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with elevated variant', () => {
+    const tree = renderer.create(<Card variant="elevated">Elevated Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with outlined variant', () => {
+    const tree = renderer.create(<Card variant="outlined">Outlined Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with flat variant', () => {
+    const tree = renderer.create(<Card variant="flat">Flat Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with no padding', () => {
+    const tree = renderer.create(<Card padding="none">No Padding Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with small padding', () => {
+    const tree = renderer.create(<Card padding="small">Small Padding Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with medium padding', () => {
+    const tree = renderer.create(<Card padding="medium">Medium Padding Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with large padding', () => {
+    const tree = renderer.create(<Card padding="large">Large Padding Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with no border radius', () => {
+    const tree = renderer.create(<Card borderRadius="none">No Border Radius Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with small border radius', () => {
+    const tree = renderer.create(<Card borderRadius="small">Small Border Radius Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with medium border radius', () => {
+    const tree = renderer.create(<Card borderRadius="medium">Medium Border Radius Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with large border radius', () => {
+    const tree = renderer.create(<Card borderRadius="large">Large Border Radius Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with full border radius', () => {
+    const tree = renderer.create(<Card borderRadius="full">Full Border Radius Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with hover effect', () => {
+    const tree = renderer.create(<Card hoverable>Hoverable Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with custom width and height', () => {
+    const tree = renderer.create(<Card width="300px" height="200px">Custom Size Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with custom background color', () => {
+    const tree = renderer.create(<Card backgroundColor="bg-blue-100">Blue Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with custom border color', () => {
+    const tree = renderer.create(<Card borderColor="border-red-500">Red Border Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with header and footer', () => {
+    const tree = renderer.create(
+      <Card
+        header={<div data-testid="card-header">Card Header</div>}
+        footer={<div data-testid="card-footer">Card Footer</div>}
+      >
+        Card Body
+      </Card>
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with onClick handler', () => {
+    const tree = renderer.create(<Card onClick={() => {}}>Clickable Card</Card>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/Input/__tests__/Input.spec.tsx
+++ b/packages/@smolitux/core/src/components/Input/__tests__/Input.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Input } from '../Input';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Input Snapshots', () => {
+  test('renders correctly with default props', () => {
+    const tree = renderer.create(<Input />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with value', () => {
+    const tree = renderer.create(<Input value="Test Value" readOnly />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with placeholder', () => {
+    const tree = renderer.create(<Input placeholder="Enter text here" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with label', () => {
+    const tree = renderer.create(<Input label="Username" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with helper text', () => {
+    const tree = renderer.create(<Input helperText="Enter your username" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with error message', () => {
+    const tree = renderer.create(<Input error="Username is required" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly when disabled', () => {
+    const tree = renderer.create(<Input disabled />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly when required', () => {
+    const tree = renderer.create(<Input required />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with left icon', () => {
+    const leftIcon = <span data-testid="left-icon">@</span>;
+    const tree = renderer.create(<Input leftIcon={leftIcon} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with right icon', () => {
+    const rightIcon = <span data-testid="right-icon">✓</span>;
+    const tree = renderer.create(<Input rightIcon={rightIcon} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with both icons', () => {
+    const leftIcon = <span data-testid="left-icon">@</span>;
+    const rightIcon = <span data-testid="right-icon">✓</span>;
+    const tree = renderer.create(<Input leftIcon={leftIcon} rightIcon={rightIcon} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with small size', () => {
+    const tree = renderer.create(<Input size="sm" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with medium size', () => {
+    const tree = renderer.create(<Input size="md" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with large size', () => {
+    const tree = renderer.create(<Input size="lg" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with outline variant', () => {
+    const tree = renderer.create(<Input variant="outline" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with filled variant', () => {
+    const tree = renderer.create(<Input variant="filled" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with unstyled variant', () => {
+    const tree = renderer.create(<Input variant="unstyled" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with full width', () => {
+    const tree = renderer.create(<Input fullWidth />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with custom class name', () => {
+    const tree = renderer.create(<Input className="custom-class" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with different input types', () => {
+    const types = ['text', 'password', 'email', 'number', 'tel', 'url', 'search', 'date'];
+    
+    types.forEach(type => {
+      const tree = renderer.create(<Input type={type} />).toJSON();
+      expect(tree).toMatchSnapshot(`Input with type ${type}`);
+    });
+  });
+
+  test('renders correctly with id', () => {
+    const tree = renderer.create(<Input id="username-input" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('renders correctly with name', () => {
+    const tree = renderer.create(<Input name="username" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/__mocks__/fileMock.js
+++ b/src/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/src/__mocks__/node_modules/y18n.js
+++ b/src/__mocks__/node_modules/y18n.js
@@ -1,0 +1,10 @@
+module.exports = {
+  __esModule: true,
+  default: {
+    __: (str) => str,
+    __n: (singular, plural, count) => count === 1 ? singular : plural,
+    setLocale: () => {},
+    getLocale: () => 'en',
+    updateLocale: () => {},
+  }
+};

--- a/src/__mocks__/styleMock.js
+++ b/src/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
Diese PR enthält die Implementierung von Snapshot-Tests für die Smolitux UI-Bibliothek.

## Enthaltene Änderungen

- Snapshot-Tests für die Button-Komponente
- Snapshot-Tests für die Card-Komponente
- Snapshot-Tests für die Input-Komponente
- Jest-Konfiguration für Snapshot-Tests
- Dokumentation für Snapshot-Tests

## Nächste Schritte

- Implementierung von Snapshot-Tests für weitere Komponenten
- Integration mit Chromatic für visuelle Regressionstests
- Automatisierte Snapshot-Updates bei absichtlichen Änderungen