### PR TITLE
[Test]: Hinzufügen weiterer Tests für Charts- und Media-Komponenten

### DIFF
--- a/packages/@smolitux/charts/src/components/Heatmap/__tests__/Heatmap.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/Heatmap/__tests__/Heatmap.a11y.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Heatmap } from '../Heatmap';
+
+// Extend Jest matchers with accessibility checks
+expect.extend(toHaveNoViolations);
+
+// Mock for useTheme hook
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' })
+}));
+
+describe('Heatmap Accessibility', () => {
+  const mockData = [
+    { x: 'A', y: '1', value: 10 },
+    { x: 'A', y: '2', value: 20 },
+    { x: 'A', y: '3', value: 30 },
+    { x: 'B', y: '1', value: 40 },
+    { x: 'B', y: '2', value: 50 },
+    { x: 'B', y: '3', value: 60 },
+    { x: 'C', y: '1', value: 70 },
+    { x: 'C', y: '2', value: 80 },
+    { x: 'C', y: '3', value: 90 }
+  ];
+
+  test('should not have accessibility violations', async () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        title="Data Heatmap"
+        aria-label="Heatmap showing data values across categories"
+      />
+    );
+    
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have appropriate ARIA attributes', () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        title="Data Heatmap"
+        aria-label="Heatmap showing data values across categories"
+      />
+    );
+    
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'Heatmap showing data values across categories');
+  });
+
+  test('should include descriptive title', () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        title="Data Heatmap"
+      />
+    );
+    
+    const titleElement = container.querySelector('text.chart-title');
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent('Data Heatmap');
+  });
+
+  test('should include axis labels for better understanding', () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        xAxis={{ title: 'Categories' }}
+        yAxis={{ title: 'Metrics' }}
+      />
+    );
+    
+    const xAxisLabel = container.querySelector('.x-axis-label');
+    const yAxisLabel = container.querySelector('.y-axis-label');
+    
+    expect(xAxisLabel).toBeInTheDocument();
+    expect(xAxisLabel).toHaveTextContent('Categories');
+    expect(yAxisLabel).toBeInTheDocument();
+    expect(yAxisLabel).toHaveTextContent('Metrics');
+  });
+
+  test('should provide sufficient color contrast', () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        colorScale={{
+          type: 'sequential',
+          colors: ['#ffffff', '#000000'],
+          min: 0,
+          max: 100
+        }}
+        showValues={true}
+        valueTextColor="#ffffff"
+      />
+    );
+    
+    // Check that value text has good contrast against cell backgrounds
+    const valueTexts = container.querySelectorAll('text.cell-value');
+    expect(valueTexts.length).toBe(mockData.length);
+    
+    // At least one value text should have white color for contrast against dark cells
+    const whiteText = Array.from(valueTexts).find(text => 
+      text.getAttribute('fill') === '#ffffff'
+    );
+    
+    expect(whiteText).toBeInTheDocument();
+  });
+
+  test('should provide alternative text description for screen readers', () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        aria-label="Heatmap showing values from 10 to 90 across a 3x3 grid"
+        title="Data Heatmap"
+      />
+    );
+    
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'Heatmap showing values from 10 to 90 across a 3x3 grid');
+  });
+
+  test('should have accessible legend with sufficient contrast', () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        showLegend={true}
+        legendTextColor="#000000"
+      />
+    );
+    
+    // Check that legend text has good contrast
+    const legendTexts = container.querySelectorAll('.legend-label');
+    
+    // Legend should be present
+    expect(legendTexts.length).toBeGreaterThan(0);
+  });
+
+  test('should have cells with appropriate ARIA attributes', () => {
+    const { container } = render(
+      <Heatmap 
+        data={mockData}
+        showValues={true}
+      />
+    );
+    
+    // Cells should have appropriate ARIA attributes
+    const cells = container.querySelectorAll('rect.heatmap-cell');
+    
+    cells.forEach((cell, index) => {
+      expect(cell).toHaveAttribute('aria-label');
+      
+      // The aria-label should contain the value
+      const value = mockData[index].value;
+      const ariaLabel = cell.getAttribute('aria-label');
+      expect(ariaLabel).toContain(value.toString());
+    });
+  });
+});

--- a/packages/@smolitux/charts/src/components/Heatmap/__tests__/Heatmap.test.tsx
+++ b/packages/@smolitux/charts/src/components/Heatmap/__tests__/Heatmap.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Heatmap } from '../Heatmap';
+
+// Mock for useTheme hook
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' })
+}));
+
+describe('Heatmap', () => {
+  const mockData = [
+    { x: 'A', y: '1', value: 10 },
+    { x: 'A', y: '2', value: 20 },
+    { x: 'A', y: '3', value: 30 },
+    { x: 'B', y: '1', value: 40 },
+    { x: 'B', y: '2', value: 50 },
+    { x: 'B', y: '3', value: 60 },
+    { x: 'C', y: '1', value: 70 },
+    { x: 'C', y: '2', value: 80 },
+    { x: 'C', y: '3', value: 90 }
+  ];
+
+  test('renders chart with default props', () => {
+    render(<Heatmap data={mockData} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    
+    // Cells should be rendered
+    const cells = document.querySelectorAll('rect.heatmap-cell');
+    expect(cells.length).toBe(mockData.length);
+  });
+
+  test('passes height and width properties correctly', () => {
+    render(<Heatmap data={mockData} height={400} width={800} />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('height', '400');
+    expect(svg).toHaveAttribute('width', '800');
+  });
+
+  test('applies custom className', () => {
+    render(<Heatmap data={mockData} className="custom-chart" />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveClass('custom-chart');
+  });
+
+  test('renders with title when provided', () => {
+    render(<Heatmap data={mockData} title="Heat Map Chart" />);
+    
+    expect(screen.getByText('Heat Map Chart')).toBeInTheDocument();
+  });
+
+  test('renders axis labels when provided', () => {
+    render(<Heatmap 
+      data={mockData} 
+      xAxis={{ title: 'X Axis' }}
+      yAxis={{ title: 'Y Axis' }}
+    />);
+    
+    expect(screen.getByText('X Axis')).toBeInTheDocument();
+    expect(screen.getByText('Y Axis')).toBeInTheDocument();
+  });
+
+  test('renders with custom color scale', () => {
+    const colorScale = {
+      type: 'sequential' as const,
+      colors: ['#ffffff', '#ff0000'],
+      min: 0,
+      max: 100
+    };
+    
+    render(<Heatmap data={mockData} colorScale={colorScale} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    
+    // Cells should be rendered with different colors
+    const cells = document.querySelectorAll('rect.heatmap-cell');
+    expect(cells.length).toBe(mockData.length);
+    
+    // Check that cells have different fill colors
+    const fillColors = new Set();
+    cells.forEach(cell => {
+      fillColors.add(cell.getAttribute('fill'));
+    });
+    
+    // Should have more than one color
+    expect(fillColors.size).toBeGreaterThan(1);
+  });
+
+  test('renders with custom cell size', () => {
+    render(<Heatmap data={mockData} cellSize={50} />);
+    
+    // Cells should be rendered with the specified size
+    const cells = document.querySelectorAll('rect.heatmap-cell');
+    const firstCell = cells[0];
+    
+    expect(firstCell).toHaveAttribute('width', '50');
+    expect(firstCell).toHaveAttribute('height', '50');
+  });
+
+  test('renders with cell borders when showBorders is true', () => {
+    render(<Heatmap data={mockData} showBorders={true} />);
+    
+    // Cells should have stroke attribute
+    const cells = document.querySelectorAll('rect.heatmap-cell');
+    const firstCell = cells[0];
+    
+    expect(firstCell).toHaveAttribute('stroke');
+  });
+
+  test('renders with cell labels when showValues is true', () => {
+    render(<Heatmap data={mockData} showValues={true} />);
+    
+    // Value labels should be rendered
+    const valueLabels = document.querySelectorAll('text.cell-value');
+    expect(valueLabels.length).toBe(mockData.length);
+    
+    // Check that the first value label has the correct text
+    expect(valueLabels[0]).toHaveTextContent('10');
+  });
+
+  test('renders with custom value formatter', () => {
+    render(
+      <Heatmap 
+        data={mockData} 
+        showValues={true} 
+        formatValue={(value) => `${value}%`}
+      />
+    );
+    
+    // Value labels should be rendered with the custom format
+    const valueLabels = document.querySelectorAll('text.cell-value');
+    expect(valueLabels[0]).toHaveTextContent('10%');
+  });
+
+  test('renders with legend when showLegend is true', () => {
+    render(<Heatmap data={mockData} showLegend={true} />);
+    
+    // Legend should be rendered
+    const legend = document.querySelector('.heatmap-legend');
+    expect(legend).toBeInTheDocument();
+  });
+
+  test('renders with custom legend position', () => {
+    render(<Heatmap data={mockData} showLegend={true} legendPosition="right" />);
+    
+    // Legend should be rendered
+    const legend = document.querySelector('.heatmap-legend');
+    expect(legend).toBeInTheDocument();
+  });
+
+  test('renders with tooltip when showTooltip is true', () => {
+    render(<Heatmap data={mockData} showTooltip={true} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  test('renders with animation when animated is true', () => {
+    render(<Heatmap data={mockData} animated={true} />);
+    
+    // Cells should have animation class
+    const cells = document.querySelectorAll('rect.heatmap-cell');
+    const animatedCells = Array.from(cells).filter(cell => 
+      cell.classList.contains('animate-fade-in')
+    );
+    
+    expect(animatedCells.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/@smolitux/charts/src/components/RadarChart/__tests__/RadarChart.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/RadarChart/__tests__/RadarChart.a11y.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { RadarChart } from '../RadarChart';
+
+// Extend Jest matchers with accessibility checks
+expect.extend(toHaveNoViolations);
+
+// Mock for useTheme hook
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' })
+}));
+
+describe('RadarChart Accessibility', () => {
+  const mockData = {
+    id: 'skills',
+    name: 'Skills Assessment',
+    data: [
+      { axis: 'JavaScript', value: 80 },
+      { axis: 'React', value: 90 },
+      { axis: 'CSS', value: 70 },
+      { axis: 'HTML', value: 95 },
+      { axis: 'Node.js', value: 75 },
+      { axis: 'TypeScript', value: 85 }
+    ]
+  };
+
+  test('should not have accessibility violations', async () => {
+    const { container } = render(
+      <RadarChart 
+        data={mockData}
+        title="Skills Radar Chart"
+        aria-label="Radar chart showing skills assessment across 6 technologies"
+      />
+    );
+    
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have appropriate ARIA attributes', () => {
+    const { container } = render(
+      <RadarChart 
+        data={mockData}
+        title="Skills Radar Chart"
+        aria-label="Radar chart showing skills assessment across 6 technologies"
+      />
+    );
+    
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'Radar chart showing skills assessment across 6 technologies');
+  });
+
+  test('should include descriptive title', () => {
+    const { container } = render(
+      <RadarChart 
+        data={mockData}
+        title="Skills Radar Chart"
+      />
+    );
+    
+    const titleElement = container.querySelector('text.chart-title');
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent('Skills Radar Chart');
+  });
+
+  test('should provide sufficient color contrast', () => {
+    const { container } = render(
+      <RadarChart 
+        data={mockData}
+        colors={['#000080']} // Dark blue
+        axisLabelColor="#000000" // Black text
+      />
+    );
+    
+    // Check that axis labels have good contrast
+    const axisLabels = container.querySelectorAll('text.axis-label');
+    expect(axisLabels.length).toBe(mockData.data.length);
+    
+    // Axis labels should have black color for contrast
+    const blackLabel = Array.from(axisLabels).find(label => 
+      label.getAttribute('fill') === '#000000'
+    );
+    
+    expect(blackLabel).toBeInTheDocument();
+  });
+
+  test('should provide alternative text description for screen readers', () => {
+    const { container } = render(
+      <RadarChart 
+        data={mockData}
+        aria-label="Radar chart showing JavaScript: 80%, React: 90%, CSS: 70%, HTML: 95%, Node.js: 75%, TypeScript: 85%"
+        title="Skills Radar Chart"
+      />
+    );
+    
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'Radar chart showing JavaScript: 80%, React: 90%, CSS: 70%, HTML: 95%, Node.js: 75%, TypeScript: 85%');
+  });
+
+  test('should have accessible legend with sufficient contrast', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'teamAverage',
+        name: 'Team Average',
+        data: [
+          { axis: 'JavaScript', value: 75 },
+          { axis: 'React', value: 80 },
+          { axis: 'CSS', value: 65 },
+          { axis: 'HTML', value: 90 },
+          { axis: 'Node.js', value: 70 },
+          { axis: 'TypeScript', value: 75 }
+        ]
+      }
+    ];
+    
+    const { container } = render(
+      <RadarChart 
+        data={multiSeriesData}
+        showLegend={true}
+        legendTextColor="#000000"
+      />
+    );
+    
+    // Check that legend text has good contrast
+    const legendTexts = container.querySelectorAll('text.legend-label');
+    expect(legendTexts.length).toBe(multiSeriesData.length);
+    
+    // Legend text should have black color for contrast
+    const blackText = Array.from(legendTexts).find(text => 
+      text.getAttribute('fill') === '#000000'
+    );
+    
+    expect(blackText).toBeInTheDocument();
+  });
+
+  test('should have accessible level indicators', () => {
+    const { container } = render(
+      <RadarChart 
+        data={mockData}
+        levels={5}
+        levelLabelColor="#000000"
+      />
+    );
+    
+    // Level circles should be rendered
+    const levelCircles = container.querySelectorAll('circle.level-circle');
+    expect(levelCircles.length).toBe(5);
+    
+    // Level labels should have good contrast
+    const levelLabels = container.querySelectorAll('text.level-label');
+    expect(levelLabels.length).toBeGreaterThan(0);
+    
+    // Level labels should have black color for contrast
+    const blackLabel = Array.from(levelLabels).find(label => 
+      label.getAttribute('fill') === '#000000'
+    );
+    
+    expect(blackLabel).toBeInTheDocument();
+  });
+
+  test('should have accessible value labels when shown', () => {
+    const { container } = render(
+      <RadarChart 
+        data={mockData}
+        showValues={true}
+        valueTextColor="#000000"
+      />
+    );
+    
+    // Value labels should be rendered
+    const valueLabels = container.querySelectorAll('text.value-label');
+    expect(valueLabels.length).toBe(mockData.data.length);
+    
+    // Value labels should have black color for contrast
+    const blackLabel = Array.from(valueLabels).find(label => 
+      label.getAttribute('fill') === '#000000'
+    );
+    
+    expect(blackLabel).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/charts/src/components/RadarChart/__tests__/RadarChart.test.tsx
+++ b/packages/@smolitux/charts/src/components/RadarChart/__tests__/RadarChart.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RadarChart } from '../RadarChart';
+
+// Mock for useTheme hook
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' })
+}));
+
+describe('RadarChart', () => {
+  const mockData = {
+    id: 'skills',
+    name: 'Skills Assessment',
+    data: [
+      { axis: 'JavaScript', value: 80 },
+      { axis: 'React', value: 90 },
+      { axis: 'CSS', value: 70 },
+      { axis: 'HTML', value: 95 },
+      { axis: 'Node.js', value: 75 },
+      { axis: 'TypeScript', value: 85 }
+    ]
+  };
+
+  test('renders chart with default props', () => {
+    render(<RadarChart data={mockData} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    
+    // Axis labels should be rendered
+    expect(screen.getByText('JavaScript')).toBeInTheDocument();
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('CSS')).toBeInTheDocument();
+    expect(screen.getByText('HTML')).toBeInTheDocument();
+    expect(screen.getByText('Node.js')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+  });
+
+  test('passes height and width properties correctly', () => {
+    render(<RadarChart data={mockData} height={400} width={800} />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('height', '400');
+    expect(svg).toHaveAttribute('width', '800');
+  });
+
+  test('applies custom className', () => {
+    render(<RadarChart data={mockData} className="custom-chart" />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveClass('custom-chart');
+  });
+
+  test('renders with title when provided', () => {
+    render(<RadarChart data={mockData} title="Skills Radar Chart" />);
+    
+    expect(screen.getByText('Skills Radar Chart')).toBeInTheDocument();
+  });
+
+  test('handles array of data series', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'teamAverage',
+        name: 'Team Average',
+        data: [
+          { axis: 'JavaScript', value: 75 },
+          { axis: 'React', value: 80 },
+          { axis: 'CSS', value: 65 },
+          { axis: 'HTML', value: 90 },
+          { axis: 'Node.js', value: 70 },
+          { axis: 'TypeScript', value: 75 }
+        ]
+      }
+    ];
+    
+    render(<RadarChart data={multiSeriesData} />);
+    
+    // Both series names should be in the legend
+    expect(screen.getByText('Skills Assessment')).toBeInTheDocument();
+    expect(screen.getByText('Team Average')).toBeInTheDocument();
+  });
+
+  test('renders with custom colors', () => {
+    const customColors = ['#FF0000', '#00FF00', '#0000FF'];
+    render(<RadarChart data={mockData} colors={customColors} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    
+    // Radar area should have the first custom color
+    const radarArea = document.querySelector('path.radar-area');
+    expect(radarArea).toHaveAttribute('fill', '#FF0000');
+  });
+
+  test('renders with custom levels', () => {
+    render(<RadarChart data={mockData} levels={5} />);
+    
+    // Level circles should be rendered
+    const levelCircles = document.querySelectorAll('circle.level-circle');
+    expect(levelCircles.length).toBe(5);
+  });
+
+  test('renders with custom opacity', () => {
+    render(<RadarChart data={mockData} areaOpacity={0.5} />);
+    
+    // Radar area should have the specified opacity
+    const radarArea = document.querySelector('path.radar-area');
+    expect(radarArea).toHaveAttribute('fill-opacity', '0.5');
+  });
+
+  test('renders with animation when animated is true', () => {
+    render(<RadarChart data={mockData} animated={true} />);
+    
+    // Radar area should have animation class
+    const radarArea = document.querySelector('path.radar-area');
+    expect(radarArea).toHaveClass('animate-radar');
+  });
+
+  test('renders without animation when animated is false', () => {
+    render(<RadarChart data={mockData} animated={false} />);
+    
+    // Radar area should not have animation class
+    const radarArea = document.querySelector('path.radar-area');
+    expect(radarArea).not.toHaveClass('animate-radar');
+  });
+
+  test('renders with custom max value', () => {
+    render(<RadarChart data={mockData} maxValue={100} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  test('renders with custom axis labels', () => {
+    render(
+      <RadarChart 
+        data={mockData} 
+        axisLabels={{
+          JavaScript: 'JS',
+          React: 'React.js',
+          CSS: 'CSS3',
+          HTML: 'HTML5',
+          'Node.js': 'Node',
+          TypeScript: 'TS'
+        }}
+      />
+    );
+    
+    // Custom axis labels should be rendered
+    expect(screen.getByText('JS')).toBeInTheDocument();
+    expect(screen.getByText('React.js')).toBeInTheDocument();
+    expect(screen.getByText('CSS3')).toBeInTheDocument();
+    expect(screen.getByText('HTML5')).toBeInTheDocument();
+    expect(screen.getByText('Node')).toBeInTheDocument();
+    expect(screen.getByText('TS')).toBeInTheDocument();
+  });
+
+  test('renders with custom value formatter', () => {
+    render(
+      <RadarChart 
+        data={mockData} 
+        showValues={true}
+        formatValue={(value) => `${value}%`}
+      />
+    );
+    
+    // Value labels should be rendered with the custom format
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(screen.getByText('90%')).toBeInTheDocument();
+    expect(screen.getByText('70%')).toBeInTheDocument();
+    expect(screen.getByText('95%')).toBeInTheDocument();
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText('85%')).toBeInTheDocument();
+  });
+
+  test('renders with legend when showLegend is true', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'teamAverage',
+        name: 'Team Average',
+        data: [
+          { axis: 'JavaScript', value: 75 },
+          { axis: 'React', value: 80 },
+          { axis: 'CSS', value: 65 },
+          { axis: 'HTML', value: 90 },
+          { axis: 'Node.js', value: 70 },
+          { axis: 'TypeScript', value: 75 }
+        ]
+      }
+    ];
+    
+    render(<RadarChart data={multiSeriesData} showLegend={true} />);
+    
+    // Legend should be rendered
+    expect(screen.getByText('Skills Assessment')).toBeInTheDocument();
+    expect(screen.getByText('Team Average')).toBeInTheDocument();
+  });
+
+  test('renders without legend when showLegend is false', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'teamAverage',
+        name: 'Team Average',
+        data: [
+          { axis: 'JavaScript', value: 75 },
+          { axis: 'React', value: 80 },
+          { axis: 'CSS', value: 65 },
+          { axis: 'HTML', value: 90 },
+          { axis: 'Node.js', value: 70 },
+          { axis: 'TypeScript', value: 75 }
+        ]
+      }
+    ];
+    
+    render(<RadarChart data={multiSeriesData} showLegend={false} />);
+    
+    // Legend should not be rendered
+    expect(screen.queryByText('Skills Assessment')).not.toBeInTheDocument();
+    expect(screen.queryByText('Team Average')).not.toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/charts/src/components/ScatterPlot/__tests__/ScatterPlot.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/ScatterPlot/__tests__/ScatterPlot.a11y.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { ScatterPlot } from '../ScatterPlot';
+
+// Extend Jest matchers with accessibility checks
+expect.extend(toHaveNoViolations);
+
+// Mock for useTheme hook
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' })
+}));
+
+describe('ScatterPlot Accessibility', () => {
+  const mockData = {
+    id: 'dataset1',
+    name: 'Dataset 1',
+    data: [
+      { x: 10, y: 20, size: 5 },
+      { x: 15, y: 30, size: 8 },
+      { x: 20, y: 15, size: 6 },
+      { x: 25, y: 40, size: 10 },
+      { x: 30, y: 25, size: 7 },
+      { x: 35, y: 35, size: 9 }
+    ]
+  };
+
+  test('should not have accessibility violations', async () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        title="Data Scatter Plot"
+        aria-label="Scatter plot showing data points across x and y axes"
+      />
+    );
+    
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have appropriate ARIA attributes', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        title="Data Scatter Plot"
+        aria-label="Scatter plot showing data points across x and y axes"
+      />
+    );
+    
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'Scatter plot showing data points across x and y axes');
+  });
+
+  test('should include descriptive title', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        title="Data Scatter Plot"
+      />
+    );
+    
+    const titleElement = container.querySelector('text.chart-title');
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toHaveTextContent('Data Scatter Plot');
+  });
+
+  test('should include axis labels for better understanding', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        axisLabels={{ x: 'X Values', y: 'Y Values' }}
+      />
+    );
+    
+    const xAxisLabel = container.querySelector('.x-axis-label');
+    const yAxisLabel = container.querySelector('.y-axis-label');
+    
+    expect(xAxisLabel).toBeInTheDocument();
+    expect(xAxisLabel).toHaveTextContent('X Values');
+    expect(yAxisLabel).toBeInTheDocument();
+    expect(yAxisLabel).toHaveTextContent('Y Values');
+  });
+
+  test('should provide sufficient color contrast', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        colors={['#000080']} // Dark blue
+        axisLabelColor="#000000" // Black text
+      />
+    );
+    
+    // Check that axis labels have good contrast
+    const axisLabels = container.querySelectorAll('text.axis-label');
+    expect(axisLabels.length).toBeGreaterThan(0);
+    
+    // Axis labels should have black color for contrast
+    const blackLabel = Array.from(axisLabels).find(label => 
+      label.getAttribute('fill') === '#000000'
+    );
+    
+    expect(blackLabel).toBeInTheDocument();
+  });
+
+  test('should provide alternative text description for screen readers', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        aria-label="Scatter plot showing 6 data points with varying x and y values"
+        title="Data Scatter Plot"
+      />
+    );
+    
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'Scatter plot showing 6 data points with varying x and y values');
+  });
+
+  test('should have accessible legend with sufficient contrast', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'dataset2',
+        name: 'Dataset 2',
+        data: [
+          { x: 12, y: 22, size: 5 },
+          { x: 17, y: 32, size: 8 },
+          { x: 22, y: 17, size: 6 },
+          { x: 27, y: 42, size: 10 },
+          { x: 32, y: 27, size: 7 },
+          { x: 37, y: 37, size: 9 }
+        ]
+      }
+    ];
+    
+    const { container } = render(
+      <ScatterPlot 
+        data={multiSeriesData}
+        showLegend={true}
+        legendTextColor="#000000"
+      />
+    );
+    
+    // Check that legend text has good contrast
+    const legendTexts = container.querySelectorAll('text.legend-label');
+    expect(legendTexts.length).toBe(multiSeriesData.length);
+    
+    // Legend text should have black color for contrast
+    const blackText = Array.from(legendTexts).find(text => 
+      text.getAttribute('fill') === '#000000'
+    );
+    
+    expect(blackText).toBeInTheDocument();
+  });
+
+  test('should have accessible data points with appropriate ARIA attributes', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+      />
+    );
+    
+    // Data points should have appropriate ARIA attributes
+    const dataPoints = container.querySelectorAll('circle.data-point');
+    expect(dataPoints.length).toBe(mockData.data.length);
+    
+    dataPoints.forEach((point, index) => {
+      expect(point).toHaveAttribute('aria-label');
+      
+      // The aria-label should contain the x and y values
+      const { x, y } = mockData.data[index];
+      const ariaLabel = point.getAttribute('aria-label');
+      expect(ariaLabel).toContain(x.toString());
+      expect(ariaLabel).toContain(y.toString());
+    });
+  });
+
+  test('should have accessible grid lines when shown', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        showGrid={true}
+        gridColor="#cccccc" // Light gray for subtle grid
+      />
+    );
+    
+    // Grid lines should be rendered
+    const gridLines = container.querySelectorAll('line.grid-line');
+    expect(gridLines.length).toBeGreaterThan(0);
+    
+    // Grid lines should have appropriate color for subtle presentation
+    const grayLine = Array.from(gridLines).find(line => 
+      line.getAttribute('stroke') === '#cccccc'
+    );
+    
+    expect(grayLine).toBeInTheDocument();
+  });
+
+  test('should have accessible trend line when shown', () => {
+    const { container } = render(
+      <ScatterPlot 
+        data={mockData}
+        showTrendLine={true}
+        trendLineColor="#000000" // Black for good contrast
+      />
+    );
+    
+    // Trend line should be rendered
+    const trendLine = container.querySelector('line.trend-line');
+    expect(trendLine).toBeInTheDocument();
+    
+    // Trend line should have good contrast
+    expect(trendLine).toHaveAttribute('stroke', '#000000');
+  });
+});

--- a/packages/@smolitux/charts/src/components/ScatterPlot/__tests__/ScatterPlot.test.tsx
+++ b/packages/@smolitux/charts/src/components/ScatterPlot/__tests__/ScatterPlot.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ScatterPlot } from '../ScatterPlot';
+
+// Mock for useTheme hook
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' })
+}));
+
+describe('ScatterPlot', () => {
+  const mockData = {
+    id: 'dataset1',
+    name: 'Dataset 1',
+    data: [
+      { x: 10, y: 20, size: 5 },
+      { x: 15, y: 30, size: 8 },
+      { x: 20, y: 15, size: 6 },
+      { x: 25, y: 40, size: 10 },
+      { x: 30, y: 25, size: 7 },
+      { x: 35, y: 35, size: 9 }
+    ]
+  };
+
+  test('renders chart with default props', () => {
+    render(<ScatterPlot data={mockData} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    
+    // Points should be rendered
+    const points = document.querySelectorAll('circle.data-point');
+    expect(points.length).toBe(mockData.data.length);
+  });
+
+  test('passes height and width properties correctly', () => {
+    render(<ScatterPlot data={mockData} height={400} width={800} />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('height', '400');
+    expect(svg).toHaveAttribute('width', '800');
+  });
+
+  test('applies custom className', () => {
+    render(<ScatterPlot data={mockData} className="custom-chart" />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveClass('custom-chart');
+  });
+
+  test('renders with title when provided', () => {
+    render(<ScatterPlot data={mockData} title="Scatter Plot Chart" />);
+    
+    expect(screen.getByText('Scatter Plot Chart')).toBeInTheDocument();
+  });
+
+  test('renders axis labels when provided', () => {
+    render(<ScatterPlot 
+      data={mockData} 
+      axisLabels={{ x: 'X Axis', y: 'Y Axis' }}
+    />);
+    
+    expect(screen.getByText('X Axis')).toBeInTheDocument();
+    expect(screen.getByText('Y Axis')).toBeInTheDocument();
+  });
+
+  test('handles array of data series', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'dataset2',
+        name: 'Dataset 2',
+        data: [
+          { x: 12, y: 22, size: 5 },
+          { x: 17, y: 32, size: 8 },
+          { x: 22, y: 17, size: 6 },
+          { x: 27, y: 42, size: 10 },
+          { x: 32, y: 27, size: 7 },
+          { x: 37, y: 37, size: 9 }
+        ]
+      }
+    ];
+    
+    render(<ScatterPlot data={multiSeriesData} />);
+    
+    // Both series names should be in the legend
+    expect(screen.getByText('Dataset 1')).toBeInTheDocument();
+    expect(screen.getByText('Dataset 2')).toBeInTheDocument();
+    
+    // Points from both series should be rendered
+    const points = document.querySelectorAll('circle.data-point');
+    expect(points.length).toBe(mockData.data.length * 2);
+  });
+
+  test('renders with custom colors', () => {
+    const customColors = ['#FF0000', '#00FF00', '#0000FF'];
+    render(<ScatterPlot data={mockData} colors={customColors} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    
+    // Points should have the first custom color
+    const points = document.querySelectorAll('circle.data-point');
+    const redPoint = Array.from(points).find(point => 
+      point.getAttribute('fill') === '#FF0000'
+    );
+    
+    expect(redPoint).toBeInTheDocument();
+  });
+
+  test('renders with custom point size', () => {
+    render(<ScatterPlot data={mockData} pointSize={10} />);
+    
+    // Points should have the specified size
+    const points = document.querySelectorAll('circle.data-point');
+    const firstPoint = points[0];
+    
+    expect(firstPoint).toHaveAttribute('r', '10');
+  });
+
+  test('renders with variable point sizes when sizeScale is provided', () => {
+    render(<ScatterPlot 
+      data={mockData} 
+      sizeScale={{ min: 5, max: 20 }}
+    />);
+    
+    // Points should have different sizes
+    const points = document.querySelectorAll('circle.data-point');
+    const radii = Array.from(points).map(point => 
+      parseFloat(point.getAttribute('r') || '0')
+    );
+    
+    // Check that there are different sizes
+    const uniqueRadii = new Set(radii);
+    expect(uniqueRadii.size).toBeGreaterThan(1);
+  });
+
+  test('renders with grid when showGrid is true', () => {
+    render(<ScatterPlot data={mockData} showGrid={true} />);
+    
+    // Grid lines should be rendered
+    const gridLines = document.querySelectorAll('line.grid-line');
+    expect(gridLines.length).toBeGreaterThan(0);
+  });
+
+  test('renders with animation when animated is true', () => {
+    render(<ScatterPlot data={mockData} animated={true} />);
+    
+    // Points should have animation class
+    const points = document.querySelectorAll('circle.data-point');
+    const animatedPoints = Array.from(points).filter(point => 
+      point.classList.contains('animate-fade-in')
+    );
+    
+    expect(animatedPoints.length).toBeGreaterThan(0);
+  });
+
+  test('renders without animation when animated is false', () => {
+    render(<ScatterPlot data={mockData} animated={false} />);
+    
+    // Points should not have animation class
+    const points = document.querySelectorAll('circle.data-point');
+    const animatedPoints = Array.from(points).filter(point => 
+      point.classList.contains('animate-fade-in')
+    );
+    
+    expect(animatedPoints.length).toBe(0);
+  });
+
+  test('renders with custom axis scales', () => {
+    render(<ScatterPlot 
+      data={mockData} 
+      xScale={{ min: 0, max: 50 }}
+      yScale={{ min: 0, max: 50 }}
+    />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  test('renders with trend line when showTrendLine is true', () => {
+    render(<ScatterPlot data={mockData} showTrendLine={true} />);
+    
+    // Trend line should be rendered
+    const trendLine = document.querySelector('line.trend-line');
+    expect(trendLine).toBeInTheDocument();
+  });
+
+  test('renders with legend when showLegend is true', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'dataset2',
+        name: 'Dataset 2',
+        data: [
+          { x: 12, y: 22, size: 5 },
+          { x: 17, y: 32, size: 8 },
+          { x: 22, y: 17, size: 6 },
+          { x: 27, y: 42, size: 10 },
+          { x: 32, y: 27, size: 7 },
+          { x: 37, y: 37, size: 9 }
+        ]
+      }
+    ];
+    
+    render(<ScatterPlot data={multiSeriesData} showLegend={true} />);
+    
+    // Legend should be rendered
+    expect(screen.getByText('Dataset 1')).toBeInTheDocument();
+    expect(screen.getByText('Dataset 2')).toBeInTheDocument();
+  });
+
+  test('renders without legend when showLegend is false', () => {
+    const multiSeriesData = [
+      mockData,
+      {
+        id: 'dataset2',
+        name: 'Dataset 2',
+        data: [
+          { x: 12, y: 22, size: 5 },
+          { x: 17, y: 32, size: 8 },
+          { x: 22, y: 17, size: 6 },
+          { x: 27, y: 42, size: 10 },
+          { x: 32, y: 27, size: 7 },
+          { x: 37, y: 37, size: 9 }
+        ]
+      }
+    ];
+    
+    render(<ScatterPlot data={multiSeriesData} showLegend={false} />);
+    
+    // Legend should not be rendered
+    expect(screen.queryByText('Dataset 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Dataset 2')).not.toBeInTheDocument();
+  });
+
+  test('renders with tooltip when showTooltip is true', () => {
+    render(<ScatterPlot data={mockData} showTooltip={true} />);
+    
+    // SVG should be rendered
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/media/src/components/MediaCarousel/__tests__/MediaCarousel.a11y.test.tsx
+++ b/packages/@smolitux/media/src/components/MediaCarousel/__tests__/MediaCarousel.a11y.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { MediaCarousel } from '../MediaCarousel';
+
+// Extend Jest matchers with accessibility checks
+expect.extend(toHaveNoViolations);
+
+// Mock the Button component from @smolitux/core
+jest.mock('@smolitux/core', () => ({
+  Button: ({ children, onClick, ...props }: { children: React.ReactNode, onClick?: () => void }) => (
+    <button onClick={onClick} {...props}>{children}</button>
+  ),
+  Icon: ({ name, ...props }: { name: string }) => (
+    <span data-icon={name} {...props}>{name}</span>
+  )
+}));
+
+describe('MediaCarousel Accessibility', () => {
+  const mockItems = [
+    {
+      id: '1',
+      type: 'image',
+      src: 'https://example.com/image1.jpg',
+      alt: 'Image 1',
+      title: 'First Image'
+    },
+    {
+      id: '2',
+      type: 'image',
+      src: 'https://example.com/image2.jpg',
+      alt: 'Image 2',
+      title: 'Second Image'
+    },
+    {
+      id: '3',
+      type: 'video',
+      src: 'https://example.com/video.mp4',
+      poster: 'https://example.com/poster.jpg',
+      title: 'Sample Video'
+    }
+  ];
+
+  test('should not have accessibility violations', async () => {
+    const { container } = render(
+      <MediaCarousel 
+        items={mockItems}
+        aria-label="Media carousel with images and videos"
+      />
+    );
+    
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have appropriate ARIA attributes', () => {
+    const { container } = render(
+      <MediaCarousel 
+        items={mockItems}
+        aria-label="Media carousel with images and videos"
+      />
+    );
+    
+    const carousel = container.querySelector('[data-testid="media-carousel"]');
+    expect(carousel).toHaveAttribute('aria-label', 'Media carousel with images and videos');
+    expect(carousel).toHaveAttribute('role', 'region');
+  });
+
+  test('should have accessible navigation buttons', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} />
+    );
+    
+    const prevButton = container.querySelector('button[aria-label="Previous slide"]');
+    const nextButton = container.querySelector('button[aria-label="Next slide"]');
+    
+    expect(prevButton).toBeInTheDocument();
+    expect(nextButton).toBeInTheDocument();
+    
+    expect(prevButton).toHaveAttribute('aria-controls', 'media-carousel-items');
+    expect(nextButton).toHaveAttribute('aria-controls', 'media-carousel-items');
+  });
+
+  test('should have accessible indicators', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} showIndicators={true} />
+    );
+    
+    const indicators = container.querySelectorAll('[role="button"][aria-label^="Go to slide"]');
+    expect(indicators.length).toBe(mockItems.length);
+    
+    // First indicator should be marked as current
+    expect(indicators[0]).toHaveAttribute('aria-current', 'true');
+    
+    // Other indicators should not be marked as current
+    for (let i = 1; i < indicators.length; i++) {
+      expect(indicators[i]).not.toHaveAttribute('aria-current', 'true');
+    }
+  });
+
+  test('should have accessible images with alt text', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} />
+    );
+    
+    const image = container.querySelector('img');
+    expect(image).toHaveAttribute('alt', 'Image 1');
+  });
+
+  test('should have accessible video elements', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} initialIndex={2} />
+    );
+    
+    const video = container.querySelector('video');
+    expect(video).toHaveAttribute('title', 'Sample Video');
+    expect(video).toHaveAttribute('controls');
+  });
+
+  test('should have accessible captions when shown', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} showCaptions={true} />
+    );
+    
+    const caption = container.querySelector('.media-caption');
+    expect(caption).toBeInTheDocument();
+    expect(caption).toHaveTextContent('First Image');
+    expect(caption).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('should announce slide changes to screen readers', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} />
+    );
+    
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+  });
+
+  test('should have keyboard navigation support', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} />
+    );
+    
+    const prevButton = container.querySelector('button[aria-label="Previous slide"]');
+    const nextButton = container.querySelector('button[aria-label="Next slide"]');
+    
+    expect(prevButton).toHaveAttribute('tabIndex', '0');
+    expect(nextButton).toHaveAttribute('tabIndex', '0');
+  });
+
+  test('should have focus management for indicators', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} showIndicators={true} />
+    );
+    
+    const indicators = container.querySelectorAll('[role="button"][aria-label^="Go to slide"]');
+    
+    // All indicators should be focusable
+    indicators.forEach(indicator => {
+      expect(indicator).toHaveAttribute('tabIndex', '0');
+    });
+  });
+
+  test('should pause autoplay when focused for better accessibility', () => {
+    const { container } = render(
+      <MediaCarousel items={mockItems} autoPlay={true} pauseOnFocus={true} />
+    );
+    
+    const carousel = container.querySelector('[data-testid="media-carousel"]');
+    expect(carousel).toHaveAttribute('data-pause-on-focus', 'true');
+  });
+});

--- a/packages/@smolitux/media/src/components/MediaCarousel/__tests__/MediaCarousel.test.tsx
+++ b/packages/@smolitux/media/src/components/MediaCarousel/__tests__/MediaCarousel.test.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MediaCarousel } from '../MediaCarousel';
+
+// Mock the Button component from @smolitux/core
+jest.mock('@smolitux/core', () => ({
+  Button: ({ children, onClick, ...props }: { children: React.ReactNode, onClick?: () => void }) => (
+    <button onClick={onClick} {...props}>{children}</button>
+  ),
+  Icon: ({ name, ...props }: { name: string }) => (
+    <span data-icon={name} {...props}>{name}</span>
+  )
+}));
+
+describe('MediaCarousel', () => {
+  const mockItems = [
+    {
+      id: '1',
+      type: 'image',
+      src: 'https://example.com/image1.jpg',
+      alt: 'Image 1',
+      title: 'First Image'
+    },
+    {
+      id: '2',
+      type: 'image',
+      src: 'https://example.com/image2.jpg',
+      alt: 'Image 2',
+      title: 'Second Image'
+    },
+    {
+      id: '3',
+      type: 'video',
+      src: 'https://example.com/video.mp4',
+      poster: 'https://example.com/poster.jpg',
+      title: 'Sample Video'
+    }
+  ];
+
+  test('renders carousel with default props', () => {
+    render(<MediaCarousel items={mockItems} />);
+    
+    // Current item should be rendered
+    const currentItem = screen.getByAltText('Image 1');
+    expect(currentItem).toBeInTheDocument();
+    expect(currentItem).toHaveAttribute('src', 'https://example.com/image1.jpg');
+    
+    // Navigation buttons should be rendered
+    expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    render(<MediaCarousel items={mockItems} className="custom-carousel" />);
+    const carousel = screen.getByTestId('media-carousel');
+    expect(carousel).toHaveClass('custom-carousel');
+  });
+
+  test('navigates to next item when next button is clicked', () => {
+    render(<MediaCarousel items={mockItems} />);
+    
+    // Initially, the first item should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    
+    // Click the next button
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextButton);
+    
+    // Now the second item should be displayed
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+  });
+
+  test('navigates to previous item when previous button is clicked', () => {
+    render(<MediaCarousel items={mockItems} initialIndex={1} />);
+    
+    // Initially, the second item should be displayed
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+    
+    // Click the previous button
+    const prevButton = screen.getByRole('button', { name: /previous/i });
+    fireEvent.click(prevButton);
+    
+    // Now the first item should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+  });
+
+  test('wraps around to the first item when at the end', () => {
+    render(<MediaCarousel items={mockItems} initialIndex={2} />);
+    
+    // Initially, the third item should be displayed
+    expect(screen.getByText('Sample Video')).toBeInTheDocument();
+    
+    // Click the next button
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextButton);
+    
+    // Now the first item should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+  });
+
+  test('wraps around to the last item when at the beginning', () => {
+    render(<MediaCarousel items={mockItems} />);
+    
+    // Initially, the first item should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    
+    // Click the previous button
+    const prevButton = screen.getByRole('button', { name: /previous/i });
+    fireEvent.click(prevButton);
+    
+    // Now the last item should be displayed
+    expect(screen.getByText('Sample Video')).toBeInTheDocument();
+  });
+
+  test('displays indicators when showIndicators is true', () => {
+    render(<MediaCarousel items={mockItems} showIndicators={true} />);
+    
+    // Indicators should be rendered
+    const indicators = screen.getAllByRole('button', { name: /go to slide/i });
+    expect(indicators.length).toBe(mockItems.length);
+  });
+
+  test('navigates to specific item when indicator is clicked', () => {
+    render(<MediaCarousel items={mockItems} showIndicators={true} />);
+    
+    // Initially, the first item should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    
+    // Click the third indicator
+    const indicators = screen.getAllByRole('button', { name: /go to slide/i });
+    fireEvent.click(indicators[2]);
+    
+    // Now the third item should be displayed
+    expect(screen.getByText('Sample Video')).toBeInTheDocument();
+  });
+
+  test('displays captions when showCaptions is true', () => {
+    render(<MediaCarousel items={mockItems} showCaptions={true} />);
+    
+    // Caption should be rendered
+    expect(screen.getByText('First Image')).toBeInTheDocument();
+  });
+
+  test('auto-advances when autoPlay is true', () => {
+    jest.useFakeTimers();
+    
+    render(<MediaCarousel items={mockItems} autoPlay={true} interval={1000} />);
+    
+    // Initially, the first item should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    
+    // Advance time by 1000ms
+    jest.advanceTimersByTime(1000);
+    
+    // Now the second item should be displayed
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+    
+    jest.useRealTimers();
+  });
+
+  test('pauses auto-advance when pauseOnHover is true and mouse enters', () => {
+    jest.useFakeTimers();
+    
+    render(<MediaCarousel items={mockItems} autoPlay={true} interval={1000} pauseOnHover={true} />);
+    
+    // Initially, the first item should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    
+    // Mouse enter the carousel
+    const carousel = screen.getByTestId('media-carousel');
+    fireEvent.mouseEnter(carousel);
+    
+    // Advance time by 1000ms
+    jest.advanceTimersByTime(1000);
+    
+    // The first item should still be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    
+    // Mouse leave the carousel
+    fireEvent.mouseLeave(carousel);
+    
+    // Advance time by 1000ms
+    jest.advanceTimersByTime(1000);
+    
+    // Now the second item should be displayed
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+    
+    jest.useRealTimers();
+  });
+
+  test('renders video items correctly', () => {
+    render(<MediaCarousel items={mockItems} initialIndex={2} />);
+    
+    // Video element should be rendered
+    const videoElement = screen.getByTitle('Sample Video');
+    expect(videoElement).toBeInTheDocument();
+    expect(videoElement.tagName).toBe('VIDEO');
+    expect(videoElement).toHaveAttribute('src', 'https://example.com/video.mp4');
+    expect(videoElement).toHaveAttribute('poster', 'https://example.com/poster.jpg');
+  });
+
+  test('calls onItemChange when item changes', () => {
+    const onItemChange = jest.fn();
+    render(<MediaCarousel items={mockItems} onItemChange={onItemChange} />);
+    
+    // Click the next button
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextButton);
+    
+    // onItemChange should be called with the new index and item
+    expect(onItemChange).toHaveBeenCalledWith(1, mockItems[1]);
+  });
+
+  test('renders with custom navigation buttons', () => {
+    render(
+      <MediaCarousel 
+        items={mockItems} 
+        prevButtonText="Back"
+        nextButtonText="Forward"
+      />
+    );
+    
+    expect(screen.getByRole('button', { name: /back/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /forward/i })).toBeInTheDocument();
+  });
+
+  test('hides navigation buttons when hideNavigation is true', () => {
+    render(<MediaCarousel items={mockItems} hideNavigation={true} />);
+    
+    expect(screen.queryByRole('button', { name: /previous/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
+  });
+
+  test('renders with custom indicator component', () => {
+    const CustomIndicator = ({ active }: { active: boolean }) => (
+      <div data-testid={`custom-indicator-${active ? 'active' : 'inactive'}`} />
+    );
+    
+    render(
+      <MediaCarousel 
+        items={mockItems} 
+        showIndicators={true}
+        indicatorComponent={CustomIndicator}
+      />
+    );
+    
+    expect(screen.getByTestId('custom-indicator-active')).toBeInTheDocument();
+    expect(screen.getAllByTestId('custom-indicator-inactive').length).toBe(mockItems.length - 1);
+  });
+});

--- a/packages/@smolitux/media/src/components/MediaGrid/__tests__/MediaGrid.a11y.test.tsx
+++ b/packages/@smolitux/media/src/components/MediaGrid/__tests__/MediaGrid.a11y.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { MediaGrid } from '../MediaGrid';
+
+// Extend Jest matchers with accessibility checks
+expect.extend(toHaveNoViolations);
+
+describe('MediaGrid Accessibility', () => {
+  const mockItems = [
+    {
+      id: '1',
+      type: 'image',
+      src: 'https://example.com/image1.jpg',
+      alt: 'Image 1',
+      title: 'First Image'
+    },
+    {
+      id: '2',
+      type: 'image',
+      src: 'https://example.com/image2.jpg',
+      alt: 'Image 2',
+      title: 'Second Image'
+    },
+    {
+      id: '3',
+      type: 'video',
+      src: 'https://example.com/video.mp4',
+      poster: 'https://example.com/poster.jpg',
+      title: 'Sample Video'
+    },
+    {
+      id: '4',
+      type: 'audio',
+      src: 'https://example.com/audio.mp3',
+      title: 'Sample Audio'
+    }
+  ];
+
+  test('should not have accessibility violations', async () => {
+    const { container } = render(
+      <MediaGrid 
+        items={mockItems}
+        aria-label="Media grid with images, videos, and audio"
+      />
+    );
+    
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should have appropriate ARIA attributes', () => {
+    const { container } = render(
+      <MediaGrid 
+        items={mockItems}
+        aria-label="Media grid with images, videos, and audio"
+      />
+    );
+    
+    const grid = container.querySelector('[data-testid="media-grid"]');
+    expect(grid).toHaveAttribute('aria-label', 'Media grid with images, videos, and audio');
+    expect(grid).toHaveAttribute('role', 'grid');
+  });
+
+  test('should have accessible images with alt text', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} />
+    );
+    
+    const images = container.querySelectorAll('img');
+    images.forEach(img => {
+      expect(img).toHaveAttribute('alt');
+    });
+  });
+
+  test('should have accessible video elements', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} />
+    );
+    
+    const videos = container.querySelectorAll('video');
+    videos.forEach(video => {
+      expect(video).toHaveAttribute('controls');
+      expect(video).toHaveAttribute('title');
+    });
+  });
+
+  test('should have accessible audio elements', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} />
+    );
+    
+    const audios = container.querySelectorAll('audio');
+    audios.forEach(audio => {
+      expect(audio).toHaveAttribute('controls');
+      expect(audio).toHaveAttribute('title');
+    });
+  });
+
+  test('should have accessible captions when shown', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} showCaptions={true} />
+    );
+    
+    const captions = container.querySelectorAll('.media-caption');
+    expect(captions.length).toBe(mockItems.length);
+    
+    captions.forEach(caption => {
+      expect(caption).toHaveAttribute('aria-hidden', 'false');
+    });
+  });
+
+  test('should have accessible filter controls', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} showFilters={true} />
+    );
+    
+    const filterControls = container.querySelector('[data-testid="media-filters"]');
+    expect(filterControls).toHaveAttribute('role', 'toolbar');
+    expect(filterControls).toHaveAttribute('aria-label', 'Filter media by type');
+    
+    const filterButtons = container.querySelectorAll('[data-testid="media-filters"] button');
+    filterButtons.forEach(button => {
+      expect(button).toHaveAttribute('aria-pressed');
+    });
+  });
+
+  test('should have accessible pagination controls', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} paginate={true} itemsPerPage={2} />
+    );
+    
+    const paginationControls = container.querySelector('[data-testid="media-pagination"]');
+    expect(paginationControls).toHaveAttribute('role', 'navigation');
+    expect(paginationControls).toHaveAttribute('aria-label', 'Pagination');
+    
+    const pageButtons = container.querySelectorAll('[data-testid="media-pagination"] button');
+    pageButtons.forEach(button => {
+      expect(button).toHaveAttribute('aria-label');
+    });
+    
+    // Current page button should have aria-current="page"
+    const currentPageButton = container.querySelector('[aria-current="page"]');
+    expect(currentPageButton).toBeInTheDocument();
+  });
+
+  test('should have keyboard navigation support for grid items', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} />
+    );
+    
+    const gridItems = container.querySelectorAll('[data-testid="media-grid-item"]');
+    gridItems.forEach(item => {
+      expect(item).toHaveAttribute('tabIndex', '0');
+    });
+  });
+
+  test('should have focus management for filter buttons', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} showFilters={true} />
+    );
+    
+    const filterButtons = container.querySelectorAll('[data-testid="media-filters"] button');
+    filterButtons.forEach(button => {
+      expect(button).toHaveAttribute('tabIndex', '0');
+    });
+  });
+
+  test('should have focus management for pagination buttons', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} paginate={true} itemsPerPage={2} />
+    );
+    
+    const paginationButtons = container.querySelectorAll('[data-testid="media-pagination"] button');
+    paginationButtons.forEach(button => {
+      expect(button).toHaveAttribute('tabIndex', '0');
+    });
+  });
+
+  test('should announce filter changes to screen readers', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} showFilters={true} />
+    );
+    
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+  });
+
+  test('should announce page changes to screen readers', () => {
+    const { container } = render(
+      <MediaGrid items={mockItems} paginate={true} itemsPerPage={2} />
+    );
+    
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/media/src/components/MediaGrid/__tests__/MediaGrid.test.tsx
+++ b/packages/@smolitux/media/src/components/MediaGrid/__tests__/MediaGrid.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MediaGrid } from '../MediaGrid';
+
+describe('MediaGrid', () => {
+  const mockItems = [
+    {
+      id: '1',
+      type: 'image',
+      src: 'https://example.com/image1.jpg',
+      alt: 'Image 1',
+      title: 'First Image'
+    },
+    {
+      id: '2',
+      type: 'image',
+      src: 'https://example.com/image2.jpg',
+      alt: 'Image 2',
+      title: 'Second Image'
+    },
+    {
+      id: '3',
+      type: 'video',
+      src: 'https://example.com/video.mp4',
+      poster: 'https://example.com/poster.jpg',
+      title: 'Sample Video'
+    },
+    {
+      id: '4',
+      type: 'audio',
+      src: 'https://example.com/audio.mp3',
+      title: 'Sample Audio'
+    }
+  ];
+
+  test('renders grid with default props', () => {
+    render(<MediaGrid items={mockItems} />);
+    
+    // Grid container should be rendered
+    const grid = screen.getByTestId('media-grid');
+    expect(grid).toBeInTheDocument();
+    
+    // All items should be rendered
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+    expect(screen.getByTitle('Sample Video')).toBeInTheDocument();
+    expect(screen.getByTitle('Sample Audio')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    render(<MediaGrid items={mockItems} className="custom-grid" />);
+    const grid = screen.getByTestId('media-grid');
+    expect(grid).toHaveClass('custom-grid');
+  });
+
+  test('renders with custom columns', () => {
+    render(<MediaGrid items={mockItems} columns={3} />);
+    const grid = screen.getByTestId('media-grid');
+    expect(grid).toHaveStyle('grid-template-columns: repeat(3, 1fr)');
+  });
+
+  test('renders with custom gap', () => {
+    render(<MediaGrid items={mockItems} gap={20} />);
+    const grid = screen.getByTestId('media-grid');
+    expect(grid).toHaveStyle('gap: 20px');
+  });
+
+  test('renders with custom item width', () => {
+    render(<MediaGrid items={mockItems} itemWidth={300} />);
+    const gridItems = screen.getAllByTestId('media-grid-item');
+    gridItems.forEach(item => {
+      expect(item).toHaveStyle('width: 300px');
+    });
+  });
+
+  test('renders with custom item height', () => {
+    render(<MediaGrid items={mockItems} itemHeight={200} />);
+    const gridItems = screen.getAllByTestId('media-grid-item');
+    gridItems.forEach(item => {
+      expect(item).toHaveStyle('height: 200px');
+    });
+  });
+
+  test('renders with captions when showCaptions is true', () => {
+    render(<MediaGrid items={mockItems} showCaptions={true} />);
+    
+    // Captions should be rendered
+    expect(screen.getByText('First Image')).toBeInTheDocument();
+    expect(screen.getByText('Second Image')).toBeInTheDocument();
+    expect(screen.getByText('Sample Video')).toBeInTheDocument();
+    expect(screen.getByText('Sample Audio')).toBeInTheDocument();
+  });
+
+  test('calls onItemClick when an item is clicked', () => {
+    const onItemClick = jest.fn();
+    render(<MediaGrid items={mockItems} onItemClick={onItemClick} />);
+    
+    // Click the first item
+    const firstItem = screen.getByAltText('Image 1');
+    fireEvent.click(firstItem);
+    
+    // onItemClick should be called with the item
+    expect(onItemClick).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  test('renders with custom item renderer', () => {
+    const customRenderer = (item: any) => (
+      <div data-testid="custom-item">
+        <span>{item.title}</span>
+      </div>
+    );
+    
+    render(<MediaGrid items={mockItems} itemRenderer={customRenderer} />);
+    
+    // Custom rendered items should be displayed
+    const customItems = screen.getAllByTestId('custom-item');
+    expect(customItems.length).toBe(mockItems.length);
+    expect(screen.getByText('First Image')).toBeInTheDocument();
+  });
+
+  test('renders with responsive columns', () => {
+    render(
+      <MediaGrid 
+        items={mockItems} 
+        responsiveColumns={{
+          sm: 1,
+          md: 2,
+          lg: 3,
+          xl: 4
+        }}
+      />
+    );
+    
+    // Grid should have responsive classes
+    const grid = screen.getByTestId('media-grid');
+    expect(grid).toHaveClass('grid-responsive');
+  });
+
+  test('renders with masonry layout when masonry is true', () => {
+    render(<MediaGrid items={mockItems} masonry={true} />);
+    
+    // Grid should have masonry class
+    const grid = screen.getByTestId('media-grid');
+    expect(grid).toHaveClass('grid-masonry');
+  });
+
+  test('renders with lazy loading when lazyLoad is true', () => {
+    render(<MediaGrid items={mockItems} lazyLoad={true} />);
+    
+    // Images should have loading="lazy" attribute
+    const images = screen.getAllByRole('img');
+    images.forEach(img => {
+      expect(img).toHaveAttribute('loading', 'lazy');
+    });
+  });
+
+  test('renders with placeholder when loading is true', () => {
+    render(<MediaGrid items={mockItems} loading={true} />);
+    
+    // Placeholder should be rendered
+    const placeholders = screen.getAllByTestId('media-placeholder');
+    expect(placeholders.length).toBe(mockItems.length);
+  });
+
+  test('renders with custom placeholder when provided', () => {
+    const customPlaceholder = <div data-testid="custom-placeholder">Loading...</div>;
+    render(<MediaGrid items={mockItems} loading={true} placeholder={customPlaceholder} />);
+    
+    // Custom placeholder should be rendered
+    const placeholders = screen.getAllByTestId('custom-placeholder');
+    expect(placeholders.length).toBe(mockItems.length);
+  });
+
+  test('renders with filter controls when showFilters is true', () => {
+    render(<MediaGrid items={mockItems} showFilters={true} />);
+    
+    // Filter controls should be rendered
+    const filterControls = screen.getByTestId('media-filters');
+    expect(filterControls).toBeInTheDocument();
+    
+    // Filter buttons for each media type should be rendered
+    expect(screen.getByRole('button', { name: /all/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /image/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /video/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /audio/i })).toBeInTheDocument();
+  });
+
+  test('filters items when filter is applied', () => {
+    render(<MediaGrid items={mockItems} showFilters={true} />);
+    
+    // Initially all items should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+    expect(screen.getByTitle('Sample Video')).toBeInTheDocument();
+    expect(screen.getByTitle('Sample Audio')).toBeInTheDocument();
+    
+    // Click the image filter button
+    const imageFilterButton = screen.getByRole('button', { name: /image/i });
+    fireEvent.click(imageFilterButton);
+    
+    // Only image items should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+    expect(screen.queryByTitle('Sample Video')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Sample Audio')).not.toBeInTheDocument();
+  });
+
+  test('renders with pagination when paginate is true', () => {
+    render(<MediaGrid items={mockItems} paginate={true} itemsPerPage={2} />);
+    
+    // Pagination controls should be rendered
+    const paginationControls = screen.getByTestId('media-pagination');
+    expect(paginationControls).toBeInTheDocument();
+    
+    // Only first page items should be displayed
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument();
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument();
+    expect(screen.queryByTitle('Sample Video')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Sample Audio')).not.toBeInTheDocument();
+    
+    // Click the next page button
+    const nextPageButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextPageButton);
+    
+    // Second page items should be displayed
+    expect(screen.queryByAltText('Image 1')).not.toBeInTheDocument();
+    expect(screen.queryByAltText('Image 2')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Sample Video')).toBeInTheDocument();
+    expect(screen.getByTitle('Sample Audio')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Beschreibung

Dieser Pull Request fügt Tests für die verbleibenden Komponenten in den @smolitux/charts und @smolitux/media Paketen hinzu.

## Hinzugefügte Tests

### @smolitux/charts
- **Heatmap**: Standard-Tests und Barrierefreiheitstests
- **RadarChart**: Standard-Tests und Barrierefreiheitstests
- **ScatterPlot**: Standard-Tests und Barrierefreiheitstests

### @smolitux/media
- **MediaCarousel**: Standard-Tests und Barrierefreiheitstests
- **MediaGrid**: Standard-Tests und Barrierefreiheitstests

## Testabdeckung

Die Tests decken folgende Aspekte ab:
- Rendering mit verschiedenen Props
- Interaktionen (Klicks, Eingaben, Navigation, etc.)
- Barrierefreiheit (ARIA-Attribute, Tastaturnavigation, etc.)
- Edge Cases und Fehlerbehandlung
- Responsive Verhalten

## Zusammenhang

Dieser PR ergänzt den vorherigen PR #108 und vervollständigt die Testabdeckung für die verbleibenden Komponenten in den @smolitux/charts und @smolitux/media Paketen. Mit diesen Tests stellen wir sicher, dass alle Komponenten wie erwartet funktionieren und den WCAG-Richtlinien entsprechen.