### PR TITLE
Verbesserte GitHub Pages Workflows

### DIFF
--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -17,21 +17,42 @@ on:
         required: false
         default: 'Manuelle Aktualisierung der Dokumentation'
 
+# Berechtigungen fuer den GitHub Token
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# Gleichzeitige Ausfuehrungen verhindern
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 defaults:
   run:
     working-directory: docs
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  # Build-Job
+  build:
+    name: Build Docusaurus Site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Alle Branches und Tags abrufen
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: npm
           cache-dependency-path: docs/package-lock.json
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
 
       - name: Clean install
         run: |
@@ -45,10 +66,20 @@ jobs:
       - name: Create .nojekyll file
         run: touch build/.nojekyll
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/build
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          path: docs/build
+
+  # Deploy-Job
+  deploy:
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/reset-github-pages.yml
+++ b/.github/workflows/reset-github-pages.yml
@@ -1,0 +1,40 @@
+name: Reset GitHub Pages Settings
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Grund fuer das Zuruecksetzen der GitHub Pages-Einstellungen'
+        required: false
+        default: 'Behebung von Problemen mit der GitHub Pages-Bereitstellung'
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  reset-pages:
+    name: Reset GitHub Pages Settings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+        
+      - name: Create empty gh-pages branch
+        run: |
+          git checkout --orphan temp-gh-pages
+          git rm -rf .
+          echo "# GitHub Pages" > README.md
+          echo "This branch contains the built documentation." >> README.md
+          touch .nojekyll
+          git add README.md .nojekyll
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Reset GitHub Pages"
+          git branch -D gh-pages || true
+          git branch -m gh-pages
+          git push -f origin gh-pages


### PR DESCRIPTION
Diese PR verbessert die GitHub Pages Workflows, um die Probleme mit der Bereitstellung zu beheben.

Änderungen:
- Verbesserter Docusaurus-Deploy-Workflow mit zweistufigem Prozess (Build und Deploy)
- Verwendung der offiziellen GitHub Pages Actions für bessere Kompatibilität
- Hinzufügung eines Reset-Workflows, um die GitHub Pages-Einstellungen bei Bedarf zurückzusetzen

Nach dem Merge dieser PR sollte die GitHub Pages-Dokumentation korrekt veröffentlicht werden. Falls weiterhin Probleme auftreten, kann der Reset-Workflow manuell ausgeführt werden, um die GitHub Pages-Einstellungen zurückzusetzen.