### PR TITLE
Add accessibility tests for Grid

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -314,6 +314,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'accessibility/a11y-components',
         'accessibility/component-status',
+        'accessibility/best-practices',
         {
           type: 'category',
           label: 'Components',

--- a/docs/wiki/accessibility/README.md
+++ b/docs/wiki/accessibility/README.md
@@ -4,6 +4,8 @@
 
 Die Smolitux UI Bibliothek wurde mit einem starken Fokus auf Barrierefreiheit entwickelt, um sicherzustellen, dass alle Benutzer, unabhängig von ihren Fähigkeiten oder Einschränkungen, die Komponenten effektiv nutzen können. Diese Dokumentation bietet einen Überblick über die implementierten Barrierefreiheitsverbesserungen und bewährte Praktiken.
 
+Weitere Hinweise findest du im Dokument [Best Practices für barrierefreie Komponenten](./best-practices.md).
+
 ## Implementierte Komponenten
 
 Die folgenden Komponenten wurden mit Barrierefreiheitsverbesserungen implementiert:

--- a/docs/wiki/accessibility/best-practices.md
+++ b/docs/wiki/accessibility/best-practices.md
@@ -1,0 +1,40 @@
+# Best Practices für barrierefreie Komponenten
+
+Diese Richtlinien zeigen, wie Smolitux UI Komponenten zugänglich implementiert werden. Sie basieren auf den WCAG 2.1 AA-Standards.
+
+## Struktur und Semantik
+
+- Nutze semantische HTML-Elemente und verwende ARIA nur, wenn nötig.
+- Beschrifte interaktive Elemente mit `aria-label`, `aria-labelledby` oder sichtbarem Text.
+- Vermeide es, Informationen ausschließlich über Farbe zu vermitteln.
+
+## Tastaturbedienung
+
+- Alle interaktiven Komponenten müssen per Tastatur bedienbar sein.
+- Die Tab-Reihenfolge und Fokusindikatoren sollen nachvollziehbar sein.
+- Komplexe Widgets brauchen Fokus-Management und `Escape` zum Schließen.
+
+## Screenreader-Unterstützung
+
+- Verwende `aria-live` und `aria-busy` für Statusänderungen.
+- Nutze `aria-roledescription` für komplexe Widgets.
+- Nutze versteckte Inhalte nur für Screenreader (`sr-only`).
+
+## Bewegung und Animation
+
+- Respektiere `prefers-reduced-motion` und biete Alternativen ohne Animation.
+- Animationen dürfen nicht von Inhalt oder Bedienung ablenken.
+
+## Beispiele
+
+```tsx
+<Button aria-label="Menü öffnen" onClick={openMenu}>
+  <MenuIcon />
+</Button>
+
+<Modal isOpen={isOpen} onClose={close} initialFocusRef={closeButtonRef}>
+  <button ref={closeButtonRef} onClick={close}>Schließen</button>
+</Modal>
+```
+
+Weitere Informationen findest du in den [Barrierefreiheits-Richtlinien](../guidelines/accessibility.md) und in den komponentenspezifischen Dokumenten.

--- a/packages/@smolitux/layout/src/components/Grid/__tests__/Grid.a11y.test.tsx
+++ b/packages/@smolitux/layout/src/components/Grid/__tests__/Grid.a11y.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import Grid from '../Grid';
+
+expect.extend(toHaveNoViolations);
+
+describe('Grid Accessibility', () => {
+  test('should have no basic accessibility violations', async () => {
+    const { container } = render(
+      <Grid container spacing={2}>
+        <Grid item xs={6}>
+          Item 1
+        </Grid>
+        <Grid item xs={6}>
+          Item 2
+        </Grid>
+      </Grid>
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('should handle interactive content without violations', async () => {
+    const { container } = render(
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <button>Click me</button>
+        </Grid>
+      </Grid>
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Summary
- implement Grid accessibility tests

## Testing
- `npx prettier --write packages/@smolitux/layout/src/components/Grid/__tests__/Grid.a11y.test.tsx`
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: lerna not found)*
- `npm run test` *(fails: jest not found)*
- `cd docs && npm run build` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6844501661588324ad7b27a2e455e831