### PR TITLE
Fix: MDX-Fehler mit leeren Ausdrücken und doppelte Route behoben

### DIFF
--- a/docs/docs/development/roadmap/index.md
+++ b/docs/docs/development/roadmap/index.md
@@ -1,3 +1,7 @@
+---
+slug: /development/roadmap-details
+---
+
 # Smolitux UI Bibliothek - Entwicklungs-Roadmap
 
 Diese Roadmap beschreibt den Plan zur Weiterentwicklung und Fertigstellung der Smolitux UI Bibliothek. Sie enthält eine detaillierte Analyse des aktuellen Zustands, eine priorisierte Liste von Aufgaben und einen Schritt-für-Schritt-Plan zur Umsetzung.

--- a/docs/docs/testing/testplan/05-Spezielle-Komponententests.md
+++ b/docs/docs/testing/testplan/05-Spezielle-Komponententests.md
@@ -304,7 +304,7 @@ export const setTestDate = (year, month, day) => {
         columns={columns} 
         showSearch={true}
         showPagination={true}
-        itemsPerPage={50} {/* Alle auf einer Seite für einfachere Tests */}
+        itemsPerPage={50} /* Alle auf einer Seite für einfachere Tests */
       />
     );
     


### PR DESCRIPTION
Diese PR behebt zwei verbleibende Fehler im Build-Prozess der Dokumentation:

1. **MDX-Fehler mit leeren Ausdrücken in `05-Spezielle-Komponententests.md`**:
   - Korrektur eines ungültigen JSX-Kommentars, der zu einem "Unexpected empty expression"-Fehler führte
   - Entfernung der geschweiften Klammern um den Kommentar

2. **Doppelte Route für `/development/roadmap`**:
   - Hinzufügung eines benutzerdefinierten Slugs für die Datei `roadmap/index.md`, um Konflikte mit `roadmap-main.md` zu vermeiden
   - Der neue Slug ist `/development/roadmap-details`

Diese Änderungen beheben die verbleibenden Fehler beim Build-Prozess der Dokumentation.