### PR TITLE
Fix: Acorn-Parsing-Fehler in MDX-Datei behoben

### DIFF
--- a/docs/docs/testing/testplan/05-Spezielle-Komponententests.md
+++ b/docs/docs/testing/testplan/05-Spezielle-Komponententests.md
@@ -277,25 +277,29 @@ export const setTestDate = (year, month, day) => {
   };
 };
 ```
-  const [errors, setErrors] = React.useState({
-    name: '',
-    email: ''
-  });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    const newErrors = {
-      name: values.name ? '' : 'Name is required',
-      email: values.email ? '' : 'Email is required'
-    };
-    
-    setErrors(newErrors);
-    
-    if (Object.values(newErrors).every(error => !error)) {
-      // Form is valid
-      console.log('Form submitted:', values);
-  });
+```tsx
+const [errors, setErrors] = React.useState({
+  name: '',
+  email: ''
+});
+
+const handleSubmit = (e: React.FormEvent) => {
+  e.preventDefault();
+
+  const newErrors = {
+    name: values.name ? '' : 'Name is required',
+    email: values.email ? '' : 'Email is required'
+  };
+
+  setErrors(newErrors);
+
+  if (Object.values(newErrors).every(error => !error)) {
+    console.log('Form submitted:', values);
+  }
+};
+```
+
 
   test('combines filtering and sorting correctly', async () => {
     render(


### PR DESCRIPTION
Diese PR behebt einen Acorn-Parsing-Fehler in der Datei `05-Spezielle-Komponententests.md`.

Änderungen:
- Korrektur eines fehlerhaften Code-Blocks, der zu einem "Could not parse expression with acorn"-Fehler führte
- Hinzufügung eines korrekten Code-Block-Formats mit Sprachangabe (tsx)
- Korrektur der Klammern und Syntax im Code-Beispiel

Diese Änderung behebt den letzten bekannten Fehler beim Build-Prozess der Dokumentation.