### PR TITLE
Fix GitHub Pages deployment: disable Jekyll and use Docusaurus directly

### DIFF
--- a/.github/workflows/deploy-docusaurus.yml
+++ b/.github/workflows/deploy-docusaurus.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build website
         run: npm run build
 
+      - name: Create .nojekyll file
+        run: touch ../docs/build/.nojekyll
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/jekyll-gh-pages.yml.disabled
+++ b/.github/workflows/jekyll-gh-pages.yml.disabled
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/docs/examples/form-examples.md
+++ b/docs/docs/examples/form-examples.md
@@ -10,6 +10,7 @@ Diese Seite enthält Beispiele für die Verwendung von Smolitux-UI-Formularkompo
 
 Ein einfaches Anmeldeformular mit E-Mail und Passwort.
 
+{% raw %}
 ```jsx
 import React from 'react';
 import { Form, FormField, Input, Button, Stack } from '@smolitux/ui';
@@ -63,11 +64,13 @@ function LoginForm() {
 
 export default LoginForm;
 ```
+{% endraw %}
 
 ## Registrierungsformular
 
 Ein umfassenderes Registrierungsformular mit mehreren Feldern und Validierungen.
 
+{% raw %}
 ```jsx
 import React from 'react';
 import { 
@@ -191,11 +194,13 @@ function RegistrationForm() {
 
 export default RegistrationForm;
 ```
+{% endraw %}
 
 ## Mehrstufiges Formular
 
 Ein mehrstufiges Formular mit Fortschrittsanzeige.
 
+{% raw %}
 ```jsx
 import React, { useState } from 'react';
 import { 
@@ -369,6 +374,7 @@ function MultiStepForm() {
 
 export default MultiStepForm;
 ```
+{% endraw %}
 
 ## Dynamisches Formular
 


### PR DESCRIPTION
Diese PR behebt Probleme mit dem GitHub Pages-Deployment:

- Jekyll wird deaktiviert, indem die Jekyll-Workflow-Datei umbenannt wird
- Eine `.nojekyll`-Datei wird hinzugefügt, um Jekyll auf GitHub Pages zu deaktivieren
- Der Docusaurus-Workflow wird angepasst, um die `.nojekyll`-Datei mit zu veröffentlichen
- Die Liquid-Syntax-Konflikte in den Markdown-Dateien werden behoben, indem Code-Blöcke mit `{% raw %}` und `{% endraw %}` umschlossen werden