### PR TITLE
Fix front matter for blog posts

### DIFF
--- a/docs/blog/2025-05-15-accessibility-focus-smolitux.md
+++ b/docs/blog/2025-05-15-accessibility-focus-smolitux.md
@@ -1,8 +1,13 @@
 ---
 slug: accessibility-focus-smolitux
-title: [Accessibility First: Building Inclusive Components in Smolitux-UI]
-authors: [sam]
-tags: [accessibility, a11y, components, docusaurus]
+title: Accessibility First: Building Inclusive Components in Smolitux-UI
+authors:
+  - sam
+tags:
+  - accessibility
+  - a11y
+  - components
+  - docusaurus
 ---
 
 # Accessibility First: Building Inclusive Components in Smolitux-UI

--- a/docs/blog/2025-05-15-smolitux-ui-roadmap-2025.md
+++ b/docs/blog/2025-05-15-smolitux-ui-roadmap-2025.md
@@ -1,8 +1,14 @@
 ---
 slug: smolitux-ui-roadmap-2025
-title: [Smolitux-UI Roadmap for 2025: Sustainability Meets Accessibility]
-authors: [sam, johanna]
-tags: [roadmap, sustainability, accessibility, community]
+title: Smolitux-UI Roadmap for 2025: Sustainability Meets Accessibility
+authors:
+  - sam
+  - johanna
+tags:
+  - roadmap
+  - sustainability
+  - accessibility
+  - community
 ---
 
 # Smolitux-UI Roadmap for 2025: Sustainability Meets Accessibility


### PR DESCRIPTION
## Summary
- fix title syntax in `accessibility-focus` blog post
- previously corrected front matter in `smolitux-ui-roadmap-2025` post

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844401082e88324b21e339803f0c039