### PR TITLE
feat: integrate TensorFlow.js for voice control

### DIFF
--- a/packages/@smolitux/voice-control/__tests__/CommandProcessor.test.ts
+++ b/packages/@smolitux/voice-control/__tests__/CommandProcessor.test.ts
@@ -1,0 +1,28 @@
+import { CommandProcessor } from '../src/CommandProcessor';
+
+describe('CommandProcessor', () => {
+  let processor: CommandProcessor;
+  let registeredComponents: Map<string, string[]>;
+
+  beforeEach(() => {
+    processor = new CommandProcessor();
+    registeredComponents = new Map();
+    registeredComponents.set('button1', ['klick', 'drücken']);
+    registeredComponents.set('input1', ['eingabe', 'löschen']);
+  });
+
+  test('should identify command and target for exact match', () => {
+    const result = processor.processCommand('klick', registeredComponents);
+    expect(result).toEqual({ command: 'klick', targetId: 'button1' });
+  });
+
+  test('should identify command and target for partial match', () => {
+    const result = processor.processCommand('bitte klick den button', registeredComponents);
+    expect(result).toEqual({ command: 'klick', targetId: 'button1' });
+  });
+
+  test('should return null for unrecognized commands', () => {
+    const result = processor.processCommand('unbekannter befehl', registeredComponents);
+    expect(result).toEqual({ command: null, targetId: null });
+  });
+});

--- a/packages/@smolitux/voice-control/jest.config.js
+++ b/packages/@smolitux/voice-control/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config');
+module.exports = { ...base, rootDir: __dirname };

--- a/packages/@smolitux/voice-control/package.json
+++ b/packages/@smolitux/voice-control/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@smolitux/voice-control",
+  "version": "0.2.1",
+  "description": "Voice control utilities for Smolitux UI",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "build:js": "tsup src/index.ts --format cjs,esm",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test": "jest",
+    "build:types": "tsc --emitDeclarationOnly"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "tsup": "^8.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
+  },
+  "dependencies": {
+    "@tensorflow/tfjs": "^4.22.0",
+    "@tensorflow-models/speech-commands": "^0.5.4"
+  }
+}

--- a/packages/@smolitux/voice-control/src/CommandProcessor.ts
+++ b/packages/@smolitux/voice-control/src/CommandProcessor.ts
@@ -1,0 +1,16 @@
+export class CommandProcessor {
+  processCommand(
+    text: string,
+    registeredComponents: Map<string, string[]>
+  ): { command: string; targetId: string } | { command: null; targetId: null } {
+    const normalized = text.toLowerCase().trim();
+    for (const [componentId, commands] of registeredComponents.entries()) {
+      for (const command of commands) {
+        if (normalized.includes(command.toLowerCase())) {
+          return { command, targetId: componentId };
+        }
+      }
+    }
+    return { command: null, targetId: null };
+  }
+}

--- a/packages/@smolitux/voice-control/src/FeedbackManager.ts
+++ b/packages/@smolitux/voice-control/src/FeedbackManager.ts
@@ -1,0 +1,62 @@
+export class FeedbackManager {
+  private audioContext: AudioContext | null = null;
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      document.addEventListener(
+        'click',
+        () => {
+          if (!this.audioContext) {
+            this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+          }
+        },
+        { once: true }
+      );
+    }
+  }
+
+  provideFeedback(type: 'start' | 'stop' | 'command', command?: string) {
+    this.provideVisualFeedback(type, command);
+    this.provideAudioFeedback(type);
+  }
+
+  private provideVisualFeedback(type: 'start' | 'stop' | 'command', command?: string) {
+    const el = document.getElementById('voice-feedback');
+    if (!el) return;
+    switch (type) {
+      case 'start':
+        el.textContent = 'Spracherkennung aktiv';
+        el.classList.add('listening');
+        break;
+      case 'stop':
+        el.textContent = 'Spracherkennung gestoppt';
+        el.classList.remove('listening');
+        break;
+      case 'command':
+        el.textContent = `Befehl erkannt: ${command}`;
+        break;
+    }
+  }
+
+  private provideAudioFeedback(type: 'start' | 'stop' | 'command') {
+    if (!this.audioContext) return;
+    const oscillator = this.audioContext.createOscillator();
+    const gainNode = this.audioContext.createGain();
+    oscillator.connect(gainNode);
+    gainNode.connect(this.audioContext.destination);
+    switch (type) {
+      case 'start':
+        oscillator.frequency.value = 880;
+        break;
+      case 'stop':
+        oscillator.frequency.value = 440;
+        break;
+      case 'command':
+        oscillator.frequency.value = 660;
+        break;
+    }
+    gainNode.gain.value = 0.1;
+    oscillator.start();
+    setTimeout(() => oscillator.stop(), 100);
+  }
+}

--- a/packages/@smolitux/voice-control/src/VoiceControlManager.ts
+++ b/packages/@smolitux/voice-control/src/VoiceControlManager.ts
@@ -1,0 +1,75 @@
+import { RecognitionEngine } from './engines/RecognitionEngine';
+import { WebSpeechRecognitionEngine } from './engines/WebSpeechRecognitionEngine';
+import { TensorFlowRecognitionEngine } from './engines/TensorFlowRecognitionEngine';
+import { CommandProcessor } from './CommandProcessor';
+import { FeedbackManager } from './FeedbackManager';
+
+export type EngineType = 'webSpeech' | 'tensorFlow' | 'external';
+
+export class VoiceControlManager {
+  private recognitionEngine: RecognitionEngine;
+  private commandProcessor: CommandProcessor;
+  private feedbackManager: FeedbackManager;
+  private registeredComponents: Map<string, string[]> = new Map();
+
+  public onRecognitionResult: (text: string) => void = () => {};
+  public onCommandRecognized: (command: string, target: string) => void = () => {};
+  public onListeningStateChanged: (isListening: boolean) => void = () => {};
+
+  constructor(engineType: EngineType = 'webSpeech', language = 'de-DE') {
+    switch (engineType) {
+      case 'tensorFlow':
+        this.recognitionEngine = new TensorFlowRecognitionEngine();
+        break;
+      case 'external':
+        this.recognitionEngine = new WebSpeechRecognitionEngine(language);
+        break;
+      case 'webSpeech':
+      default:
+        this.recognitionEngine = new WebSpeechRecognitionEngine(language);
+        break;
+    }
+
+    this.commandProcessor = new CommandProcessor();
+    this.feedbackManager = new FeedbackManager();
+
+    this.setupEventListeners();
+  }
+
+  private setupEventListeners() {
+    this.recognitionEngine.onResult = (text) => {
+      this.onRecognitionResult(text);
+      const { command, targetId } = this.commandProcessor.processCommand(text, this.registeredComponents);
+      if (command && targetId) {
+        this.onCommandRecognized(command, targetId);
+        this.feedbackManager.provideFeedback('command', command);
+      }
+    };
+
+    this.recognitionEngine.onStateChange = (isListening) => {
+      this.onListeningStateChanged(isListening);
+    };
+  }
+
+  public startListening() {
+    this.recognitionEngine.start();
+    this.feedbackManager.provideFeedback('start');
+  }
+
+  public stopListening() {
+    this.recognitionEngine.stop();
+    this.feedbackManager.provideFeedback('stop');
+  }
+
+  public registerComponent(id: string, commands: string[]) {
+    this.registeredComponents.set(id, commands);
+  }
+
+  public unregisterComponent(id: string) {
+    this.registeredComponents.delete(id);
+  }
+
+  public cleanup() {
+    this.recognitionEngine.cleanup();
+  }
+}

--- a/packages/@smolitux/voice-control/src/VoiceControlProvider.tsx
+++ b/packages/@smolitux/voice-control/src/VoiceControlProvider.tsx
@@ -1,0 +1,88 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { VoiceControlManager, EngineType } from './VoiceControlManager';
+
+interface VoiceControlContextType {
+  isListening: boolean;
+  startListening: () => void;
+  stopListening: () => void;
+  recognizedText: string;
+  lastCommand: string;
+  targetComponent: string | null;
+  registerComponent: (id: string, commands: string[]) => void;
+  unregisterComponent: (id: string) => void;
+}
+
+interface VoiceControlProviderProps {
+  children: ReactNode;
+  engineType?: EngineType;
+  language?: string;
+  debug?: boolean;
+}
+
+const VoiceControlContext = createContext<VoiceControlContextType | undefined>(undefined);
+
+export const VoiceControlProvider: React.FC<VoiceControlProviderProps> = ({
+  children,
+  engineType = 'webSpeech',
+  language = 'de-DE',
+  debug = false,
+}) => {
+  const [manager] = useState(() => new VoiceControlManager(engineType, language));
+  const [isListening, setIsListening] = useState(false);
+  const [recognizedText, setRecognizedText] = useState('');
+  const [lastCommand, setLastCommand] = useState('');
+  const [targetComponent, setTargetComponent] = useState<string | null>(null);
+
+  useEffect(() => {
+    manager.onRecognitionResult = (text) => {
+      setRecognizedText(text);
+      if (debug) console.log('Recognized text:', text);
+    };
+
+    manager.onCommandRecognized = (command, target) => {
+      setLastCommand(command);
+      setTargetComponent(target);
+      if (debug) console.log(`Command recognized: ${command}, Target: ${target}`);
+    };
+
+    manager.onListeningStateChanged = (listening) => {
+      setIsListening(listening);
+      if (debug) console.log('Listening state changed:', listening);
+    };
+
+    return () => {
+      manager.cleanup();
+    };
+  }, [manager, debug]);
+
+  const startListening = () => manager.startListening();
+  const stopListening = () => manager.stopListening();
+  const registerComponent = (id: string, commands: string[]) => manager.registerComponent(id, commands);
+  const unregisterComponent = (id: string) => manager.unregisterComponent(id);
+
+  return (
+    <VoiceControlContext.Provider
+      value={{
+        isListening,
+        startListening,
+        stopListening,
+        recognizedText,
+        lastCommand,
+        targetComponent,
+        registerComponent,
+        unregisterComponent,
+      }}
+    >
+      {children}
+      <div id="voice-feedback" aria-live="polite" style={{ position: 'absolute', top: -9999 }} />
+    </VoiceControlContext.Provider>
+  );
+};
+
+export const useVoiceControl = () => {
+  const context = useContext(VoiceControlContext);
+  if (context === undefined) {
+    throw new Error('useVoiceControl must be used within a VoiceControlProvider');
+  }
+  return context;
+};

--- a/packages/@smolitux/voice-control/src/engines/RecognitionEngine.ts
+++ b/packages/@smolitux/voice-control/src/engines/RecognitionEngine.ts
@@ -1,0 +1,7 @@
+export interface RecognitionEngine {
+  onResult: (text: string) => void;
+  onStateChange: (isListening: boolean) => void;
+  start(): void;
+  stop(): void;
+  cleanup(): void;
+}

--- a/packages/@smolitux/voice-control/src/engines/TensorFlowRecognitionEngine.ts
+++ b/packages/@smolitux/voice-control/src/engines/TensorFlowRecognitionEngine.ts
@@ -1,0 +1,71 @@
+import * as tf from '@tensorflow/tfjs';
+import * as speech from '@tensorflow-models/speech-commands';
+import { RecognitionEngine } from './RecognitionEngine';
+
+export class TensorFlowRecognitionEngine implements RecognitionEngine {
+  private model: speech.SpeechCommandRecognizer | null = null;
+  private listening = false;
+  private commandVocabulary: string[] = [];
+
+  public onResult: (text: string) => void = () => {};
+  public onStateChange: (isListening: boolean) => void = () => {};
+
+  constructor() {
+    this.initModel();
+  }
+
+  private async initModel() {
+    try {
+      this.model = speech.create('BROWSER_FFT');
+      await this.model.ensureModelLoaded();
+      this.commandVocabulary = this.model.wordLabels();
+      this.model.params().scoreThreshold = 0.75;
+      // warmup
+      await tf.ready();
+    } catch (error) {
+      console.error('Failed to load TensorFlow.js speech model:', error);
+    }
+  }
+
+  public async start() {
+    if (!this.model) {
+      await this.initModel();
+    }
+
+    if (this.model && !this.listening) {
+      this.listening = true;
+      this.onStateChange(true);
+      this.model.listen(
+        (result) => {
+          const scores = Array.from(result.scores as Float32Array);
+          const maxScore = Math.max(...scores);
+          const maxIndex = scores.indexOf(maxScore);
+          if (maxScore > (this.model!.params().scoreThreshold || 0)) {
+            const recognizedCommand = this.commandVocabulary[maxIndex];
+            this.onResult(recognizedCommand);
+          }
+        },
+        {
+          includeSpectrogram: false,
+          probabilityThreshold: 0.75,
+          overlapFactor: 0.5
+        }
+      );
+    }
+  }
+
+  public stop() {
+    if (this.model && this.listening) {
+      this.model.stopListening();
+      this.listening = false;
+      this.onStateChange(false);
+    }
+  }
+
+  public cleanup() {
+    this.stop();
+    if (this.model) {
+      this.model.stopListening();
+    }
+  }
+}

--- a/packages/@smolitux/voice-control/src/engines/WebSpeechRecognitionEngine.ts
+++ b/packages/@smolitux/voice-control/src/engines/WebSpeechRecognitionEngine.ts
@@ -1,0 +1,70 @@
+import { RecognitionEngine } from './RecognitionEngine';
+
+export class WebSpeechRecognitionEngine implements RecognitionEngine {
+  private recognition: SpeechRecognition | null = null;
+  private listening = false;
+
+  public onResult: (text: string) => void = () => {};
+  public onStateChange: (isListening: boolean) => void = () => {};
+
+  constructor(language = 'de-DE') {
+    const SpeechRecognitionConstructor =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (SpeechRecognitionConstructor) {
+      this.recognition = new SpeechRecognitionConstructor();
+      this.recognition.lang = language;
+      this.recognition.continuous = true;
+      this.recognition.interimResults = false;
+      this.setupEventListeners();
+    } else {
+      console.error('Speech recognition is not supported in this browser.');
+    }
+  }
+
+  private setupEventListeners() {
+    if (!this.recognition) return;
+    this.recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const last = event.results.length - 1;
+      const text = event.results[last][0].transcript;
+      this.onResult(text);
+    };
+
+    this.recognition.onstart = () => {
+      this.listening = true;
+      this.onStateChange(true);
+    };
+
+    this.recognition.onend = () => {
+      this.listening = false;
+      this.onStateChange(false);
+    };
+
+    this.recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      console.error('Speech recognition error', event.error);
+      this.listening = false;
+      this.onStateChange(false);
+    };
+  }
+
+  public start() {
+    if (this.recognition && !this.listening) {
+      this.recognition.start();
+    }
+  }
+
+  public stop() {
+    if (this.recognition && this.listening) {
+      this.recognition.stop();
+    }
+  }
+
+  public cleanup() {
+    this.stop();
+    if (this.recognition) {
+      this.recognition.onresult = null;
+      this.recognition.onstart = null;
+      this.recognition.onend = null;
+      this.recognition.onerror = null;
+    }
+  }
+}

--- a/packages/@smolitux/voice-control/src/index.ts
+++ b/packages/@smolitux/voice-control/src/index.ts
@@ -1,0 +1,5 @@
+export { VoiceControlProvider, useVoiceControl } from './VoiceControlProvider';
+export { withVoiceControl } from './withVoiceControl';
+export type { VoiceControlProps } from './withVoiceControl';
+export { VoiceControlManager } from './VoiceControlManager';
+export type { EngineType } from './VoiceControlManager';

--- a/packages/@smolitux/voice-control/src/withVoiceControl.tsx
+++ b/packages/@smolitux/voice-control/src/withVoiceControl.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useId } from 'react';
+import { useVoiceControl } from './VoiceControlProvider';
+
+export interface VoiceControlProps {
+  voiceCommands?: string[];
+  voiceEnabled?: boolean;
+  onVoiceCommand?: (command: string) => void;
+}
+
+export function withVoiceControl<P extends object>(
+  Component: React.ComponentType<P>,
+  defaultCommands: string[] = []
+) {
+  return React.forwardRef<unknown, P & VoiceControlProps>((props, ref) => {
+    const { voiceCommands = defaultCommands, voiceEnabled = true, onVoiceCommand, ...rest } = props;
+    const id = useId();
+    const { registerComponent, unregisterComponent, targetComponent, lastCommand } = useVoiceControl();
+    const componentRef = useRef<HTMLElement>(null);
+
+    useEffect(() => {
+      if (voiceEnabled && voiceCommands.length > 0) {
+        registerComponent(id, voiceCommands);
+      }
+      return () => {
+        if (voiceEnabled) {
+          unregisterComponent(id);
+        }
+      };
+    }, [id, registerComponent, unregisterComponent, voiceEnabled, voiceCommands]);
+
+    useEffect(() => {
+      if (targetComponent === id && lastCommand && onVoiceCommand) {
+        onVoiceCommand(lastCommand);
+      }
+    }, [id, lastCommand, onVoiceCommand, targetComponent]);
+
+    return <Component ref={ref || componentRef} {...(rest as P)} />;
+  });
+}

--- a/packages/@smolitux/voice-control/tsconfig.json
+++ b/packages/@smolitux/voice-control/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary
- add new `@smolitux/voice-control` package with TensorFlow.js support
- implement recognition engines and voice control provider
- include unit tests for command processor

## Testing
- `npm run lint` *(fails: 923 errors)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: lerna not found)*


------
https://chatgpt.com/codex/tasks/task_e_684465a4f710832487a13af2593f569c