### PR TITLE
Implement basic Resonance stories and docs

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -130,6 +130,12 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           items: ['components/charts/line-chart'],
         },
+        {
+          type: 'category',
+          label: 'Resonance',
+          collapsed: true,
+          items: ['components/resonance/index'],
+        },
       ],
     },
     {

--- a/docs/wiki/components/resonance/index.md
+++ b/docs/wiki/components/resonance/index.md
@@ -1,0 +1,45 @@
+# Resonance Components
+
+Die Resonance-Komponenten bilden das soziale Fundament von Smolitux UI. Sie ermöglichen Feeds, Posts und Profile für dezentrale Netzwerke.
+
+## FeedView
+Zeigt eine Liste von Beiträgen mit optionaler Filterung.
+```tsx
+import { FeedView } from '@smolitux/resonance';
+```
+
+## FeedFilter
+Auswahl der angezeigten Feed-Kategorie.
+```tsx
+import { FeedFilter } from '@smolitux/resonance';
+```
+
+## FeedItem
+Ein einzelner Beitrag im Feed.
+```tsx
+import { FeedItem } from '@smolitux/resonance';
+```
+
+## PostView
+Detailansicht eines Beitrags mit Medien und Interaktionen.
+```tsx
+import { PostView } from '@smolitux/resonance';
+```
+
+## PostInteractions
+Buttons für Likes, Kommentare und Teilen.
+```tsx
+import { PostInteractions } from '@smolitux/resonance';
+```
+
+## ProfileHeader
+Kopfbereich eines Benutzerprofils.
+```tsx
+import { ProfileHeader } from '@smolitux/resonance';
+```
+
+## ProfileContent
+Inhaltsbereich eines Benutzerprofils.
+```tsx
+import { ProfileContent } from '@smolitux/resonance';
+```

--- a/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
@@ -3,6 +3,14 @@ import { Card } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';
 import { MediaPlayer } from '@smolitux/core';
 
+// theme integration with fallback
+let useTheme: () => { themeMode: string };
+try {
+  useTheme = require('@smolitux/theme').useTheme;
+} catch {
+  useTheme = () => ({ themeMode: 'light' });
+}
+
 export interface FeedItemData {
   /** Eindeutige ID */
   id: string;
@@ -89,6 +97,10 @@ export const FeedItem: React.FC<FeedItemProps> = ({
     if (onShare) onShare(item.id);
   };
 
+  const { themeMode } = useTheme();
+  const textMuted = themeMode === 'dark' ? '#d1d5db' : '#6b7280';
+  const accent = '#3b82f6';
+
   const handleClick = () => {
     if (onClick) onClick(item.id);
   };
@@ -169,11 +181,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
           alignItems: 'center',
         }}
       >
-        <Text 
-          size="sm" 
-          color="#3b82f6"
-          style={{ fontWeight: 500 }}
-        >
+        <Text size="sm" style={{ fontWeight: 500, color: accent }}>
           {`${item.monetization.earnings} ${item.monetization.currency}`} earned
         </Text>
       </Box>
@@ -211,7 +219,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
           </Box>
           <Box>
             <Text weight="bold">{item.author.name}</Text>
-            <Text size="sm" color="#6b7280">{formatDate(item.createdAt)}</Text>
+            <Text size="sm" style={{ color: textMuted }}>{formatDate(item.createdAt)}</Text>
           </Box>
         </Flex>
 
@@ -239,9 +247,9 @@ export const FeedItem: React.FC<FeedItemProps> = ({
           <Flex>
             <Flex 
               align="center" 
-              style={{ 
+              style={{
                 marginRight: '16px',
-                color: item.isLiked ? '#3b82f6' : 'inherit',
+                color: item.isLiked ? accent : 'inherit',
                 fontWeight: item.isLiked ? 500 : 400,
               }}
               onClick={handleLike}
@@ -256,11 +264,11 @@ export const FeedItem: React.FC<FeedItemProps> = ({
               >
                 <path 
                   d="M14 10h3l-4 8v-6h-3l4-8v6z" 
-                  stroke={item.isLiked ? "#3b82f6" : "currentColor"} 
+                  stroke={item.isLiked ? accent : "currentColor"}
                   strokeWidth="2" 
                   strokeLinecap="round" 
                   strokeLinejoin="round"
-                  fill={item.isLiked ? "#3b82f6" : "none"}
+                  fill={item.isLiked ? accent : "none"}
                 />
               </svg>
               <Text size="sm">{item.stats.likes}</Text>
@@ -290,8 +298,8 @@ export const FeedItem: React.FC<FeedItemProps> = ({
             </Flex>
             <Flex 
               align="center" 
-              style={{ 
-                color: item.isShared ? '#3b82f6' : 'inherit',
+              style={{
+                color: item.isShared ? accent : 'inherit',
                 fontWeight: item.isShared ? 500 : 400,
               }}
               onClick={handleShare}
@@ -306,7 +314,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
               >
                 <path 
                   d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8M16 6l-4-4-4 4M12 2v13" 
-                  stroke={item.isShared ? "#3b82f6" : "currentColor"} 
+                  stroke={item.isShared ? accent : "currentColor"}
                   strokeWidth="2" 
                   strokeLinecap="round" 
                   strokeLinejoin="round"

--- a/packages/@smolitux/resonance/src/components/feed/stories/FeedItem.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/stories/FeedItem.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { FeedItem, FeedItemData } from '../FeedItem';
+
+const meta: Meta<typeof FeedItem> = {
+  title: 'Resonance/Feed/FeedItem',
+  component: FeedItem,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof FeedItem>;
+
+const demoItem: FeedItemData = {
+  id: '1',
+  author: { id: 'u1', name: 'Alice', avatar: 'https://placehold.co/40' },
+  createdAt: new Date().toISOString(),
+  contentType: 'text',
+  content: { text: 'Hello world' },
+  stats: { likes: 4, comments: 1, shares: 0, views: 25 },
+};
+
+export const Default: Story = {
+  args: { item: demoItem },
+};

--- a/packages/@smolitux/resonance/src/components/feed/stories/FeedView.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/stories/FeedView.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { FeedView } from '../FeedView';
+import { FeedItemData } from '../FeedItem';
+
+const meta: Meta<typeof FeedView> = {
+  title: 'Resonance/Feed/FeedView',
+  component: FeedView,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof FeedView>;
+
+const items: FeedItemData[] = [
+  {
+    id: '1',
+    author: { id: 'u1', name: 'Alice', avatar: 'https://placehold.co/40' },
+    createdAt: new Date().toISOString(),
+    contentType: 'text',
+    content: { text: 'Example post' },
+    stats: { likes: 2, comments: 0, shares: 0, views: 10 },
+  },
+];
+
+export const Default: Story = {
+  args: { feedItems: items },
+};

--- a/packages/@smolitux/resonance/src/components/post/stories/PostInteractions.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/post/stories/PostInteractions.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { PostInteractions } from '../PostInteractions';
+
+const meta: Meta<typeof PostInteractions> = {
+  title: 'Resonance/Post/PostInteractions',
+  component: PostInteractions,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof PostInteractions>;
+
+export const Default: Story = {
+  args: { likeCount: 3, commentCount: 1, shareCount: 0, viewCount: 10 },
+};

--- a/packages/@smolitux/resonance/src/components/post/stories/PostView.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/post/stories/PostView.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { PostView } from '../PostView';
+import { FeedItemData } from '../../feed/FeedItem';
+
+const meta: Meta<typeof PostView> = {
+  title: 'Resonance/Post/PostView',
+  component: PostView,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof PostView>;
+
+const post: FeedItemData = {
+  id: '1',
+  author: { id: 'u1', name: 'Alice', avatar: 'https://placehold.co/48' },
+  createdAt: new Date().toISOString(),
+  contentType: 'text',
+  content: { text: 'Post detail' },
+  stats: { likes: 5, comments: 1, shares: 0, views: 50 },
+};
+
+export const Default: Story = {
+  args: { post },
+};

--- a/packages/@smolitux/resonance/src/components/profile/stories/ProfileContent.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/stories/ProfileContent.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProfileContent } from '../ProfileContent';
+
+const meta: Meta<typeof ProfileContent> = {
+  title: 'Resonance/Profile/ProfileContent',
+  component: ProfileContent,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof ProfileContent>;
+
+export const Default: Story = {
+  args: { posts: [], isLoading: false },
+};

--- a/packages/@smolitux/resonance/src/components/profile/stories/ProfileHeader.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/stories/ProfileHeader.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProfileHeader } from '../ProfileHeader';
+
+const meta: Meta<typeof ProfileHeader> = {
+  title: 'Resonance/Profile/ProfileHeader',
+  component: ProfileHeader,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof ProfileHeader>;
+
+export const Default: Story = {
+  args: {
+    username: 'Alice',
+    avatar: 'https://placehold.co/80',
+    followerCount: 10,
+    followingCount: 5,
+    postCount: 3,
+  },
+};


### PR DESCRIPTION
## Summary
- add documentation page for Resonance components
- register the page in the Docusaurus sidebar
- integrate theme hook in FeedItem component
- provide minimal Storybook stories for FeedItem, FeedView, PostView, PostInteractions, ProfileHeader and ProfileContent

## Testing
- `npm run build` *(fails: lerna not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `cd docs && npm run build` *(fails: missing Docusaurus packages)*

------
https://chatgpt.com/codex/tasks/task_e_68446573175883249162961d9d6b5825