### PR TITLE
Aktualisierung der GitHub Actions-Versionen

### DIFF
--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v2
 
       - name: Clean install
         run: |
@@ -67,7 +67,7 @@ jobs:
         run: touch build/.nojekyll
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v1
         with:
           path: docs/build
 
@@ -82,4 +82,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/reset-github-pages.yml
+++ b/.github/workflows/reset-github-pages.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v2
         
       - name: Create empty gh-pages branch
         run: |


### PR DESCRIPTION
Diese PR aktualisiert die GitHub Actions-Versionen für bessere Kompatibilität.

Änderungen:
- Downgrade von `actions/configure-pages` von v3 auf v2
- Downgrade von `actions/upload-pages-artifact` von v2 auf v1
- Downgrade von `actions/deploy-pages` von v2 auf v1

Diese Änderungen beheben das Problem mit der fehlenden `actions/upload-artifact@v3`-Abhängigkeit und sollten die GitHub Pages-Bereitstellung korrigieren.