### PR TITLE
[Fix]: Lint-Fehler in verschiedenen Paketen beheben

### DIFF
--- a/packages/@smolitux/ai/src/components/EngagementScore/__tests__/EngagementScore.test.tsx
+++ b/packages/@smolitux/ai/src/components/EngagementScore/__tests__/EngagementScore.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { EngagementScore } from './EngagementScore';
+import { EngagementScore } from '../EngagementScore';
 
 describe('EngagementScore', () => {
   const mockEngagementData = {

--- a/packages/@smolitux/ai/src/components/SentimentDisplay/__tests__/SentimentDisplay.test.tsx
+++ b/packages/@smolitux/ai/src/components/SentimentDisplay/__tests__/SentimentDisplay.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { SentimentDisplay } from './SentimentDisplay';
+import { SentimentDisplay } from '../SentimentDisplay';
 
 describe('SentimentDisplay', () => {
   const mockSentimentData = {

--- a/packages/@smolitux/ai/src/components/TrendingTopics/__tests__/TrendingTopics.test.tsx
+++ b/packages/@smolitux/ai/src/components/TrendingTopics/__tests__/TrendingTopics.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { TrendingTopics } from './TrendingTopics';
+import { TrendingTopics } from '../TrendingTopics';
 
 describe('TrendingTopics', () => {
   const mockTopicsData = {

--- a/packages/@smolitux/blockchain/src/components/SmartContractInteraction/__tests__/SmartContractInteraction.test.tsx
+++ b/packages/@smolitux/blockchain/src/components/SmartContractInteraction/__tests__/SmartContractInteraction.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { SmartContractInteraction } from './SmartContractInteraction';
 
 describe('SmartContractInteraction', () => {

--- a/packages/@smolitux/blockchain/src/components/TokenEconomy/__tests__/TokenEconomy.test.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenEconomy/__tests__/TokenEconomy.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { TokenEconomy } from './TokenEconomy';
 
 describe('TokenEconomy', () => {

--- a/packages/@smolitux/charts/src/components/AreaChart/__tests__/AreaChart.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/AreaChart/__tests__/AreaChart.a11y.test.tsx
@@ -3,10 +3,10 @@ import { render } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { AreaChart } from '../AreaChart';
 
-// Erweitere Jest-Matcher um Barrierefreiheitsprüfungen
+// Extend Jest matchers with accessibility checks
 expect.extend(toHaveNoViolations);
 
-// Mock für useTheme hook
+// Mock for useTheme hook
 jest.mock('@smolitux/theme', () => ({
   useTheme: () => ({ themeMode: 'light' })
 }));
@@ -28,8 +28,8 @@ describe('AreaChart Accessibility', () => {
     const { container } = render(
       <AreaChart 
         data={mockData}
-        title="Monatliche Besucher"
-        aria-label="Diagramm: Monatliche Besucher"
+        title="Monthly Visitors"
+        aria-label="Chart: Monthly Visitors"
       />
     );
     
@@ -41,13 +41,13 @@ describe('AreaChart Accessibility', () => {
     const { container } = render(
       <AreaChart 
         data={mockData}
-        title="Monatliche Besucher"
-        aria-label="Diagramm: Monatliche Besucher"
+        title="Monthly Visitors"
+        aria-label="Chart: Monthly Visitors"
       />
     );
     
     const svg = container.querySelector('svg');
-    expect(svg).toHaveAttribute('aria-label', 'Diagramm: Monatliche Besucher');
+    expect(svg).toHaveAttribute('aria-label', 'Chart: Monthly Visitors');
   });
 
   test('should be keyboard navigable when interactive elements are present', () => {
@@ -56,11 +56,11 @@ describe('AreaChart Accessibility', () => {
         data={mockData}
         showPoints={true}
         showTooltips={true}
-        aria-label="Interaktives Diagramm: Monatliche Besucher"
+        aria-label="Interactive Chart: Monthly Visitors"
       />
     );
     
-    // Prüfen, ob das SVG-Element fokussierbar ist, wenn es interaktive Elemente enthält
+    // Check if the SVG element is focusable when it contains interactive elements
     const svg = container.querySelector('svg');
     expect(svg).toHaveAttribute('tabIndex', '0');
   });

--- a/packages/@smolitux/charts/src/components/AreaChart/__tests__/AreaChart.test.tsx
+++ b/packages/@smolitux/charts/src/components/AreaChart/__tests__/AreaChart.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { AreaChart } from '../AreaChart';
 
-// Mock für useTheme hook
+// Mock for useTheme hook
 jest.mock('@smolitux/theme', () => ({
   useTheme: () => ({ themeMode: 'light' })
 }));
@@ -23,11 +23,11 @@ describe('AreaChart', () => {
   test('renders chart with placeholder text', () => {
     render(<AreaChart data={mockData} />);
     
-    // SVG sollte gerendert werden
+    // SVG should be rendered
     const svg = document.querySelector('svg');
     expect(svg).toBeInTheDocument();
     
-    // Platzhaltertext sollte angezeigt werden
+    // Placeholder text should be displayed
     expect(screen.getByText('AreaChart Platzhalter')).toBeInTheDocument();
   });
 
@@ -63,14 +63,14 @@ describe('AreaChart', () => {
     
     render(<AreaChart data={multiSeriesData} />);
     
-    // Chart sollte ohne Fehler gerendert werden
+    // Chart should be rendered without errors
     expect(document.querySelector('svg')).toBeInTheDocument();
   });
 
   test('renders with title when provided', () => {
     render(<AreaChart data={mockData} title="Test Chart Title" />);
     
-    // SVG sollte gerendert werden
+    // SVG should be rendered
     const svg = document.querySelector('svg');
     expect(svg).toBeInTheDocument();
   });

--- a/packages/@smolitux/resonance/src/components/feed/__tests__/FeedFilter.test.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/__tests__/FeedFilter.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { FeedFilter } from './FeedFilter';
+import { FeedFilter } from '../FeedFilter';
 
 describe('FeedFilter', () => {
   const mockOnFilterChange = jest.fn();

--- a/packages/@smolitux/resonance/src/components/feed/__tests__/FeedItem.test.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/__tests__/FeedItem.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { FeedItem } from './FeedItem';
+import { FeedItem } from '../FeedItem';
 
 describe('FeedItem', () => {
   const mockPost = {

--- a/packages/@smolitux/resonance/src/components/feed/__tests__/FeedSidebar.test.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/__tests__/FeedSidebar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { FeedSidebar } from './FeedSidebar';
+import { FeedSidebar } from '../FeedSidebar';
 
 describe('FeedSidebar', () => {
   const mockTrendingTopics = [

--- a/packages/@smolitux/resonance/src/components/feed/__tests__/FeedView.test.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/__tests__/FeedView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { FeedView } from './FeedView';
+import { FeedView } from '../FeedView';
 
 describe('FeedView', () => {
   const mockPosts = [

--- a/packages/@smolitux/resonance/src/components/governance/__tests__/GovernanceDashboard.test.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/__tests__/GovernanceDashboard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { GovernanceDashboard } from './GovernanceDashboard';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GovernanceDashboard } from '../GovernanceDashboard';
 
 describe('GovernanceDashboard', () => {
   const mockProposals = [

--- a/packages/@smolitux/resonance/src/components/governance/__tests__/ProposalView.test.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/__tests__/ProposalView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { ProposalView } from './ProposalView';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProposalView } from '../ProposalView';
 
 describe('ProposalView', () => {
   const mockProposal = {

--- a/packages/@smolitux/resonance/src/components/governance/__tests__/VotingSystem.test.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/__tests__/VotingSystem.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { VotingSystem } from './VotingSystem';
+import { VotingSystem } from '../VotingSystem';
 
 describe('VotingSystem', () => {
   const mockProposal = {

--- a/packages/@smolitux/resonance/src/components/monetization/__tests__/CreatorDashboard.test.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/__tests__/CreatorDashboard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { CreatorDashboard } from './CreatorDashboard';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CreatorDashboard } from '../CreatorDashboard';
 
 describe('CreatorDashboard', () => {
   const mockCreatorData = {

--- a/packages/@smolitux/resonance/src/components/monetization/__tests__/RevenueModel.test.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/__tests__/RevenueModel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { RevenueModel } from './RevenueModel';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RevenueModel } from '../RevenueModel';
 
 describe('RevenueModel', () => {
   const mockRevenueData = {

--- a/packages/@smolitux/resonance/src/components/monetization/__tests__/RewardSystem.test.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/__tests__/RewardSystem.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { RewardSystem } from './RewardSystem';
+import { RewardSystem } from '../RewardSystem';
 
 describe('RewardSystem', () => {
   const mockRewards = [

--- a/packages/@smolitux/resonance/src/components/post/__tests__/PostCreator.test.tsx
+++ b/packages/@smolitux/resonance/src/components/post/__tests__/PostCreator.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { PostCreator } from './PostCreator';
+import { PostCreator } from '../PostCreator';
 
 describe('PostCreator', () => {
   const mockOnSubmit = jest.fn();

--- a/packages/@smolitux/resonance/src/components/post/__tests__/PostInteractions.test.tsx
+++ b/packages/@smolitux/resonance/src/components/post/__tests__/PostInteractions.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { PostInteractions } from './PostInteractions';
+import { PostInteractions } from '../PostInteractions';
 
 describe('PostInteractions', () => {
   const mockPost = {

--- a/packages/@smolitux/resonance/src/components/post/__tests__/PostMetrics.test.tsx
+++ b/packages/@smolitux/resonance/src/components/post/__tests__/PostMetrics.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { PostMetrics } from './PostMetrics';
+import { PostMetrics } from '../PostMetrics';
 
 describe('PostMetrics', () => {
   const mockMetrics = {

--- a/packages/@smolitux/resonance/src/components/post/__tests__/PostView.test.tsx
+++ b/packages/@smolitux/resonance/src/components/post/__tests__/PostView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { PostView } from './PostView';
+import { PostView } from '../PostView';
 
 describe('PostView', () => {
   const mockPost = {

--- a/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileContent.test.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileContent.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ProfileContent } from './ProfileContent';
+import { ProfileContent } from '../ProfileContent';
 
 describe('ProfileContent', () => {
   const mockPosts = [

--- a/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileEditor.test.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileEditor.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { ProfileEditor } from './ProfileEditor';
+import { ProfileEditor } from '../ProfileEditor';
 
 describe('ProfileEditor', () => {
   const mockProfile = {

--- a/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileHeader.test.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileHeader.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ProfileHeader } from './ProfileHeader';
+import { ProfileHeader } from '../ProfileHeader';
 
 describe('ProfileHeader', () => {
   const mockProfile = {

--- a/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileWallet.test.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/__tests__/ProfileWallet.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ProfileWallet } from './ProfileWallet';
+import { ProfileWallet } from '../ProfileWallet';
 
 describe('ProfileWallet', () => {
   const mockWallet = {


### PR DESCRIPTION
## Beschreibung

Dieser Pull Request behebt Lint-Fehler in verschiedenen Paketen der Smolitux UI Bibliothek.

## Änderungen

- **Import-Pfade**: Korrigiere falsche Import-Pfade in Test-Dateien (von `./Komponente` zu `../Komponente`)
- **Ungenutzte Importe**: Entferne ungenutzte `waitFor`-Importe aus Test-Dateien
- **Übersetzung**: Übersetze deutsche Kommentare in @smolitux/charts in Englisch

## Betroffene Pakete

- @smolitux/ai
- @smolitux/charts
- @smolitux/resonance
- @smolitux/blockchain

## Zusammenhang

Dieser PR ist Teil der Lint-Fehler-Behebung, die in der Analyse-Phase identifiziert wurde und ergänzt den vorherigen PR für @smolitux/blockchain-Komponenten.