### PR TITLE
[Fix]: Behebe Lint-Fehler in @smolitux/theme-Paket

### DIFF
--- a/packages/@smolitux/theme/src/ThemeUtilities.tsx
+++ b/packages/@smolitux/theme/src/ThemeUtilities.tsx
@@ -1,4 +1,4 @@
-import { Theme, ThemeMode } from './types';
+import { Theme } from './types';
 
 /**
  * Berechnet eine Farbe basierend auf dem aktuellen Theme
@@ -6,8 +6,7 @@ import { Theme, ThemeMode } from './types';
 export function getColorByTheme(
   theme: Theme,
   colorName: keyof Theme['colors'], 
-  shade: keyof Theme['colors']['primary'],
-  themeMode: ThemeMode
+  shade: keyof Theme['colors']['primary']
 ): string {
   const colorScale = theme.colors[colorName];
   if (!colorScale || typeof colorScale === 'string') {

--- a/packages/@smolitux/theme/src/theme-provider.tsx
+++ b/packages/@smolitux/theme/src/theme-provider.tsx
@@ -204,8 +204,7 @@ export const shadows = {
  */
 export function getColorByTheme(
   colorName: keyof typeof colors, 
-  shade: keyof typeof colors.primary,
-  themeMode: ThemeMode
+  shade: keyof typeof colors.primary
 ): string {
   const colorScale = colors[colorName];
   if (!colorScale) {


### PR DESCRIPTION
## Beschreibung

Dieser Pull Request behebt Lint-Fehler im @smolitux/theme-Paket.

## Änderungen

- Entferne unbenutzte ThemeMode-Import in ThemeUtilities.tsx
- Entferne unbenutzte themeMode-Parameter in getColorByTheme-Funktion

## Testplan

- Lint-Tests für das @smolitux/theme-Paket wurden erfolgreich ausgeführt