### PR TITLE
Fix Docusaurus React Version Compatibility

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,8 +20,8 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0",


### PR DESCRIPTION
Diese PR behebt ein Problem mit der Docusaurus-Dokumentation, indem React von Version 19 auf Version 18.2.0 heruntergestuft wird. Dies löst Kompatibilitätsprobleme mit Docusaurus-Abhängigkeiten, die nur mit React 16-18 funktionieren.

Änderungen:
- Downgrade von React und React-DOM auf Version 18.2.0
- Behebung des Fehlers `ERR_MODULE_NOT_FOUND` beim Starten des Docusaurus-Servers

Nach dem Merge dieser PR kann die GitHub Pages-Dokumentation über den bestehenden Workflow korrekt veröffentlicht werden.