### PR TITLE
Tests für Slider und Switch Komponenten hinzugefügt

### DIFF
--- a/packages/@smolitux/core/src/components/Slider/__tests__/Slider.spec.tsx
+++ b/packages/@smolitux/core/src/components/Slider/__tests__/Slider.spec.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Slider } from '../Slider';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+// Mock für den FormControl-Context
+jest.mock('../../FormControl', () => ({
+  useFormControl: () => ({
+    disabled: false,
+    required: false,
+    hasError: false,
+    id: undefined,
+    label: undefined,
+    name: undefined,
+    size: 'md',
+    readOnly: false,
+    isFocused: false,
+    isValid: false,
+    isInvalid: false,
+    isSuccess: false,
+    isLoading: false
+  })
+}));
+
+describe('Slider Snapshots', () => {
+  it('renders default slider correctly', () => {
+    const { asFragment } = render(<Slider />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with label correctly', () => {
+    const { asFragment } = render(<Slider label="Volume" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with custom min, max, and value correctly', () => {
+    const { asFragment } = render(<Slider min={10} max={50} value={30} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders disabled slider correctly', () => {
+    const { asFragment } = render(<Slider disabled />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with helper text correctly', () => {
+    const { asFragment } = render(<Slider helperText="Adjust the volume" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with error state correctly', () => {
+    const { asFragment } = render(<Slider error="Invalid value" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with success message correctly', () => {
+    const { asFragment } = render(<Slider successMessage="Value saved" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with required state correctly', () => {
+    const { asFragment } = render(<Slider required label="Required Field" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with different sizes correctly', () => {
+    const sizes: Array<'xs' | 'sm' | 'md' | 'lg' | 'xl'> = ['xs', 'sm', 'md', 'lg', 'xl'];
+    
+    const fragments = sizes.map(size => {
+      const { asFragment } = render(<Slider size={size} />);
+      return { size, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ size, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Slider with size ${size}`);
+    });
+  });
+
+  it('renders slider with different variants correctly', () => {
+    const variants: Array<'solid' | 'outline' | 'filled' | 'minimal'> = ['solid', 'outline', 'filled', 'minimal'];
+    
+    const fragments = variants.map(variant => {
+      const { asFragment } = render(<Slider variant={variant} />);
+      return { variant, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ variant, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Slider with variant ${variant}`);
+    });
+  });
+
+  it('renders slider with different color schemes correctly', () => {
+    const colorSchemes: Array<'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'neutral'> = [
+      'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'neutral'
+    ];
+    
+    const fragments = colorSchemes.map(colorScheme => {
+      const { asFragment } = render(<Slider colorScheme={colorScheme} value={50} />);
+      return { colorScheme, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ colorScheme, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Slider with color scheme ${colorScheme}`);
+    });
+  });
+
+  it('renders slider with vertical orientation correctly', () => {
+    const { asFragment } = render(<Slider orientation="vertical" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with shadow correctly', () => {
+    const { asFragment } = render(<Slider shadow />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with transparent background correctly', () => {
+    const { asFragment } = render(<Slider transparent />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with marks correctly', () => {
+    const { asFragment } = render(
+      <Slider 
+        showMarks 
+        marks={[
+          { value: 0, label: 'Min' },
+          { value: 50, label: '50%' },
+          { value: 100, label: 'Max' }
+        ]}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with scale correctly', () => {
+    const { asFragment } = render(<Slider showScale scaleSteps={2} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with custom value format correctly', () => {
+    const { asFragment } = render(
+      <Slider 
+        showValue 
+        value={50} 
+        valueFormat={(value) => `${value}%`} 
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with different thumb shapes correctly', () => {
+    const thumbShapes: Array<'circle' | 'square' | 'rectangle' | 'diamond'> = ['circle', 'square', 'rectangle', 'diamond'];
+    
+    const fragments = thumbShapes.map(thumbShape => {
+      const { asFragment } = render(<Slider thumbShape={thumbShape} />);
+      return { thumbShape, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ thumbShape, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Slider with thumb shape ${thumbShape}`);
+    });
+  });
+
+  it('renders slider with different track shapes correctly', () => {
+    const trackShapes: Array<'rounded' | 'square'> = ['rounded', 'square'];
+    
+    const fragments = trackShapes.map(trackShape => {
+      const { asFragment } = render(<Slider trackShape={trackShape} />);
+      return { trackShape, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ trackShape, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Slider with track shape ${trackShape}`);
+    });
+  });
+
+  it('renders slider with custom thumb icon correctly', () => {
+    const thumbIcon = <span data-testid="thumb-icon">●</span>;
+    const { asFragment } = render(<Slider thumbIcon={thumbIcon} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders slider with highlight range correctly', () => {
+    const { asFragment } = render(<Slider highlightRange={[20, 80]} highlightColor="rgba(0, 0, 255, 0.2)" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders range slider correctly', () => {
+    const { asFragment } = render(<Slider isRange value={20} value2={80} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/Switch/__tests__/Switch.spec.tsx
+++ b/packages/@smolitux/core/src/components/Switch/__tests__/Switch.spec.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Switch } from '../Switch';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+// Mock für den FormControl-Context
+jest.mock('../../FormControl', () => ({
+  useFormControl: () => ({
+    disabled: false,
+    required: false,
+    hasError: false,
+    id: undefined,
+    label: undefined,
+    name: undefined,
+    size: 'md',
+    readOnly: false,
+    isFocused: false,
+    isValid: false,
+    isInvalid: false,
+    isSuccess: false,
+    isLoading: false
+  })
+}));
+
+describe('Switch Snapshots', () => {
+  it('renders default switch correctly', () => {
+    const { asFragment } = render(<Switch />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with label correctly', () => {
+    const { asFragment } = render(<Switch label="Toggle me" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with helper text correctly', () => {
+    const { asFragment } = render(<Switch helperText="This is a helper text" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with error message correctly', () => {
+    const { asFragment } = render(<Switch error="This is an error message" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with success message correctly', () => {
+    const { asFragment } = render(<Switch successMessage="This is a success message" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders checked switch correctly', () => {
+    const { asFragment } = render(<Switch checked />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders disabled switch correctly', () => {
+    const { asFragment } = render(<Switch disabled />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with different sizes correctly', () => {
+    const sizes: Array<'xs' | 'sm' | 'md' | 'lg' | 'xl'> = ['xs', 'sm', 'md', 'lg', 'xl'];
+    
+    const fragments = sizes.map(size => {
+      const { asFragment } = render(<Switch size={size} />);
+      return { size, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ size, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Switch with size ${size}`);
+    });
+  });
+
+  it('renders switch with different color schemes correctly', () => {
+    const colorSchemes: Array<'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'neutral'> = [
+      'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'neutral'
+    ];
+    
+    const fragments = colorSchemes.map(colorScheme => {
+      const { asFragment } = render(<Switch colorScheme={colorScheme} checked />);
+      return { colorScheme, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ colorScheme, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Switch with color scheme ${colorScheme}`);
+    });
+  });
+
+  it('renders switch with different variants correctly', () => {
+    const variants: Array<'solid' | 'outline' | 'filled' | 'minimal'> = ['solid', 'outline', 'filled', 'minimal'];
+    
+    const fragments = variants.map(variant => {
+      const { asFragment } = render(<Switch variant={variant} />);
+      return { variant, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ variant, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Switch with variant ${variant}`);
+    });
+  });
+
+  it('renders switch with label on the left correctly', () => {
+    const { asFragment } = render(<Switch label="Left Label" labelPosition="left" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with label on the right correctly', () => {
+    const { asFragment } = render(<Switch label="Right Label" labelPosition="right" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with different label alignments correctly', () => {
+    const alignments: Array<'start' | 'center' | 'end'> = ['start', 'center', 'end'];
+    
+    const fragments = alignments.map(align => {
+      const { asFragment } = render(<Switch label="Aligned Label" labelPosition="left" labelAlign={align} />);
+      return { align, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ align, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Switch with label alignment ${align}`);
+    });
+  });
+
+  it('renders switch with icons correctly', () => {
+    const { asFragment } = render(<Switch icons />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with on/off text correctly', () => {
+    const { asFragment } = render(<Switch showText />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with custom on/off text correctly', () => {
+    const { asFragment } = render(<Switch showText onText="YES" offText="NO" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with iOS style correctly', () => {
+    const { asFragment } = render(<Switch isIOS />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with Android style correctly', () => {
+    const { asFragment } = render(<Switch isAndroid />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with Material style correctly', () => {
+    const { asFragment } = render(<Switch isMaterial />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with loading state correctly', () => {
+    const { asFragment } = render(<Switch isLoading />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with custom thumb component correctly', () => {
+    const customThumb = <div data-testid="custom-thumb">Custom</div>;
+    const { asFragment } = render(<Switch thumbComponent={customThumb} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders switch with custom track component correctly', () => {
+    const customTrack = <div data-testid="custom-track">Custom</div>;
+    const { asFragment } = render(<Switch trackComponent={customTrack} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Dieser Pull Request fügt Snapshot-Tests für weitere Komponenten hinzu, die bereits Unit-Tests haben.

## Enthaltene Änderungen

### Neue Snapshot-Tests für:
- Slider-Komponente
- Switch-Komponente

## Nächste Schritte

Nach der Genehmigung dieses Pull Requests werde ich mit der Erstellung von Tests für die verbleibenden Komponenten fortfahren.