### PR TITLE
Tests für Pagination, RadioGroup, Skeleton und Toast Komponenten hinzugefügt

### DIFF
--- a/packages/@smolitux/core/src/components/Pagination/__tests__/Pagination.spec.tsx
+++ b/packages/@smolitux/core/src/components/Pagination/__tests__/Pagination.spec.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Pagination } from '../Pagination';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Pagination Snapshots', () => {
+  it('renders default pagination correctly', () => {
+    const { asFragment } = render(
+      <Pagination pageCount={10} currentPage={1} onChange={jest.fn()} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with current page in middle correctly', () => {
+    const { asFragment } = render(
+      <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with current page at end correctly', () => {
+    const { asFragment } = render(
+      <Pagination pageCount={10} currentPage={10} onChange={jest.fn()} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with different siblingCount correctly', () => {
+    const siblingCounts = [0, 1, 2];
+    
+    const fragments = siblingCounts.map(siblingCount => {
+      const { asFragment } = render(
+        <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} siblingCount={siblingCount} />
+      );
+      return { siblingCount, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ siblingCount, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Pagination with siblingCount ${siblingCount}`);
+    });
+  });
+
+  it('renders pagination with first/last buttons correctly', () => {
+    const { asFragment } = render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={jest.fn()} 
+        showFirstLast={true}
+        labels={{ first: 'First', last: 'Last' }}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with prev/next buttons correctly', () => {
+    const { asFragment } = render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={jest.fn()} 
+        showPrevNext={true}
+        labels={{ previous: 'Previous', next: 'Next' }}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with all navigation buttons correctly', () => {
+    const { asFragment } = render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={jest.fn()} 
+        showFirstLast={true}
+        showPrevNext={true}
+        labels={{ first: 'First', last: 'Last', previous: 'Previous', next: 'Next' }}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with different sizes correctly', () => {
+    const sizes = ['sm', 'md', 'lg'];
+    
+    const fragments = sizes.map(size => {
+      const { asFragment } = render(
+        <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} size={size as any} />
+      );
+      return { size, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ size, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Pagination with size ${size}`);
+    });
+  });
+
+  it('renders pagination with different variants correctly', () => {
+    const variants = ['outlined', 'filled', 'simple'];
+    
+    const fragments = variants.map(variant => {
+      const { asFragment } = render(
+        <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} variant={variant as any} />
+      );
+      return { variant, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ variant, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Pagination with variant ${variant}`);
+    });
+  });
+
+  it('renders disabled pagination correctly', () => {
+    const { asFragment } = render(
+      <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} disabled />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with page count correctly', () => {
+    const { asFragment } = render(
+      <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} showPageCount />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with custom className correctly', () => {
+    const { asFragment } = render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={jest.fn()} 
+        className="custom-pagination"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with small number of pages correctly', () => {
+    const { asFragment } = render(
+      <Pagination pageCount={3} currentPage={2} onChange={jest.fn()} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with single page correctly', () => {
+    const { asFragment } = render(
+      <Pagination pageCount={1} currentPage={1} onChange={jest.fn()} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders pagination with all features enabled correctly', () => {
+    const { asFragment } = render(
+      <Pagination 
+        pageCount={20} 
+        currentPage={10} 
+        onChange={jest.fn()} 
+        siblingCount={2}
+        showFirstLast={true}
+        showPrevNext={true}
+        showPageCount={true}
+        size="lg"
+        variant="filled"
+        labels={{ first: 'First', last: 'Last', previous: 'Previous', next: 'Next' }}
+        className="custom-pagination"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/@smolitux/core/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -1,0 +1,310 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Pagination } from '../Pagination';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Pagination', () => {
+  it('renders correctly with default props', () => {
+    render(<Pagination pageCount={10} currentPage={1} onChange={jest.fn()} />);
+    
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(7); // 1, 2, 3, 4, 5, ellipsis, 10
+  });
+
+  it('renders with correct number of pages based on siblingCount', () => {
+    const { rerender } = render(
+      <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} siblingCount={1} />
+    );
+    
+    // Should show: 1, ellipsis, 4, 5, 6, ellipsis, 10
+    expect(screen.getAllByRole('button')).toHaveLength(7);
+    
+    rerender(
+      <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} siblingCount={2} />
+    );
+    
+    // Should show: 1, ellipsis, 3, 4, 5, 6, 7, ellipsis, 10
+    expect(screen.getAllByRole('button')).toHaveLength(9);
+  });
+
+  it('highlights the current page', () => {
+    render(<Pagination pageCount={10} currentPage={5} onChange={jest.fn()} />);
+    
+    const currentPageButton = screen.getByText('5');
+    expect(currentPageButton).toHaveClass('bg-primary-500');
+  });
+
+  it('calls onChange when a page is clicked', () => {
+    const handleChange = jest.fn();
+    render(<Pagination pageCount={10} currentPage={1} onChange={handleChange} />);
+    
+    const page3Button = screen.getByText('3');
+    fireEvent.click(page3Button);
+    
+    expect(handleChange).toHaveBeenCalledWith(3);
+  });
+
+  it('shows first and last page buttons when showFirstLast is true', () => {
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={jest.fn()} 
+        showFirstLast={true}
+        labels={{ first: 'First', last: 'Last' }}
+      />
+    );
+    
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Last')).toBeInTheDocument();
+  });
+
+  it('shows previous and next page buttons when showPrevNext is true', () => {
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={jest.fn()} 
+        showPrevNext={true}
+        labels={{ previous: 'Previous', next: 'Next' }}
+      />
+    );
+    
+    expect(screen.getByText('Previous')).toBeInTheDocument();
+    expect(screen.getByText('Next')).toBeInTheDocument();
+  });
+
+  it('disables previous button on first page', () => {
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={1} 
+        onChange={jest.fn()} 
+        showPrevNext={true}
+        labels={{ previous: 'Previous', next: 'Next' }}
+      />
+    );
+    
+    const previousButton = screen.getByText('Previous');
+    expect(previousButton.closest('button')).toBeDisabled();
+  });
+
+  it('disables next button on last page', () => {
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={10} 
+        onChange={jest.fn()} 
+        showPrevNext={true}
+        labels={{ previous: 'Previous', next: 'Next' }}
+      />
+    );
+    
+    const nextButton = screen.getByText('Next');
+    expect(nextButton.closest('button')).toBeDisabled();
+  });
+
+  it('navigates to previous page when previous button is clicked', () => {
+    const handleChange = jest.fn();
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={handleChange} 
+        showPrevNext={true}
+        labels={{ previous: 'Previous', next: 'Next' }}
+      />
+    );
+    
+    const previousButton = screen.getByText('Previous');
+    fireEvent.click(previousButton);
+    
+    expect(handleChange).toHaveBeenCalledWith(4);
+  });
+
+  it('navigates to next page when next button is clicked', () => {
+    const handleChange = jest.fn();
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={handleChange} 
+        showPrevNext={true}
+        labels={{ previous: 'Previous', next: 'Next' }}
+      />
+    );
+    
+    const nextButton = screen.getByText('Next');
+    fireEvent.click(nextButton);
+    
+    expect(handleChange).toHaveBeenCalledWith(6);
+  });
+
+  it('navigates to first page when first button is clicked', () => {
+    const handleChange = jest.fn();
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={handleChange} 
+        showFirstLast={true}
+        labels={{ first: 'First', last: 'Last' }}
+      />
+    );
+    
+    const firstButton = screen.getByText('First');
+    fireEvent.click(firstButton);
+    
+    expect(handleChange).toHaveBeenCalledWith(1);
+  });
+
+  it('navigates to last page when last button is clicked', () => {
+    const handleChange = jest.fn();
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={handleChange} 
+        showFirstLast={true}
+        labels={{ first: 'First', last: 'Last' }}
+      />
+    );
+    
+    const lastButton = screen.getByText('Last');
+    fireEvent.click(lastButton);
+    
+    expect(handleChange).toHaveBeenCalledWith(10);
+  });
+
+  it('renders with different sizes', () => {
+    const { rerender } = render(
+      <Pagination pageCount={10} currentPage={1} onChange={jest.fn()} size="sm" />
+    );
+    
+    let buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toHaveClass('h-8');
+    });
+    
+    rerender(
+      <Pagination pageCount={10} currentPage={1} onChange={jest.fn()} size="md" />
+    );
+    
+    buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toHaveClass('h-10');
+    });
+    
+    rerender(
+      <Pagination pageCount={10} currentPage={1} onChange={jest.fn()} size="lg" />
+    );
+    
+    buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toHaveClass('h-12');
+    });
+  });
+
+  it('renders with different variants', () => {
+    const { rerender } = render(
+      <Pagination pageCount={10} currentPage={1} onChange={jest.fn()} variant="outlined" />
+    );
+    
+    let buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toHaveClass('border');
+    });
+    
+    rerender(
+      <Pagination pageCount={10} currentPage={1} onChange={jest.fn()} variant="filled" />
+    );
+    
+    buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toHaveClass('bg-gray-100');
+    });
+    
+    rerender(
+      <Pagination pageCount={10} currentPage={1} onChange={jest.fn()} variant="simple" />
+    );
+    
+    buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toHaveClass('bg-transparent');
+    });
+  });
+
+  it('renders in disabled state', () => {
+    render(<Pagination pageCount={10} currentPage={1} onChange={jest.fn()} disabled />);
+    
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach(button => {
+      expect(button).toBeDisabled();
+    });
+  });
+
+  it('shows page count when showPageCount is true', () => {
+    render(
+      <Pagination pageCount={10} currentPage={5} onChange={jest.fn()} showPageCount />
+    );
+    
+    expect(screen.getByText('5 / 10')).toBeInTheDocument();
+  });
+
+  it('renders with custom className', () => {
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={1} 
+        onChange={jest.fn()} 
+        className="custom-pagination"
+      />
+    );
+    
+    const pagination = screen.getByRole('navigation');
+    expect(pagination).toHaveClass('custom-pagination');
+  });
+
+  it('handles edge case with small number of pages', () => {
+    render(<Pagination pageCount={3} currentPage={2} onChange={jest.fn()} />);
+    
+    // Should show all pages without ellipsis
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('handles edge case with single page', () => {
+    render(<Pagination pageCount={1} currentPage={1} onChange={jest.fn()} />);
+    
+    // Should show just one page
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('handles keyboard navigation', () => {
+    const handleChange = jest.fn();
+    render(
+      <Pagination 
+        pageCount={10} 
+        currentPage={5} 
+        onChange={handleChange} 
+        showPrevNext={true}
+        labels={{ previous: 'Previous', next: 'Next' }}
+      />
+    );
+    
+    // Test left arrow key
+    fireEvent.keyDown(screen.getByText('Previous'), { key: 'ArrowLeft' });
+    expect(handleChange).toHaveBeenCalledWith(4);
+    
+    // Test right arrow key
+    fireEvent.keyDown(screen.getByText('Next'), { key: 'ArrowRight' });
+    expect(handleChange).toHaveBeenCalledWith(6);
+  });
+});

--- a/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.spec.tsx
+++ b/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.spec.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RadioGroup } from '../RadioGroup';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('RadioGroup Snapshots', () => {
+  const options = [
+    { value: 'option1', label: 'Option 1' },
+    { value: 'option2', label: 'Option 2' },
+    { value: 'option3', label: 'Option 3' }
+  ];
+
+  it('renders default radio group correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup name="test-group" options={options} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with label correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup name="test-group" options={options} label="Select an option" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with helper text correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup name="test-group" options={options} helperText="Please select one option" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with error message correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup name="test-group" options={options} error="Selection is required" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with selected value correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup name="test-group" options={options} value="option2" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with different directions correctly', () => {
+    const directions = ['horizontal', 'vertical'];
+    
+    const fragments = directions.map(direction => {
+      const { asFragment } = render(
+        <RadioGroup name="test-group" options={options} direction={direction as any} />
+      );
+      return { direction, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ direction, fragment }) => {
+      expect(fragment).toMatchSnapshot(`RadioGroup with direction ${direction}`);
+    });
+  });
+
+  it('renders radio group with different sizes correctly', () => {
+    const sizes = ['sm', 'md', 'lg'];
+    
+    const fragments = sizes.map(size => {
+      const { asFragment } = render(
+        <RadioGroup name="test-group" options={options} size={size as any} />
+      );
+      return { size, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ size, fragment }) => {
+      expect(fragment).toMatchSnapshot(`RadioGroup with size ${size}`);
+    });
+  });
+
+  it('renders disabled radio group correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup name="test-group" options={options} disabled />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with disabled options correctly', () => {
+    const optionsWithDisabled = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+      { value: 'option3', label: 'Option 3' }
+    ];
+    
+    const { asFragment } = render(
+      <RadioGroup name="test-group" options={optionsWithDisabled} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with custom className correctly', () => {
+    const { asFragment } = render(
+      <RadioGroup 
+        name="test-group" 
+        options={options} 
+        className="custom-radio-group"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders radio group with all features enabled correctly', () => {
+    const optionsWithDisabled = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+      { value: 'option3', label: 'Option 3' }
+    ];
+    
+    const { asFragment } = render(
+      <RadioGroup 
+        name="test-group" 
+        options={optionsWithDisabled}
+        label="Select an option"
+        helperText="Please select one option"
+        value="option1"
+        size="lg"
+        direction="horizontal"
+        className="custom-radio-group"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
+++ b/packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RadioGroup } from '../RadioGroup';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('RadioGroup', () => {
+  const options = [
+    { value: 'option1', label: 'Option 1' },
+    { value: 'option2', label: 'Option 2' },
+    { value: 'option3', label: 'Option 3' }
+  ];
+
+  it('renders correctly with default props', () => {
+    render(<RadioGroup name="test-group" options={options} />);
+    
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+    expect(screen.getByText('Option 3')).toBeInTheDocument();
+  });
+
+  it('renders with label', () => {
+    render(<RadioGroup name="test-group" options={options} label="Select an option" />);
+    
+    expect(screen.getByText('Select an option')).toBeInTheDocument();
+  });
+
+  it('renders with helper text', () => {
+    render(<RadioGroup name="test-group" options={options} helperText="Please select one option" />);
+    
+    expect(screen.getByText('Please select one option')).toBeInTheDocument();
+  });
+
+  it('renders with error message', () => {
+    render(<RadioGroup name="test-group" options={options} error="Selection is required" />);
+    
+    expect(screen.getByText('Selection is required')).toBeInTheDocument();
+  });
+
+  it('selects the correct option based on value prop', () => {
+    render(<RadioGroup name="test-group" options={options} value="option2" />);
+    
+    const option1 = screen.getByLabelText('Option 1');
+    const option2 = screen.getByLabelText('Option 2');
+    const option3 = screen.getByLabelText('Option 3');
+    
+    expect(option1).not.toBeChecked();
+    expect(option2).toBeChecked();
+    expect(option3).not.toBeChecked();
+  });
+
+  it('calls onChange when an option is selected', () => {
+    const handleChange = jest.fn();
+    render(<RadioGroup name="test-group" options={options} onChange={handleChange} />);
+    
+    const option2 = screen.getByLabelText('Option 2');
+    fireEvent.click(option2);
+    
+    expect(handleChange).toHaveBeenCalledWith('option2');
+  });
+
+  it('renders with horizontal direction', () => {
+    render(<RadioGroup name="test-group" options={options} direction="horizontal" />);
+    
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toHaveClass('flex-row');
+  });
+
+  it('renders with vertical direction', () => {
+    render(<RadioGroup name="test-group" options={options} direction="vertical" />);
+    
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toHaveClass('flex-col');
+  });
+
+  it('renders with different sizes', () => {
+    const { rerender } = render(
+      <RadioGroup name="test-group" options={options} size="sm" />
+    );
+    
+    let radios = screen.getAllByRole('radio');
+    radios.forEach(radio => {
+      expect(radio.parentElement).toHaveClass('h-4');
+    });
+    
+    rerender(
+      <RadioGroup name="test-group" options={options} size="md" />
+    );
+    
+    radios = screen.getAllByRole('radio');
+    radios.forEach(radio => {
+      expect(radio.parentElement).toHaveClass('h-5');
+    });
+    
+    rerender(
+      <RadioGroup name="test-group" options={options} size="lg" />
+    );
+    
+    radios = screen.getAllByRole('radio');
+    radios.forEach(radio => {
+      expect(radio.parentElement).toHaveClass('h-6');
+    });
+  });
+
+  it('disables all options when disabled prop is true', () => {
+    render(<RadioGroup name="test-group" options={options} disabled />);
+    
+    const radios = screen.getAllByRole('radio');
+    radios.forEach(radio => {
+      expect(radio).toBeDisabled();
+    });
+  });
+
+  it('disables individual options', () => {
+    const optionsWithDisabled = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+      { value: 'option3', label: 'Option 3' }
+    ];
+    
+    render(<RadioGroup name="test-group" options={optionsWithDisabled} />);
+    
+    expect(screen.getByLabelText('Option 1')).not.toBeDisabled();
+    expect(screen.getByLabelText('Option 2')).toBeDisabled();
+    expect(screen.getByLabelText('Option 3')).not.toBeDisabled();
+  });
+
+  it('handles keyboard navigation', () => {
+    const handleChange = jest.fn();
+    render(<RadioGroup name="test-group" options={options} onChange={handleChange} />);
+    
+    const option1 = screen.getByLabelText('Option 1');
+    const option2 = screen.getByLabelText('Option 2');
+    
+    // Focus on first option
+    option1.focus();
+    
+    // Press arrow down to navigate to next option
+    fireEvent.keyDown(option1, { key: 'ArrowDown' });
+    expect(option2).toHaveFocus();
+    
+    // Press space to select
+    fireEvent.keyDown(option2, { key: ' ' });
+    expect(handleChange).toHaveBeenCalledWith('option2');
+  });
+
+  it('applies correct name attribute to all radio inputs', () => {
+    render(<RadioGroup name="test-group" options={options} />);
+    
+    const radios = screen.getAllByRole('radio');
+    radios.forEach(radio => {
+      expect(radio).toHaveAttribute('name', 'test-group');
+    });
+  });
+
+  it('renders with custom className', () => {
+    render(
+      <RadioGroup 
+        name="test-group" 
+        options={options} 
+        className="custom-radio-group"
+      />
+    );
+    
+    const radioGroup = screen.getByRole('radiogroup');
+    expect(radioGroup).toHaveClass('custom-radio-group');
+  });
+});

--- a/packages/@smolitux/core/src/components/Skeleton/__tests__/Skeleton.spec.tsx
+++ b/packages/@smolitux/core/src/components/Skeleton/__tests__/Skeleton.spec.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Skeleton } from '../Skeleton';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Skeleton Snapshots', () => {
+  it('renders default skeleton correctly', () => {
+    const { asFragment } = render(<Skeleton />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders skeleton with custom width and height correctly', () => {
+    const { asFragment } = render(<Skeleton width={200} height={100} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders skeleton with string width and height correctly', () => {
+    const { asFragment } = render(<Skeleton width="50%" height="10rem" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders skeleton with different variants correctly', () => {
+    const variants = ['text', 'circular', 'rectangular', 'rounded'];
+    
+    const fragments = variants.map(variant => {
+      const { asFragment } = render(<Skeleton variant={variant as any} />);
+      return { variant, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ variant, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Skeleton with variant ${variant}`);
+    });
+  });
+
+  it('renders skeleton with different animations correctly', () => {
+    const animations = ['pulse', 'wave', 'none'];
+    
+    const fragments = animations.map(animation => {
+      const { asFragment } = render(<Skeleton animation={animation as any} />);
+      return { animation, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ animation, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Skeleton with animation ${animation}`);
+    });
+  });
+
+  it('renders multiple skeletons correctly', () => {
+    const { asFragment } = render(<Skeleton count={3} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders multiple skeletons with gap correctly', () => {
+    const { asFragment } = render(<Skeleton count={3} gap={8} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders skeleton with custom className correctly', () => {
+    const { asFragment } = render(<Skeleton className="custom-skeleton" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders text skeleton with appropriate dimensions correctly', () => {
+    const { asFragment } = render(<Skeleton variant="text" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders circular skeleton with equal width and height correctly', () => {
+    const { asFragment } = render(<Skeleton variant="circular" width={50} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders skeleton with all features combined correctly', () => {
+    const { asFragment } = render(
+      <Skeleton 
+        variant="rounded"
+        width={300}
+        height={150}
+        animation="wave"
+        count={2}
+        gap={16}
+        className="custom-skeleton"
+        data-custom="test"
+        aria-label="Loading content"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders skeleton in dark mode correctly', () => {
+    // Override the mock for this test
+    jest.resetModules();
+    jest.mock('@smolitux/theme', () => ({
+      useTheme: jest.fn(() => ({ themeMode: 'dark' })),
+    }));
+    
+    const { asFragment } = render(<Skeleton />);
+    expect(asFragment()).toMatchSnapshot();
+    
+    // Reset the mock back
+    jest.resetModules();
+    jest.mock('@smolitux/theme', () => ({
+      useTheme: jest.fn(() => ({ themeMode: 'light' })),
+    }));
+  });
+});

--- a/packages/@smolitux/core/src/components/Skeleton/__tests__/Skeleton.test.tsx
+++ b/packages/@smolitux/core/src/components/Skeleton/__tests__/Skeleton.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Skeleton } from '../Skeleton';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Skeleton', () => {
+  it('renders correctly with default props', () => {
+    render(<Skeleton />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveClass('skeleton');
+  });
+
+  it('applies custom width and height', () => {
+    render(<Skeleton width={200} height={100} />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveStyle('width: 200px');
+    expect(skeleton).toHaveStyle('height: 100px');
+  });
+
+  it('applies string width and height', () => {
+    render(<Skeleton width="50%" height="10rem" />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveStyle('width: 50%');
+    expect(skeleton).toHaveStyle('height: 10rem');
+  });
+
+  it('renders with different variants', () => {
+    const { rerender } = render(<Skeleton variant="text" />);
+    
+    let skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveClass('skeleton-text');
+    
+    rerender(<Skeleton variant="circular" />);
+    skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveClass('skeleton-circular');
+    
+    rerender(<Skeleton variant="rectangular" />);
+    skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveClass('skeleton-rectangular');
+    
+    rerender(<Skeleton variant="rounded" />);
+    skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveClass('skeleton-rounded');
+  });
+
+  it('renders with different animations', () => {
+    const { rerender } = render(<Skeleton animation="pulse" />);
+    
+    let skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveClass('skeleton-pulse');
+    
+    rerender(<Skeleton animation="wave" />);
+    skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveClass('skeleton-wave');
+    
+    rerender(<Skeleton animation="none" />);
+    skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).not.toHaveClass('skeleton-pulse');
+    expect(skeleton).not.toHaveClass('skeleton-wave');
+  });
+
+  it('renders multiple skeletons when count is greater than 1', () => {
+    render(<Skeleton count={3} />);
+    
+    const skeletons = screen.getAllByTestId('skeleton');
+    expect(skeletons).toHaveLength(3);
+  });
+
+  it('applies gap between multiple skeletons', () => {
+    render(<Skeleton count={2} gap={8} />);
+    
+    const container = screen.getByTestId('skeleton-container');
+    expect(container).toHaveStyle('gap: 8px');
+  });
+
+  it('renders with custom className', () => {
+    render(<Skeleton className="custom-skeleton" />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveClass('custom-skeleton');
+  });
+
+  it('forwards ref to div element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Skeleton ref={ref} />);
+    
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+
+  it('passes additional props to the div element', () => {
+    render(<Skeleton data-custom="test" aria-label="Loading" />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveAttribute('data-custom', 'test');
+    expect(skeleton).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  it('renders with correct ARIA attributes for accessibility', () => {
+    render(<Skeleton />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveAttribute('aria-busy', 'true');
+    expect(skeleton).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders text variant with appropriate dimensions', () => {
+    render(<Skeleton variant="text" />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveStyle('height: 1em');
+    expect(skeleton).toHaveStyle('width: 100%');
+  });
+
+  it('renders circular variant with equal width and height', () => {
+    render(<Skeleton variant="circular" width={50} />);
+    
+    const skeleton = screen.getByTestId('skeleton');
+    expect(skeleton).toHaveStyle('width: 50px');
+    expect(skeleton).toHaveStyle('height: 50px');
+  });
+});

--- a/packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx
+++ b/packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Toast } from '../Toast';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Toast Snapshots', () => {
+  it('renders default toast correctly', () => {
+    const { asFragment } = render(
+      <Toast message="Test message" isOpen={true} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with title correctly', () => {
+    const { asFragment } = render(
+      <Toast title="Test Title" message="Test message" isOpen={true} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with different types correctly', () => {
+    const types = ['success', 'error', 'warning', 'info'];
+    
+    const fragments = types.map(type => {
+      const { asFragment } = render(
+        <Toast message="Test message" type={type as any} isOpen={true} />
+      );
+      return { type, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ type, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Toast with type ${type}`);
+    });
+  });
+
+  it('renders toast with close button correctly', () => {
+    const { asFragment } = render(
+      <Toast message="Test message" isOpen={true} showCloseButton={true} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with icon correctly', () => {
+    const { asFragment } = render(
+      <Toast message="Test message" isOpen={true} showIcon={true} type="success" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with custom icon correctly', () => {
+    const { asFragment } = render(
+      <Toast message="Test message" isOpen={true} icon={<span>🔔</span>} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with actions correctly', () => {
+    const { asFragment } = render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        actions={<button>Action</button>}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with different positions correctly', () => {
+    const positions = [
+      'top-right', 'top-left', 'bottom-right', 
+      'bottom-left', 'top-center', 'bottom-center'
+    ];
+    
+    const fragments = positions.map(position => {
+      const { asFragment } = render(
+        <Toast message="Test message" isOpen={true} position={position as any} />
+      );
+      return { position, fragment: asFragment() };
+    });
+    
+    fragments.forEach(({ position, fragment }) => {
+      expect(fragment).toMatchSnapshot(`Toast with position ${position}`);
+    });
+  });
+
+  it('renders toast with animation correctly', () => {
+    const { asFragment } = render(
+      <Toast message="Test message" isOpen={true} animateOut={true} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with custom className correctly', () => {
+    const { asFragment } = render(
+      <Toast message="Test message" isOpen={true} className="custom-toast" />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast with all features enabled correctly', () => {
+    const { asFragment } = render(
+      <Toast 
+        title="Test Title"
+        message="Test message"
+        type="success"
+        isOpen={true}
+        position="top-right"
+        showIcon={true}
+        showCloseButton={true}
+        animateOut={true}
+        actions={<button>Action</button>}
+        className="custom-toast"
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders toast in dark mode correctly', () => {
+    // Override the mock for this test
+    jest.resetModules();
+    jest.mock('@smolitux/theme', () => ({
+      useTheme: jest.fn(() => ({ themeMode: 'dark' })),
+    }));
+    
+    const { asFragment } = render(
+      <Toast message="Test message" isOpen={true} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    
+    // Reset the mock back
+    jest.resetModules();
+    jest.mock('@smolitux/theme', () => ({
+      useTheme: jest.fn(() => ({ themeMode: 'light' })),
+    }));
+  });
+});

--- a/packages/@smolitux/core/src/components/Toast/__tests__/Toast.test.tsx
+++ b/packages/@smolitux/core/src/components/Toast/__tests__/Toast.test.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { Toast } from '../Toast';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+describe('Toast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders correctly with default props', () => {
+    render(<Toast message="Test message" isOpen={true} />);
+    
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('renders with title', () => {
+    render(<Toast title="Test Title" message="Test message" isOpen={true} />);
+    
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test message')).toBeInTheDocument();
+  });
+
+  it('renders with different types', () => {
+    const { rerender } = render(<Toast message="Test message" type="success" isOpen={true} />);
+    
+    let toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bg-success-100');
+    
+    rerender(<Toast message="Test message" type="error" isOpen={true} />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bg-error-100');
+    
+    rerender(<Toast message="Test message" type="warning" isOpen={true} />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bg-warning-100');
+    
+    rerender(<Toast message="Test message" type="info" isOpen={true} />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bg-info-100');
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const handleClose = jest.fn();
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        onClose={handleClose}
+        showCloseButton={true}
+      />
+    );
+    
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+    
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('auto-closes after duration', () => {
+    const handleClose = jest.fn();
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        onClose={handleClose}
+        duration={3000}
+      />
+    );
+    
+    // Fast-forward time
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('does not auto-close when duration is 0', () => {
+    const handleClose = jest.fn();
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        onClose={handleClose}
+        duration={0}
+      />
+    );
+    
+    // Fast-forward time
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('renders with icon when showIcon is true', () => {
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        showIcon={true}
+        type="success"
+      />
+    );
+    
+    expect(screen.getByTestId('toast-icon')).toBeInTheDocument();
+  });
+
+  it('renders with custom icon', () => {
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        icon={<span data-testid="custom-icon">🔔</span>}
+      />
+    );
+    
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('renders with actions', () => {
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        actions={<button data-testid="action-button">Action</button>}
+      />
+    );
+    
+    expect(screen.getByTestId('action-button')).toBeInTheDocument();
+  });
+
+  it('applies position class correctly', () => {
+    const { rerender } = render(
+      <Toast message="Test message" isOpen={true} position="top-right" />
+    );
+    
+    let toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('top-4 right-4');
+    
+    rerender(<Toast message="Test message" isOpen={true} position="top-left" />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('top-4 left-4');
+    
+    rerender(<Toast message="Test message" isOpen={true} position="bottom-right" />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bottom-4 right-4');
+    
+    rerender(<Toast message="Test message" isOpen={true} position="bottom-left" />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bottom-4 left-4');
+    
+    rerender(<Toast message="Test message" isOpen={true} position="top-center" />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('top-4 left-1/2 -translate-x-1/2');
+    
+    rerender(<Toast message="Test message" isOpen={true} position="bottom-center" />);
+    toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bottom-4 left-1/2 -translate-x-1/2');
+  });
+
+  it('applies animation classes when animateOut is true', () => {
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        animateOut={true}
+      />
+    );
+    
+    const toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('animate-fade-in');
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(<Toast message="Test message" isOpen={false} />);
+    
+    expect(screen.queryByText('Test message')).not.toBeInTheDocument();
+  });
+
+  it('renders with custom className', () => {
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        className="custom-toast"
+      />
+    );
+    
+    const toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('custom-toast');
+  });
+
+  it('forwards ref to div element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Toast message="Test message" isOpen={true} ref={ref} />);
+    
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('DIV');
+  });
+
+  it('resets auto-close timer when toast is clicked', () => {
+    const handleClose = jest.fn();
+    render(
+      <Toast 
+        message="Test message" 
+        isOpen={true} 
+        onClose={handleClose}
+        duration={3000}
+      />
+    );
+    
+    // Advance time a bit
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    
+    // Click the toast
+    const toast = screen.getByRole('alert');
+    fireEvent.click(toast);
+    
+    // Advance time a bit more, but not enough for the full duration
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    
+    // onClose should not have been called yet
+    expect(handleClose).not.toHaveBeenCalled();
+    
+    // Advance time to complete the new duration
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    
+    // Now onClose should have been called
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/packages/@smolitux/core/src/components/Toast/__tests__/ToastProvider.test.tsx
+++ b/packages/@smolitux/core/src/components/Toast/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ToastProvider } from '../ToastProvider';
+import { useToast } from '../ToastProvider';
+
+// Mock für ThemeProvider
+jest.mock('@smolitux/theme', () => ({
+  useTheme: jest.fn(() => ({ themeMode: 'light' })),
+}));
+
+// Test-Komponente, die den useToast-Hook verwendet
+const TestComponent = () => {
+  const { addToast, removeAllToasts } = useToast();
+  
+  const handleAddSuccessToast = () => {
+    addToast({
+      title: 'Success',
+      message: 'Operation successful',
+      type: 'success',
+      duration: 3000,
+    });
+  };
+  
+  const handleAddErrorToast = () => {
+    addToast({
+      title: 'Error',
+      message: 'Something went wrong',
+      type: 'error',
+      duration: 3000,
+    });
+  };
+  
+  const handleClearToasts = () => {
+    removeAllToasts();
+  };
+  
+  return (
+    <div>
+      <button onClick={handleAddSuccessToast}>Add Success Toast</button>
+      <button onClick={handleAddErrorToast}>Add Error Toast</button>
+      <button onClick={handleClearToasts}>Clear All Toasts</button>
+    </div>
+  );
+};
+
+describe('ToastProvider', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <ToastProvider>
+        <div data-testid="test-child">Test Child</div>
+      </ToastProvider>
+    );
+    
+    expect(screen.getByTestId('test-child')).toBeInTheDocument();
+  });
+
+  it('allows adding toasts', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    const addSuccessButton = screen.getByText('Add Success Toast');
+    fireEvent.click(addSuccessButton);
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Operation successful')).toBeInTheDocument();
+  });
+
+  it('allows adding multiple toasts', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    const addSuccessButton = screen.getByText('Add Success Toast');
+    const addErrorButton = screen.getByText('Add Error Toast');
+    
+    fireEvent.click(addSuccessButton);
+    fireEvent.click(addErrorButton);
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Operation successful')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('removes toasts after duration', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    const addSuccessButton = screen.getByText('Add Success Toast');
+    fireEvent.click(addSuccessButton);
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    
+    // Fast-forward time
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    
+    // Toast should be removed
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+  });
+
+  it('allows clearing all toasts', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    const addSuccessButton = screen.getByText('Add Success Toast');
+    const addErrorButton = screen.getByText('Add Error Toast');
+    const clearButton = screen.getByText('Clear All Toasts');
+    
+    fireEvent.click(addSuccessButton);
+    fireEvent.click(addErrorButton);
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    
+    fireEvent.click(clearButton);
+    
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+    expect(screen.queryByText('Error')).not.toBeInTheDocument();
+  });
+
+  it('respects the limit prop', () => {
+    render(
+      <ToastProvider limit={2}>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    const addSuccessButton = screen.getByText('Add Success Toast');
+    const addErrorButton = screen.getByText('Add Error Toast');
+    
+    // Add 3 toasts
+    fireEvent.click(addSuccessButton);
+    fireEvent.click(addErrorButton);
+    fireEvent.click(addSuccessButton);
+    
+    // Only the 2 most recent toasts should be visible
+    const successToasts = screen.getAllByText('Success');
+    const errorToasts = screen.getAllByText('Error');
+    
+    expect(successToasts).toHaveLength(1);
+    expect(errorToasts).toHaveLength(1);
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+  });
+
+  it('applies position to all toasts', () => {
+    render(
+      <ToastProvider position="bottom-center">
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    const addSuccessButton = screen.getByText('Add Success Toast');
+    fireEvent.click(addSuccessButton);
+    
+    const toast = screen.getByRole('alert');
+    expect(toast).toHaveClass('bottom-4 left-1/2 -translate-x-1/2');
+  });
+
+  it('allows closing individual toasts', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    );
+    
+    const addSuccessButton = screen.getByText('Add Success Toast');
+    const addErrorButton = screen.getByText('Add Error Toast');
+    
+    fireEvent.click(addSuccessButton);
+    fireEvent.click(addErrorButton);
+    
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    
+    // Close the success toast
+    const closeButtons = screen.getAllByLabelText('Close');
+    fireEvent.click(closeButtons[0]);
+    
+    // Success toast should be removed, but error toast should remain
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  it('throws error when useToast is used outside of ToastProvider', () => {
+    // Suppress console.error for this test
+    const originalError = console.error;
+    console.error = jest.fn();
+    
+    expect(() => {
+      render(<TestComponent />);
+    }).toThrow('useToast must be used within a ToastProvider');
+    
+    // Restore console.error
+    console.error = originalError;
+  });
+});


### PR DESCRIPTION
Dieser Pull Request fügt Tests für weitere Komponenten hinzu.

## Enthaltene Änderungen

### Neue Tests für:
- Pagination-Komponente
- RadioGroup-Komponente
- Skeleton-Komponente
- Toast-Komponente (inkl. ToastProvider)

### Für jede Komponente wurden hinzugefügt:
- Unit-Tests (*.test.tsx) für Funktionalität und Interaktionen
- Snapshot-Tests (*.spec.tsx) für visuelle Konsistenz

## Nächste Schritte

Mit diesem Pull Request sind nun Tests für alle Komponenten im @smolitux/core Paket vorhanden.