### PR TITLE
Add snapshot linting fix plan

### DIFF
--- a/docs/Wiki/improvement-plan/snapshot-linting-fix-plan.md
+++ b/docs/Wiki/improvement-plan/snapshot-linting-fix-plan.md
@@ -1,0 +1,64 @@
+# Fix-Plan: Schnappschussdateien aktualisieren und Linting beheben
+
+**Fix‑Plan zur Aktualisierung der Schnappschussdateien und Behebung des Lintings**
+
+1. **Fehlerhafte Testdatei beheben**
+
+   - Datei `packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx` enthält eine komplette HTML‑Seite und keine Testlogik.
+   - Datei ersetzen oder löschen und durch eine korrekte Testimplementierung ersetzen (z. B. `Toast.test.tsx`).
+
+2. **Abhängigkeiten aktualisieren**
+
+   - In `package.json` im Root-Verzeichnis folgende devDependencies ergänzen:
+     ```json
+     "eslint-scope": "^8.3.0",
+     "pretty-format": "^29.7.0"
+     ```
+   - Anschließend alle Pakete neu installieren: `yarn install` oder `npm install`.
+
+3. **Node-Module-Probleme beheben**
+
+   - Falls `node_modules/eslint` oder `node_modules/jest-cli` unvollständig sind, `rm -rf node_modules` ausführen und die Abhängigkeiten komplett neu installieren.
+
+4. **.prettierignore optimieren**
+
+   - Nach Reparatur von `Toast.spec.tsx` prüfen, welche Dateien noch Probleme verursachen:
+     ```
+     packages/@smolitux/charts/src/components/ScatterPlot/ScatterPlot.old.tsx
+     packages/@smolitux/core/src/components/Menu/__tests__/Menu.spec.tsx
+     packages/@smolitux/core/src/components/Menu/__tests__/Menu.test.original.tsx
+     packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.spec.tsx
+     packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
+     packages/@smolitux/core/src/components/Skeleton/__tests__/Skeleton.spec.tsx
+     packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx (nach Fix entfernen)
+     ```
+   - Nur Dateien mit dauerhaft ungültigen Fragmenten in `.prettierignore` belassen.
+
+5. **Linting-Fehler beheben**
+
+   - Mit `npm run lint` bzw. `npm run lint:fix` alle Pakete prüfen.
+   - Linting-Warnungen oder Fehler schrittweise korrigieren (Imports, Typen, Formatierung).
+   - Bei Versionskonflikten (eslint 8 vs. 9) eine einheitliche Version definieren.
+
+6. **Schnappschüsse aktualisieren**
+
+   - Nach der Installation der Abhängigkeiten und erfolgreichem Linting:
+     `npm run test:update-snapshots` ausführen.
+   - Dadurch werden alle vorhandenen Snapshot-Dateien unter `__tests__/__snapshots__` aktualisiert.
+
+7. **Testlauf validieren**
+
+   - `npm run test` ausführen.
+   - Falls weitere Schnappschüsse fehlen oder Tests fehlschlagen, erneut `npm run test:update-snapshots` aufrufen und Fehler korrigieren.
+
+8. **Formatierung sicherstellen**
+
+   - `npm run format` ausführen und alle Änderungen committen.
+   - Bei Bedarf `npm run format:check` in CI integrieren.
+
+9. **Empfehlungen für zukünftige Tests & Formatierungen**
+   - Snapshot-Tests regelmäßig mit `npm run test:update-snapshots` aktualisieren.
+   - Linting und Formatierung als pre-commit Hooks (z. B. mit `husky`/`lint-staged`) einrichten.
+   - Größere HTML-Dateien oder generierte Testdaten als Fixtures ablegen und nicht in Testdateien einbetten.
+
+Dieser Plan führt zu konsistenten Abhängigkeiten, repariert die fehlerhafte Testdatei und sorgt dafür, dass Formatierung, Linting und Tests wieder ohne Fehler laufen.

--- a/docs/docs/improvement-plan/snapshot-linting-fix-plan.md
+++ b/docs/docs/improvement-plan/snapshot-linting-fix-plan.md
@@ -1,0 +1,64 @@
+# Fix-Plan: Schnappschussdateien aktualisieren und Linting beheben
+
+**Fix‑Plan zur Aktualisierung der Schnappschussdateien und Behebung des Lintings**
+
+1. **Fehlerhafte Testdatei beheben**
+
+   - Datei `packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx` enthält eine komplette HTML‑Seite und keine Testlogik.
+   - Datei ersetzen oder löschen und durch eine korrekte Testimplementierung ersetzen (z. B. `Toast.test.tsx`).
+
+2. **Abhängigkeiten aktualisieren**
+
+   - In `package.json` im Root-Verzeichnis folgende devDependencies ergänzen:
+     ```json
+     "eslint-scope": "^8.3.0",
+     "pretty-format": "^29.7.0"
+     ```
+   - Anschließend alle Pakete neu installieren: `yarn install` oder `npm install`.
+
+3. **Node-Module-Probleme beheben**
+
+   - Falls `node_modules/eslint` oder `node_modules/jest-cli` unvollständig sind, `rm -rf node_modules` ausführen und die Abhängigkeiten komplett neu installieren.
+
+4. **.prettierignore optimieren**
+
+   - Nach Reparatur von `Toast.spec.tsx` prüfen, welche Dateien noch Probleme verursachen:
+     ```
+     packages/@smolitux/charts/src/components/ScatterPlot/ScatterPlot.old.tsx
+     packages/@smolitux/core/src/components/Menu/__tests__/Menu.spec.tsx
+     packages/@smolitux/core/src/components/Menu/__tests__/Menu.test.original.tsx
+     packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.spec.tsx
+     packages/@smolitux/core/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
+     packages/@smolitux/core/src/components/Skeleton/__tests__/Skeleton.spec.tsx
+     packages/@smolitux/core/src/components/Toast/__tests__/Toast.spec.tsx (nach Fix entfernen)
+     ```
+   - Nur Dateien mit dauerhaft ungültigen Fragmenten in `.prettierignore` belassen.
+
+5. **Linting-Fehler beheben**
+
+   - Mit `npm run lint` bzw. `npm run lint:fix` alle Pakete prüfen.
+   - Linting-Warnungen oder Fehler schrittweise korrigieren (Imports, Typen, Formatierung).
+   - Bei Versionskonflikten (eslint 8 vs. 9) eine einheitliche Version definieren.
+
+6. **Schnappschüsse aktualisieren**
+
+   - Nach der Installation der Abhängigkeiten und erfolgreichem Linting:
+     `npm run test:update-snapshots` ausführen.
+   - Dadurch werden alle vorhandenen Snapshot-Dateien unter `__tests__/__snapshots__` aktualisiert.
+
+7. **Testlauf validieren**
+
+   - `npm run test` ausführen.
+   - Falls weitere Schnappschüsse fehlen oder Tests fehlschlagen, erneut `npm run test:update-snapshots` aufrufen und Fehler korrigieren.
+
+8. **Formatierung sicherstellen**
+
+   - `npm run format` ausführen und alle Änderungen committen.
+   - Bei Bedarf `npm run format:check` in CI integrieren.
+
+9. **Empfehlungen für zukünftige Tests & Formatierungen**
+   - Snapshot-Tests regelmäßig mit `npm run test:update-snapshots` aktualisieren.
+   - Linting und Formatierung als pre-commit Hooks (z. B. mit `husky`/`lint-staged`) einrichten.
+   - Größere HTML-Dateien oder generierte Testdaten als Fixtures ablegen und nicht in Testdateien einbetten.
+
+Dieser Plan führt zu konsistenten Abhängigkeiten, repariert die fehlerhafte Testdatei und sorgt dafür, dass Formatierung, Linting und Tests wieder ohne Fehler laufen.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -122,18 +122,13 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Media',
           collapsed: true,
-          items: [
-            'components/media/carousel',
-            'components/media/mediaplayer',
-          ],
+          items: ['components/media/carousel', 'components/media/mediaplayer'],
         },
         {
           type: 'category',
           label: 'Charts',
           collapsed: true,
-          items: [
-            'components/charts/line-chart',
-          ],
+          items: ['components/charts/line-chart'],
         },
       ],
     },
@@ -181,10 +176,7 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Releases',
           collapsed: true,
-          items: [
-            'development/releases/v0.2.1',
-            'development/releases/v0.2.2',
-          ],
+          items: ['development/releases/v0.2.1', 'development/releases/v0.2.2'],
         },
         {
           type: 'category',
@@ -280,9 +272,7 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Presentation',
           collapsed: true,
-          items: [
-            'testing/presentation/testplan-implementation',
-          ],
+          items: ['testing/presentation/testplan-implementation'],
         },
         {
           type: 'category',
@@ -316,9 +306,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'API',
       collapsed: true,
-      items: [
-        'api/reference',
-      ],
+      items: ['api/reference'],
     },
     {
       type: 'category',
@@ -391,6 +379,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'improvement-plan/button-component',
         'improvement-plan/phase2-accessibility',
+        'improvement-plan/snapshot-linting-fix-plan',
       ],
     },
   ],
@@ -400,9 +389,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Tutorial Basics',
       collapsed: false,
-      items: [
-        'tutorial-basics/create-a-document',
-      ],
+      items: ['tutorial-basics/create-a-document'],
     },
   ],
 };


### PR DESCRIPTION
## Summary
- document fixes for snapshot updates and linting
- link the new fix plan in the docs sidebar

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find module '../lib/cli')*
- `npm run test` *(fails: Cannot find module 'jest-cli')*

------
https://chatgpt.com/codex/tasks/task_e_68419bb20d048324ab60051e631ac65e