### PR TITLE
Resolve setup script conflicts

### DIFF
--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Setup Smolitux UI development environment
 
 # Clean proxy-related npm env vars to avoid warnings
 unset npm_config_http_proxy npm_config_https_proxy
@@ -36,11 +37,12 @@ module.exports = { ...base, rootDir: __dirname };
 EOF
 done
 
-# Rebuild packages like eslint and jest-cli to ensure build artifacts
-npm rebuild eslint jest-cli
+# Rebuild packages like eslint, jest-cli and ts-jest to ensure build artifacts
+# This avoids MODULE_NOT_FOUND errors when their build folders are missing.
+npm rebuild eslint jest-cli ts-jest
 
 # Verify essential tools are available from local node_modules
-for tool in eslint jest prettier; do
+for tool in eslint jest ts-jest prettier; do
   if ! npx --no-install $tool --version >/dev/null 2>&1; then
     echo "Error: $tool is not installed" >&2
     exit 1


### PR DESCRIPTION
## Summary
- ensure eslint and jest artifacts are rebuilt in `setup-dev-env.sh`
- add references to root Jest config across packages
- document repo workflow and microagents in `AGENTS.md`
- add CLAUDE instructions for future LLMs

## Testing
- `npm run lint` *(fails: Cannot find module '../lib/cli')*
- `npm run test` *(fails: Cannot find module 'jest-cli/build/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684405bf046083249536aa5dd96a3e5b