### PR TITLE
Add Manual Deployment Workflow for Docusaurus

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,41 @@
+name: Manual Deploy Docusaurus
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      
+      - name: Install dependencies
+        working-directory: docs
+        run: npm install --legacy-peer-deps
+      
+      - name: Build website
+        working-directory: docs
+        run: npm run build
+      
+      - name: Create .nojekyll file
+        run: touch docs/build/.nojekyll
+      
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs/build
+          branch: gh-pages
+          clean: true


### PR DESCRIPTION
Diese PR fügt einen manuellen Deployment-Workflow für die Docusaurus-Dokumentation hinzu.

Änderungen:
- Hinzufügen eines neuen Workflows, der manuell über die GitHub Actions-Oberfläche ausgelöst werden kann
- Der Workflow baut die Docusaurus-Dokumentation und veröffentlicht sie auf GitHub Pages
- Verwendet `npm install --legacy-peer-deps` für die Installation der Abhängigkeiten

Nach dem Merge dieser PR kann die GitHub Pages-Dokumentation über den manuellen Workflow korrekt veröffentlicht werden.