### PR TITLE
Tests für TimePicker, Toast und RadioGroup Komponenten hinzugefügt

### DIFF
--- a/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.spec.tsx
+++ b/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.spec.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RadioGroup } from '../RadioGroup';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('RadioGroup Snapshots', () => {
+  const defaultOptions = [
+    { value: 'option1', label: 'Option 1' },
+    { value: 'option2', label: 'Option 2' },
+    { value: 'option3', label: 'Option 3' }
+  ];
+
+  it('renders default radio group correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with selected value correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} value="option2" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with label correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} label="Test Label" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with helper text correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} helperText="Helper Text" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with error message correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} error="Error Message" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with different sizes correctly', () => {
+    const sizes = ['sm', 'md', 'lg'];
+    
+    const fragments = sizes.map(size => {
+      const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} size={size as any} />);
+      return { size, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ size, fragment }) => {
+      expect(fragment).toMatchSnapshot(`RadioGroup with size ${size}`);
+    });
+  });
+
+  it('renders radio group with horizontal direction correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} direction="horizontal" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with vertical direction correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} direction="vertical" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders disabled radio group correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} disabled />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with individual disabled options correctly', () => {
+    const optionsWithDisabled = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+      { value: 'option3', label: 'Option 3' }
+    ];
+    
+    const { asFragment } = render(<RadioGroup name="test-group" options={optionsWithDisabled} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders required radio group correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} required />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with custom className correctly', () => {
+    const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} className="custom-radio-group" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with different color schemes correctly', () => {
+    const colorSchemes = ['primary', 'secondary', 'success', 'danger', 'warning', 'info'];
+    
+    const fragments = colorSchemes.map(colorScheme => {
+      const { asFragment } = render(<RadioGroup name="test-group" options={defaultOptions} colorScheme={colorScheme as any} />);
+      return { colorScheme, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ colorScheme, fragment }) => {
+      expect(fragment).toMatchSnapshot(`RadioGroup with color scheme ${colorScheme}`);
+    });
+  });
+
+  it('renders radio group with all features enabled correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup 
+        name="test-group" 
+        options={defaultOptions} 
+        value="option1"
+        label="Complete Radio Group"
+        helperText="This is a helper text"
+        size="lg"
+        direction="horizontal"
+        colorScheme="primary"
+        required
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
+++ b/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RadioGroup } from '../RadioGroup';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('RadioGroup', () => {
+  const defaultOptions = [
+    { value: 'option1', label: 'Option 1' },
+    { value: 'option2', label: 'Option 2' },
+    { value: 'option3', label: 'Option 3' }
+  ];
+
+  it('renders correctly with default props', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} />);
+    
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
+    
+    const radioButtons = screen.getAllByRole('radio');
+    expect(radioButtons).toHaveLength(3);
+    expect(radioButtons[0]).not.toBeChecked();
+    expect(radioButtons[1]).not.toBeChecked();
+    expect(radioButtons[2]).not.toBeChecked();
+  });
+
+  it('renders with selected value', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} value="option2" />);
+    
+    const radioButtons = screen.getAllByRole('radio');
+    expect(radioButtons[0]).not.toBeChecked();
+    expect(radioButtons[1]).toBeChecked();
+    expect(radioButtons[2]).not.toBeChecked();
+  });
+
+  it('calls onChange when an option is selected', () => {
+    const handleChange = jest.fn();
+    render(<RadioGroup name="test-group" options={defaultOptions} onChange={handleChange} />);
+    
+    const radioButtons = screen.getAllByRole('radio');
+    fireEvent.click(radioButtons[1]);
+    
+    expect(handleChange).toHaveBeenCalledWith('option2');
+  });
+
+  it('renders with label', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} label="Test Label" />);
+    
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+  });
+
+  it('renders with helper text', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} helperText="Helper Text" />);
+    
+    expect(screen.getByText('Helper Text')).toBeInTheDocument();
+  });
+
+  it('renders with error message', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} error="Error Message" />);
+    
+    expect(screen.getByText('Error Message')).toBeInTheDocument();
+  });
+
+  it('renders with different sizes', () => {
+    const { rerender } = render(<RadioGroup name="test-group" options={defaultOptions} size="sm" />);
+    
+    let radioButtons = screen.getAllByRole('radio');
+    radioButtons.forEach(radio => {
+      expect(radio.parentElement).toHaveClass('w-4 h-4');
+    });
+    
+    rerender(<RadioGroup name="test-group" options={defaultOptions} size="md" />);
+    radioButtons = screen.getAllByRole('radio');
+    radioButtons.forEach(radio => {
+      expect(radio.parentElement).toHaveClass('w-5 h-5');
+    });
+    
+    rerender(<RadioGroup name="test-group" options={defaultOptions} size="lg" />);
+    radioButtons = screen.getAllByRole('radio');
+    radioButtons.forEach(radio => {
+      expect(radio.parentElement).toHaveClass('w-6 h-6');
+    });
+  });
+
+  it('renders with horizontal direction', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} direction="horizontal" />);
+    
+    const container = screen.getByRole('radiogroup');
+    expect(container.firstChild).toHaveClass('flex-row');
+  });
+
+  it('renders with vertical direction', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} direction="vertical" />);
+    
+    const container = screen.getByRole('radiogroup');
+    expect(container.firstChild).toHaveClass('flex-col');
+  });
+
+  it('renders with disabled state', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} disabled />);
+    
+    const radioButtons = screen.getAllByRole('radio');
+    radioButtons.forEach(radio => {
+      expect(radio).toBeDisabled();
+    });
+  });
+
+  it('renders with individual disabled options', () => {
+    const optionsWithDisabled = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+      { value: 'option3', label: 'Option 3' }
+    ];
+    
+    render(<RadioGroup name="test-group" options={optionsWithDisabled} />);
+    
+    const radioButtons = screen.getAllByRole('radio');
+    expect(radioButtons[0]).not.toBeDisabled();
+    expect(radioButtons[1]).toBeDisabled();
+    expect(radioButtons[2]).not.toBeDisabled();
+  });
+
+  it('does not call onChange when a disabled option is clicked', () => {
+    const handleChange = jest.fn();
+    const optionsWithDisabled = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+      { value: 'option3', label: 'Option 3' }
+    ];
+    
+    render(<RadioGroup name="test-group" options={optionsWithDisabled} onChange={handleChange} />);
+    
+    const radioButtons = screen.getAllByRole('radio');
+    fireEvent.click(radioButtons[1]);
+    
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('renders with correct name attribute', () => {
+    render(<RadioGroup name="custom-name" options={defaultOptions} />);
+    
+    const radioButtons = screen.getAllByRole('radio');
+    radioButtons.forEach(radio => {
+      expect(radio).toHaveAttribute('name', 'custom-name');
+    });
+  });
+
+  it('renders with correct aria attributes', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} label="Test Label" />);
+    
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toHaveAttribute('aria-labelledby');
+  });
+
+  it('renders with required attribute', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} required />);
+    
+    const radioButtons = screen.getAllByRole('radio');
+    radioButtons.forEach(radio => {
+      expect(radio).toHaveAttribute('required');
+    });
+  });
+
+  it('renders with custom className', () => {
+    render(<RadioGroup name="test-group" options={defaultOptions} className="custom-radio-group" />);
+    
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toHaveClass('custom-radio-group');
+  });
+});

--- a/packages/@smolitux/core/src/components/TimePicker/__tests__/TimePicker.spec.tsx
+++ b/packages/@smolitux/core/src/components/TimePicker/__tests__/TimePicker.spec.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TimePicker } from '../TimePicker';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+// Mock für FormControl
+jest.mock('../../FormControl/FormControl', () => ({
+  useFormControl: () => ({
+    id: 'test-id',
+    isDisabled: false,
+    isInvalid: false,
+    isReadOnly: false,
+    isRequired: false,
+  }),
+}));
+
+describe('TimePicker Snapshots', () => {
+  it('renders default time picker correctly', () => {
+    const { asFragment } = render(<TimePicker />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with label correctly', () => {
+    const { asFragment } = render(<TimePicker label="Time" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with helper text correctly', () => {
+    const { asFragment } = render(<TimePicker helperText="Select a time" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with error message correctly', () => {
+    const { asFragment } = render(<TimePicker error="Invalid time" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders disabled time picker correctly', () => {
+    const { asFragment } = render(<TimePicker disabled />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders readonly time picker correctly', () => {
+    const { asFragment } = render(<TimePicker readOnly />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with 24h format correctly', () => {
+    const { asFragment } = render(<TimePicker format="24h" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with 12h format correctly', () => {
+    const { asFragment } = render(<TimePicker format="12h" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with seconds correctly', () => {
+    const { asFragment } = render(<TimePicker hideSeconds={false} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker without seconds correctly', () => {
+    const { asFragment } = render(<TimePicker hideSeconds />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with value as string correctly', () => {
+    const { asFragment } = render(<TimePicker value="14:30" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with value as object correctly', () => {
+    const { asFragment } = render(<TimePicker value={{ hours: 14, minutes: 30 }} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with value in 12h format correctly', () => {
+    const { asFragment } = render(<TimePicker value="14:30" format="12h" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with value and seconds correctly', () => {
+    const { asFragment } = render(<TimePicker value={{ hours: 14, minutes: 30, seconds: 45 }} hideSeconds={false} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with custom className correctly', () => {
+    const { asFragment } = render(<TimePicker className="custom-time-picker" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with custom placeholder correctly', () => {
+    const { asFragment } = render(<TimePicker placeholder="Enter time" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with open dropdown correctly', () => {
+    const { asFragment } = render(<TimePicker defaultOpen />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders time picker with different sizes correctly', () => {
+    const sizes = ['sm', 'md', 'lg'];
+    
+    const fragments = sizes.map(size => {
+      const { asFragment } = render(<TimePicker size={size as any} />);
+      return { size, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ size, fragment }) => {
+      expect(fragment).toMatchSnapshot(`TimePicker with size ${size}`);
+    });
+  });
+
+  it('renders time picker with different variants correctly', () => {
+    const variants = ['outline', 'filled', 'flushed', 'unstyled'];
+    
+    const fragments = variants.map(variant => {
+      const { asFragment } = render(<TimePicker variant={variant as any} />);
+      return { variant, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ variant, fragment }) => {
+      expect(fragment).toMatchSnapshot(`TimePicker with variant ${variant}`);
+    });
+  });
+
+  it('renders time picker with different color schemes correctly', () => {
+    const colorSchemes = ['primary', 'secondary', 'success', 'danger', 'warning', 'info'];
+    
+    const fragments = colorSchemes.map(colorScheme => {
+      const { asFragment } = render(<TimePicker colorScheme={colorScheme as any} />);
+      return { colorScheme, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ colorScheme, fragment }) => {
+      expect(fragment).toMatchSnapshot(`TimePicker with color scheme ${colorScheme}`);
+    });
+  });
+
+  it('renders time picker with all features enabled correctly', () => {
+    const { asFragment } = render(
+      <TimePicker 
+        label="Time"
+        helperText="Select a time"
+        value={{ hours: 14, minutes: 30, seconds: 45 }}
+        format="12h"
+        hideSeconds={false}
+        size="lg"
+        variant="filled"
+        colorScheme="primary"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/TimePicker/__tests__/TimePicker.test.tsx
+++ b/packages/@smolitux/core/src/components/TimePicker/__tests__/TimePicker.test.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TimePicker } from '../TimePicker';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+// Mock für FormControl
+jest.mock('../../FormControl/FormControl', () => ({
+  useFormControl: () => ({
+    id: 'test-id',
+    isDisabled: false,
+    isInvalid: false,
+    isReadOnly: false,
+    isRequired: false,
+  }),
+}));
+
+describe('TimePicker', () => {
+  it('renders correctly with default props', () => {
+    render(<TimePicker />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('placeholder', 'HH:MM');
+  });
+
+  it('renders with custom placeholder', () => {
+    render(<TimePicker placeholder="Enter time" />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('placeholder', 'Enter time');
+  });
+
+  it('renders with label', () => {
+    render(<TimePicker label="Time" />);
+    
+    expect(screen.getByText('Time')).toBeInTheDocument();
+  });
+
+  it('renders with helper text', () => {
+    render(<TimePicker helperText="Select a time" />);
+    
+    expect(screen.getByText('Select a time')).toBeInTheDocument();
+  });
+
+  it('renders with error message', () => {
+    render(<TimePicker error="Invalid time" />);
+    
+    expect(screen.getByText('Invalid time')).toBeInTheDocument();
+  });
+
+  it('renders in disabled state', () => {
+    render(<TimePicker disabled />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
+
+  it('renders in readonly state', () => {
+    render(<TimePicker readOnly />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('readonly');
+  });
+
+  it('renders with 24h format', () => {
+    render(<TimePicker format="24h" />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('placeholder', 'HH:MM');
+    
+    // Open the dropdown
+    fireEvent.click(input);
+    
+    // Check that there's no AM/PM selector
+    expect(screen.queryByText('AM')).not.toBeInTheDocument();
+    expect(screen.queryByText('PM')).not.toBeInTheDocument();
+  });
+
+  it('renders with 12h format', () => {
+    render(<TimePicker format="12h" />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('placeholder', 'HH:MM AM/PM');
+    
+    // Open the dropdown
+    fireEvent.click(input);
+    
+    // Check that there's an AM/PM selector
+    expect(screen.getByText('AM')).toBeInTheDocument();
+    expect(screen.getByText('PM')).toBeInTheDocument();
+  });
+
+  it('renders with seconds when hideSeconds is false', () => {
+    render(<TimePicker hideSeconds={false} />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('placeholder', 'HH:MM:SS');
+    
+    // Open the dropdown
+    fireEvent.click(input);
+    
+    // Check that there's a seconds selector
+    expect(screen.getByLabelText('Seconds')).toBeInTheDocument();
+  });
+
+  it('hides seconds when hideSeconds is true', () => {
+    render(<TimePicker hideSeconds />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('placeholder', 'HH:MM');
+    
+    // Open the dropdown
+    fireEvent.click(input);
+    
+    // Check that there's no seconds selector
+    expect(screen.queryByLabelText('Seconds')).not.toBeInTheDocument();
+  });
+
+  it('calls onChange when time is selected', () => {
+    const handleChange = jest.fn();
+    render(<TimePicker onChange={handleChange} />);
+    
+    const input = screen.getByRole('textbox');
+    
+    // Open the dropdown
+    fireEvent.click(input);
+    
+    // Select hour
+    const hourOption = screen.getByText('10');
+    fireEvent.click(hourOption);
+    
+    // Select minute
+    const minuteOption = screen.getByText('30');
+    fireEvent.click(minuteOption);
+    
+    expect(handleChange).toHaveBeenCalledWith({
+      hours: 10,
+      minutes: 30,
+      seconds: 0
+    });
+  });
+
+  it('displays the correct time when value is provided as string', () => {
+    render(<TimePicker value="14:30" />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('14:30');
+  });
+
+  it('displays the correct time when value is provided as object', () => {
+    render(<TimePicker value={{ hours: 14, minutes: 30 }} />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('14:30');
+  });
+
+  it('displays the correct time in 12h format', () => {
+    render(<TimePicker value="14:30" format="12h" />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('02:30 PM');
+  });
+
+  it('displays the correct time with seconds', () => {
+    render(<TimePicker value={{ hours: 14, minutes: 30, seconds: 45 }} hideSeconds={false} />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('14:30:45');
+  });
+
+  it('allows manual input of time', () => {
+    const handleChange = jest.fn();
+    render(<TimePicker onChange={handleChange} />);
+    
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '14:30' } });
+    fireEvent.blur(input);
+    
+    expect(handleChange).toHaveBeenCalledWith({
+      hours: 14,
+      minutes: 30,
+      seconds: 0
+    });
+  });
+
+  it('validates manual input', () => {
+    const handleChange = jest.fn();
+    render(<TimePicker onChange={handleChange} />);
+    
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'invalid' } });
+    fireEvent.blur(input);
+    
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Invalid time format')).toBeInTheDocument();
+  });
+
+  it('closes dropdown when clicking outside', () => {
+    render(<TimePicker />);
+    
+    const input = screen.getByRole('textbox');
+    
+    // Open the dropdown
+    fireEvent.click(input);
+    
+    // Check that the dropdown is open
+    expect(screen.getByLabelText('Hours')).toBeInTheDocument();
+    
+    // Click outside
+    fireEvent.mouseDown(document.body);
+    
+    // Check that the dropdown is closed
+    expect(screen.queryByLabelText('Hours')).not.toBeInTheDocument();
+  });
+
+  it('handles keyboard navigation', () => {
+    render(<TimePicker />);
+    
+    const input = screen.getByRole('textbox');
+    
+    // Open the dropdown with keyboard
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    
+    // Check that the dropdown is open
+    expect(screen.getByLabelText('Hours')).toBeInTheDocument();
+    
+    // Close the dropdown with Escape
+    fireEvent.keyDown(input, { key: 'Escape' });
+    
+    // Check that the dropdown is closed
+    expect(screen.queryByLabelText('Hours')).not.toBeInTheDocument();
+  });
+
+  it('renders with custom className', () => {
+    render(<TimePicker className="custom-time-picker" />);
+    
+    const container = screen.getByRole('textbox').closest('.time-picker');
+    expect(container).toHaveClass('custom-time-picker');
+  });
+
+  it('forwards ref to input element', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<TimePicker ref={ref} />);
+    
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('INPUT');
+  });
+
+  it('renders with custom input props', () => {
+    render(<TimePicker data-testid="custom-time-picker" aria-label="Time input" />);
+    
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('data-testid', 'custom-time-picker');
+    expect(input).toHaveAttribute('aria-label', 'Time input');
+  });
+});

--- a/packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx
+++ b/packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Toast } from '../Toast';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Toast Snapshots', () => {
+  it('renders default toast correctly', () => {
+    const { asFragment } = render(<Toast message="Test message" isOpen />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with title correctly', () => {
+    const { asFragment } = render(<Toast title="Test Title" message="Test message" isOpen />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with different types correctly', () => {
+    const types = ['success', 'error', 'warning', 'info'];
+    
+    const fragments = types.map(type => {
+      const { asFragment } = render(<Toast message={`${type} toast`} type={type as any} isOpen />);
+      return { type, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ type, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Toast with type ${type}`);
+    });
+  });
+
+  it('renders toast with close button correctly', () => {
+    const { asFragment } = render(<Toast message="Test message" showCloseButton isOpen />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with icon correctly', () => {
+    const { asFragment } = render(<Toast message="Test message" showIcon isOpen />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with custom icon correctly', () => {
+    const { asFragment } = render(
+      <Toast 
+        message="Test message" 
+        icon={<span>🔔</span>} 
+        isOpen 
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with actions correctly', () => {
+    const { asFragment } = render(
+      <Toast 
+        message="Test message" 
+        actions={<button>Action</button>} 
+        isOpen 
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with custom className correctly', () => {
+    const { asFragment } = render(<Toast message="Test message" className="custom-toast" isOpen />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with different positions correctly', () => {
+    const positions = ['top-right', 'top-left', 'bottom-right', 'bottom-left', 'top-center', 'bottom-center'];
+    
+    const fragments = positions.map(position => {
+      const { asFragment } = render(<Toast message="Test message" position={position as any} isOpen />);
+      return { position, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ position, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Toast with position ${position}`);
+    });
+  });
+
+  it('renders toast with animation correctly', () => {
+    const { asFragment } = render(<Toast message="Test message" animateOut isOpen />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with all features enabled correctly', () => {
+    const { asFragment } = render(
+      <Toast 
+        title="Complete Toast"
+        message="This toast has all features enabled"
+        type="success"
+        showIcon
+        showCloseButton
+        animateOut
+        actions={<button>Action</button>}
+        position="bottom-right"
+        isOpen
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/Toast/__tests__/Toast.test.tsx
+++ b/packages/@smolitux/core/src/components/Toast/__tests__/Toast.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { Toast } from '../Toast';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Toast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders correctly with default props', () => {
+    render(<Toast message="Test message" isOpen />);
+    
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('renders with title', () => {
+    render(<Toast title="Test Title" message="Test message" isOpen />);
+    
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('renders with different types', () => {
+    const { rerender } = render(<Toast message="Success toast" type="success" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-green-100');
+    
+    rerender(<Toast message="Error toast" type="error" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-red-100');
+    
+    rerender(<Toast message="Warning toast" type="warning" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-yellow-100');
+    
+    rerender(<Toast message="Info toast" type="info" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-blue-100');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const handleClose = jest.fn();
+    render(<Toast message="Test message" onClose={handleClose} showCloseButton isOpen />);
+    
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose after duration', () => {
+    const handleClose = jest.fn();
+    render(<Toast message="Test message" duration={2000} onClose={handleClose} isOpen />);
+    
+    expect(handleClose).not.toHaveBeenCalled();
+    
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose if duration is 0', () => {
+    const handleClose = jest.fn();
+    render(<Toast message="Test message" duration={0} onClose={handleClose} isOpen />);
+    
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('renders with icon when showIcon is true', () => {
+    render(<Toast message="Test message" showIcon isOpen />);
+    
+    expect(screen.getByTestId('toast-icon')).toBeInTheDocument();
+  });
+
+  it('renders with custom icon', () => {
+    render(
+      <Toast 
+        message="Test message" 
+        icon={<span data-testid="custom-icon">🔔</span>} 
+        isOpen 
+      />
+    );
+    
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('renders with actions', () => {
+    render(
+      <Toast 
+        message="Test message" 
+        actions={<button data-testid="action-button">Action</button>} 
+        isOpen 
+      />
+    );
+    
+    expect(screen.getByTestId('action-button')).toBeInTheDocument();
+  });
+
+  it('renders with custom className', () => {
+    render(<Toast message="Test message" className="custom-toast" isOpen />);
+    
+    expect(screen.getByRole('alert')).toHaveClass('custom-toast');
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(<Toast message="Test message" isOpen={false} />);
+    
+    expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+  });
+
+  it('pauses timer when hovered', () => {
+    const handleClose = jest.fn();
+    render(<Toast message="Test message" duration={2000} onClose={handleClose} isOpen />);
+    
+    const toast = screen.getByRole('alert');
+    
+    // Hover over toast
+    fireEvent.mouseEnter(toast);
+    
+    // Advance time
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    
+    // onClose should not be called because timer is paused
+    expect(handleClose).not.toHaveBeenCalled();
+    
+    // Mouse leave
+    fireEvent.mouseLeave(toast);
+    
+    // Advance time again
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    
+    // Now onClose should be called
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders with different positions', () => {
+    const { rerender } = render(<Toast message="Test message" position="top-right" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('top-4 right-4');
+    
+    rerender(<Toast message="Test message" position="top-left" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('top-4 left-4');
+    
+    rerender(<Toast message="Test message" position="bottom-right" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('bottom-4 right-4');
+    
+    rerender(<Toast message="Test message" position="bottom-left" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('bottom-4 left-4');
+    
+    rerender(<Toast message="Test message" position="top-center" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('top-4 left-1/2 -translate-x-1/2');
+    
+    rerender(<Toast message="Test message" position="bottom-center" isOpen />);
+    expect(screen.getByRole('alert')).toHaveClass('bottom-4 left-1/2 -translate-x-1/2');
+  });
+
+  it('applies animation classes when animateOut is true', () => {
+    render(<Toast message="Test message" animateOut isOpen />);
+    
+    expect(screen.getByRole('alert')).toHaveClass('animate-fade-in');
+  });
+
+  it('has correct accessibility attributes', () => {
+    render(<Toast message="Test message" type="error" isOpen />);
+    
+    const toast = screen.getByRole('alert');
+    expect(toast).toHaveAttribute('aria-live', 'assertive');
+  });
+});

--- a/packages/@smolitux/core/src/components/Toast/__tests__/ToastProvider.test.tsx
+++ b/packages/@smolitux/core/src/components/Toast/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ToastProvider } from '../ToastProvider';
+import { useToast } from '../index';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+// Test-Komponente, die den useToast-Hook verwendet
+const TestComponent = () => {
+  const { addToast, removeAllToasts } = useToast();
+  
+  const showSuccessToast = () => {
+    addToast({
+      title: 'Success',
+      message: 'Operation successful',
+      type: 'success',
+      duration: 3000
+    });
+  };
+  
+  const showErrorToast = () => {
+    addToast({
+      title: 'Error',
+      message: 'Something went wrong',
+      type: 'error',
+      duration: 3000
+    });
+  };
+  
+  const clearAllToasts = () => {
+    removeAllToasts();
+  };
+  
+  return (
+    <div>
+      <button onClick={showSuccessToast}>Show Success</button>
+      <button onClick={showErrorToast}>Show Error</button>
+      <button onClick={clearAllToasts}>Clear All</button>
+    </div>
+  );
+};
+
+describe('ToastProvider', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <ToastProvider>
+        <div data-testid="test-child">Test Child</div>
+      </ToastProvider>
+    );
+    
+    expect(screen.getByTestId('test-child')).toBeInTheDocument();
+  });
+
+  it('shows toast when addToast is called', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    fireEvent.click(screen.getByText('Show Success'));
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Operation successful')).toBeInTheDocument();
+  });
+
+  it('removes toast after duration', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    fireEvent.click(screen.getByText('Show Success'));
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+  });
+
+  it('removes all toasts when removeAllToasts is called', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    // Show multiple toasts
+    fireEvent.click(screen.getByText('Show Success'));
+    fireEvent.click(screen.getByText('Show Error'));
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    
+    // Clear all toasts
+    fireEvent.click(screen.getByText('Clear All'));
+    
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+    expect(screen.queryByText('Error')).not.toBeInTheDocument();
+  });
+
+  it('respects the limit prop', () => {
+    render(
+      <ToastProvider limit={2}>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    // Show 3 toasts (exceeding the limit)
+    fireEvent.click(screen.getByText('Show Success'));
+    fireEvent.click(screen.getByText('Show Error'));
+    fireEvent.click(screen.getByText('Show Success'));
+    
+    // Only the 2 most recent toasts should be visible
+    const successToasts = screen.getAllByText('Success');
+    const errorToasts = screen.getAllByText('Error');
+    
+    expect(successToasts).toHaveLength(1);
+    expect(errorToasts).toHaveLength(1);
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+  });
+
+  it('applies position to all toasts', () => {
+    render(
+      <ToastProvider position="bottom-center">
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    fireEvent.click(screen.getByText('Show Success'));
+    
+    const toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bottom-4');
+    expect(toast).toHaveClass('left-1/2');
+  });
+
+  it('removes toast when close button is clicked', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    fireEvent.click(screen.getByText('Show Success'));
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+    
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+  });
+
+  it('stacks multiple toasts correctly', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    // Show multiple toasts
+    fireEvent.click(screen.getByText('Show Success'));
+    fireEvent.click(screen.getByText('Show Error'));
+    
+    const toastContainer = screen.getByTestId('toast-container');
+    const toasts = screen.getAllByRole('alert');
+    
+    expect(toastContainer).toBeInTheDocument();
+    expect(toasts).toHaveLength(2);
+    
+    // Toasts should be stacked with the most recent on top
+    expect(toasts[0].textContent).toContain('Error');
+    expect(toasts[1].textContent).toContain('Success');
+  });
+
+  it('throws error when useToast is used outside of ToastProvider', () => {
+    // Suppress console.error for this test
+    const originalError = console.error;
+    console.error = jest.fn();
+    
+    expect(() => {
+      render(<TestComponent />);
+    }).toThrow('useToast must be used within a ToastProvider');
+    
+    // Restore console.error
+    console.error = originalError;
+  });
+});


### PR DESCRIPTION
Dieser Pull Request fügt Tests für weitere Komponenten hinzu.

## Enthaltene Änderungen

### Neue Tests für:
- TimePicker-Komponente
- Toast-Komponente (inkl. ToastProvider)
- RadioGroup-Komponente

### Für jede Komponente wurden hinzugefügt:
- Unit-Tests (*.test.tsx) für Funktionalität und Interaktionen
- Snapshot-Tests (*.spec.tsx) für visuelle Konsistenz

## Nächste Schritte

Nach der Genehmigung dieses Pull Requests werde ich mit der Erstellung von Tests für die verbleibenden Komponenten fortfahren.