### PR TITLE
Fix: Explizite Installation von @docusaurus/logger im Workflow

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Install dependencies
         working-directory: docs
         run: |
+          rm -rf node_modules package-lock.json
+          npm install @docusaurus/logger
           npm install
       
       - name: Build website


### PR DESCRIPTION
Diese PR behebt den Fehler im Docusaurus-Workflow, bei dem das `@docusaurus/logger`-Paket nicht gefunden werden konnte.

Änderungen:
- Explizite Installation von `@docusaurus/logger` vor der Installation der anderen Abhängigkeiten
- Löschen von `node_modules` und `package-lock.json` vor der Installation, um sicherzustellen, dass alle Abhängigkeiten korrekt installiert werden

Diese Änderungen sollten den Fehler `Error [ERR_MODULE_NOT_FOUND]: Cannot find package @docusaurus/logger` beheben.