### PR TITLE
Fix Docusaurus GitHub Pages Deployment

### DIFF
--- a/.github/workflows/deploy-docusaurus.yml
+++ b/.github/workflows/deploy-docusaurus.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: docs/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --legacy-peer-deps
       - name: Build website
         run: npm run build
 


### PR DESCRIPTION
Diese PR behebt ein Problem mit der GitHub Pages-Bereitstellung der Docusaurus-Dokumentation.

Änderungen:
- Aktualisierung des Workflows, um `npm install --legacy-peer-deps` anstelle von `npm ci` zu verwenden
- Dies behebt Probleme mit Abhängigkeitskonflikten zwischen package.json und package-lock.json

Nach dem Merge dieser PR sollte die GitHub Pages-Dokumentation korrekt veröffentlicht werden.