### PR TITLE
Add Fixed Docusaurus Deployment Workflow

### DIFF
--- a/.github/workflows/fixed-docusaurus-deploy.yml
+++ b/.github/workflows/fixed-docusaurus-deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy Docusaurus to GitHub Pages (Fixed)
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+    branches:
+      - main
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: docs
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Clean install
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install @docusaurus/logger
+          npm install
+
+      - name: Build website
+        run: npm run build
+
+      - name: Create .nojekyll file
+        run: touch build/.nojekyll
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
Diese PR fügt einen verbesserten Deployment-Workflow für die Docusaurus-Dokumentation hinzu.

Änderungen:
- Hinzufügen eines verbesserten automatischen Deployment-Workflows, der die Docusaurus-Abhängigkeiten korrekt installiert
- Der Workflow verwendet einen sauberen Installationsansatz mit expliziter Installation von @docusaurus/logger
- Dies behebt das Problem mit fehlenden Abhängigkeiten beim Build-Prozess

Nach dem Merge dieser PR kann die GitHub Pages-Dokumentation über den Workflow korrekt veröffentlicht werden.