### PR TITLE
Implement TensorFlow.js voice engine

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -130,6 +130,12 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           items: ['components/charts/line-chart'],
         },
+        {
+          type: 'category',
+          label: 'Resonance',
+          collapsed: true,
+          items: ['components/resonance/index'],
+        },
       ],
     },
     {

--- a/docs/wiki/components/resonance/index.md
+++ b/docs/wiki/components/resonance/index.md
@@ -1,0 +1,45 @@
+# Resonance Components
+
+Die Resonance-Komponenten bilden das soziale Fundament von Smolitux UI. Sie ermöglichen Feeds, Posts und Profile für dezentrale Netzwerke.
+
+## FeedView
+Zeigt eine Liste von Beiträgen mit optionaler Filterung.
+```tsx
+import { FeedView } from '@smolitux/resonance';
+```
+
+## FeedFilter
+Auswahl der angezeigten Feed-Kategorie.
+```tsx
+import { FeedFilter } from '@smolitux/resonance';
+```
+
+## FeedItem
+Ein einzelner Beitrag im Feed.
+```tsx
+import { FeedItem } from '@smolitux/resonance';
+```
+
+## PostView
+Detailansicht eines Beitrags mit Medien und Interaktionen.
+```tsx
+import { PostView } from '@smolitux/resonance';
+```
+
+## PostInteractions
+Buttons für Likes, Kommentare und Teilen.
+```tsx
+import { PostInteractions } from '@smolitux/resonance';
+```
+
+## ProfileHeader
+Kopfbereich eines Benutzerprofils.
+```tsx
+import { ProfileHeader } from '@smolitux/resonance';
+```
+
+## ProfileContent
+Inhaltsbereich eines Benutzerprofils.
+```tsx
+import { ProfileContent } from '@smolitux/resonance';
+```

--- a/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
@@ -3,6 +3,14 @@ import { Card } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';
 import { MediaPlayer } from '@smolitux/core';
 
+// theme integration with fallback
+let useTheme: () => { themeMode: string };
+try {
+  useTheme = require('@smolitux/theme').useTheme;
+} catch {
+  useTheme = () => ({ themeMode: 'light' });
+}
+
 export interface FeedItemData {
   /** Eindeutige ID */
   id: string;
@@ -89,6 +97,10 @@ export const FeedItem: React.FC<FeedItemProps> = ({
     if (onShare) onShare(item.id);
   };
 
+  const { themeMode } = useTheme();
+  const textMuted = themeMode === 'dark' ? '#d1d5db' : '#6b7280';
+  const accent = '#3b82f6';
+
   const handleClick = () => {
     if (onClick) onClick(item.id);
   };
@@ -169,11 +181,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
           alignItems: 'center',
         }}
       >
-        <Text 
-          size="sm" 
-          color="#3b82f6"
-          style={{ fontWeight: 500 }}
-        >
+        <Text size="sm" style={{ fontWeight: 500, color: accent }}>
           {`${item.monetization.earnings} ${item.monetization.currency}`} earned
         </Text>
       </Box>
@@ -211,7 +219,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
           </Box>
           <Box>
             <Text weight="bold">{item.author.name}</Text>
-            <Text size="sm" color="#6b7280">{formatDate(item.createdAt)}</Text>
+            <Text size="sm" style={{ color: textMuted }}>{formatDate(item.createdAt)}</Text>
           </Box>
         </Flex>
 
@@ -239,9 +247,9 @@ export const FeedItem: React.FC<FeedItemProps> = ({
           <Flex>
             <Flex 
               align="center" 
-              style={{ 
+              style={{
                 marginRight: '16px',
-                color: item.isLiked ? '#3b82f6' : 'inherit',
+                color: item.isLiked ? accent : 'inherit',
                 fontWeight: item.isLiked ? 500 : 400,
               }}
               onClick={handleLike}
@@ -256,11 +264,11 @@ export const FeedItem: React.FC<FeedItemProps> = ({
               >
                 <path 
                   d="M14 10h3l-4 8v-6h-3l4-8v6z" 
-                  stroke={item.isLiked ? "#3b82f6" : "currentColor"} 
+                  stroke={item.isLiked ? accent : "currentColor"}
                   strokeWidth="2" 
                   strokeLinecap="round" 
                   strokeLinejoin="round"
-                  fill={item.isLiked ? "#3b82f6" : "none"}
+                  fill={item.isLiked ? accent : "none"}
                 />
               </svg>
               <Text size="sm">{item.stats.likes}</Text>
@@ -290,8 +298,8 @@ export const FeedItem: React.FC<FeedItemProps> = ({
             </Flex>
             <Flex 
               align="center" 
-              style={{ 
-                color: item.isShared ? '#3b82f6' : 'inherit',
+              style={{
+                color: item.isShared ? accent : 'inherit',
                 fontWeight: item.isShared ? 500 : 400,
               }}
               onClick={handleShare}
@@ -306,7 +314,7 @@ export const FeedItem: React.FC<FeedItemProps> = ({
               >
                 <path 
                   d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8M16 6l-4-4-4 4M12 2v13" 
-                  stroke={item.isShared ? "#3b82f6" : "currentColor"} 
+                  stroke={item.isShared ? accent : "currentColor"}
                   strokeWidth="2" 
                   strokeLinecap="round" 
                   strokeLinejoin="round"

--- a/packages/@smolitux/resonance/src/components/feed/stories/FeedItem.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/stories/FeedItem.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { FeedItem, FeedItemData } from '../FeedItem';
+
+const meta: Meta<typeof FeedItem> = {
+  title: 'Resonance/Feed/FeedItem',
+  component: FeedItem,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof FeedItem>;
+
+const demoItem: FeedItemData = {
+  id: '1',
+  author: { id: 'u1', name: 'Alice', avatar: 'https://placehold.co/40' },
+  createdAt: new Date().toISOString(),
+  contentType: 'text',
+  content: { text: 'Hello world' },
+  stats: { likes: 4, comments: 1, shares: 0, views: 25 },
+};
+
+export const Default: Story = {
+  args: { item: demoItem },
+};

--- a/packages/@smolitux/resonance/src/components/feed/stories/FeedView.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/stories/FeedView.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { FeedView } from '../FeedView';
+import { FeedItemData } from '../FeedItem';
+
+const meta: Meta<typeof FeedView> = {
+  title: 'Resonance/Feed/FeedView',
+  component: FeedView,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof FeedView>;
+
+const items: FeedItemData[] = [
+  {
+    id: '1',
+    author: { id: 'u1', name: 'Alice', avatar: 'https://placehold.co/40' },
+    createdAt: new Date().toISOString(),
+    contentType: 'text',
+    content: { text: 'Example post' },
+    stats: { likes: 2, comments: 0, shares: 0, views: 10 },
+  },
+];
+
+export const Default: Story = {
+  args: { feedItems: items },
+};

--- a/packages/@smolitux/resonance/src/components/post/stories/PostInteractions.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/post/stories/PostInteractions.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { PostInteractions } from '../PostInteractions';
+
+const meta: Meta<typeof PostInteractions> = {
+  title: 'Resonance/Post/PostInteractions',
+  component: PostInteractions,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof PostInteractions>;
+
+export const Default: Story = {
+  args: { likeCount: 3, commentCount: 1, shareCount: 0, viewCount: 10 },
+};

--- a/packages/@smolitux/resonance/src/components/post/stories/PostView.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/post/stories/PostView.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { PostView } from '../PostView';
+import { FeedItemData } from '../../feed/FeedItem';
+
+const meta: Meta<typeof PostView> = {
+  title: 'Resonance/Post/PostView',
+  component: PostView,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof PostView>;
+
+const post: FeedItemData = {
+  id: '1',
+  author: { id: 'u1', name: 'Alice', avatar: 'https://placehold.co/48' },
+  createdAt: new Date().toISOString(),
+  contentType: 'text',
+  content: { text: 'Post detail' },
+  stats: { likes: 5, comments: 1, shares: 0, views: 50 },
+};
+
+export const Default: Story = {
+  args: { post },
+};

--- a/packages/@smolitux/resonance/src/components/profile/stories/ProfileContent.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/stories/ProfileContent.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProfileContent } from '../ProfileContent';
+
+const meta: Meta<typeof ProfileContent> = {
+  title: 'Resonance/Profile/ProfileContent',
+  component: ProfileContent,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof ProfileContent>;
+
+export const Default: Story = {
+  args: { posts: [], isLoading: false },
+};

--- a/packages/@smolitux/resonance/src/components/profile/stories/ProfileHeader.stories.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/stories/ProfileHeader.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProfileHeader } from '../ProfileHeader';
+
+const meta: Meta<typeof ProfileHeader> = {
+  title: 'Resonance/Profile/ProfileHeader',
+  component: ProfileHeader,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof ProfileHeader>;
+
+export const Default: Story = {
+  args: {
+    username: 'Alice',
+    avatar: 'https://placehold.co/80',
+    followerCount: 10,
+    followingCount: 5,
+    postCount: 3,
+  },
+};

--- a/packages/@smolitux/voice-control/__tests__/VoiceControlManager.test.ts
+++ b/packages/@smolitux/voice-control/__tests__/VoiceControlManager.test.ts
@@ -1,0 +1,20 @@
+import { VoiceControlManager } from '../src/VoiceControlManager';
+import {
+  TensorFlowRecognitionEngine,
+  TensorFlowRecognitionOptions,
+} from '../src/engines/TensorFlowRecognitionEngine';
+
+describe('VoiceControlManager TensorFlow integration', () => {
+  test('uses TensorFlowRecognitionEngine when requested', () => {
+    const manager = new VoiceControlManager('tensorFlow');
+    const engine = (manager as any).recognitionEngine;
+    expect(engine).toBeInstanceOf(TensorFlowRecognitionEngine);
+  });
+
+  test('passes tensorFlowOptions to engine', () => {
+    const options: TensorFlowRecognitionOptions = { scoreThreshold: 0.5 };
+    const manager = new VoiceControlManager('tensorFlow', 'de-DE', options);
+    const engine = (manager as any).recognitionEngine as any;
+    expect(engine.options.scoreThreshold).toBe(0.5);
+  });
+});

--- a/packages/@smolitux/voice-control/src/VoiceControlManager.ts
+++ b/packages/@smolitux/voice-control/src/VoiceControlManager.ts
@@ -1,6 +1,9 @@
 import { RecognitionEngine } from './engines/RecognitionEngine';
 import { WebSpeechRecognitionEngine } from './engines/WebSpeechRecognitionEngine';
-import { TensorFlowRecognitionEngine } from './engines/TensorFlowRecognitionEngine';
+import {
+  TensorFlowRecognitionEngine,
+  TensorFlowRecognitionOptions,
+} from './engines/TensorFlowRecognitionEngine';
 import { CommandProcessor } from './CommandProcessor';
 import { FeedbackManager } from './FeedbackManager';
 
@@ -16,10 +19,14 @@ export class VoiceControlManager {
   public onCommandRecognized: (command: string, target: string) => void = () => {};
   public onListeningStateChanged: (isListening: boolean) => void = () => {};
 
-  constructor(engineType: EngineType = 'webSpeech', language = 'de-DE') {
+  constructor(
+    engineType: EngineType = 'webSpeech',
+    language = 'de-DE',
+    tensorFlowOptions?: TensorFlowRecognitionOptions
+  ) {
     switch (engineType) {
       case 'tensorFlow':
-        this.recognitionEngine = new TensorFlowRecognitionEngine();
+        this.recognitionEngine = new TensorFlowRecognitionEngine(tensorFlowOptions);
         break;
       case 'external':
         this.recognitionEngine = new WebSpeechRecognitionEngine(language);
@@ -39,7 +46,10 @@ export class VoiceControlManager {
   private setupEventListeners() {
     this.recognitionEngine.onResult = (text) => {
       this.onRecognitionResult(text);
-      const { command, targetId } = this.commandProcessor.processCommand(text, this.registeredComponents);
+      const { command, targetId } = this.commandProcessor.processCommand(
+        text,
+        this.registeredComponents
+      );
       if (command && targetId) {
         this.onCommandRecognized(command, targetId);
         this.feedbackManager.provideFeedback('command', command);

--- a/packages/@smolitux/voice-control/src/VoiceControlProvider.tsx
+++ b/packages/@smolitux/voice-control/src/VoiceControlProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { VoiceControlManager, EngineType } from './VoiceControlManager';
+import type { TensorFlowRecognitionOptions } from './engines/TensorFlowRecognitionEngine';
 
 interface VoiceControlContextType {
   isListening: boolean;
@@ -16,6 +17,7 @@ interface VoiceControlProviderProps {
   children: ReactNode;
   engineType?: EngineType;
   language?: string;
+  tensorFlowOptions?: TensorFlowRecognitionOptions;
   debug?: boolean;
 }
 
@@ -25,9 +27,12 @@ export const VoiceControlProvider: React.FC<VoiceControlProviderProps> = ({
   children,
   engineType = 'webSpeech',
   language = 'de-DE',
+  tensorFlowOptions,
   debug = false,
 }) => {
-  const [manager] = useState(() => new VoiceControlManager(engineType, language));
+  const [manager] = useState(
+    () => new VoiceControlManager(engineType, language, tensorFlowOptions)
+  );
   const [isListening, setIsListening] = useState(false);
   const [recognizedText, setRecognizedText] = useState('');
   const [lastCommand, setLastCommand] = useState('');
@@ -57,7 +62,8 @@ export const VoiceControlProvider: React.FC<VoiceControlProviderProps> = ({
 
   const startListening = () => manager.startListening();
   const stopListening = () => manager.stopListening();
-  const registerComponent = (id: string, commands: string[]) => manager.registerComponent(id, commands);
+  const registerComponent = (id: string, commands: string[]) =>
+    manager.registerComponent(id, commands);
   const unregisterComponent = (id: string) => manager.unregisterComponent(id);
 
   return (

--- a/packages/@smolitux/voice-control/src/engines/TensorFlowRecognitionEngine.ts
+++ b/packages/@smolitux/voice-control/src/engines/TensorFlowRecognitionEngine.ts
@@ -2,26 +2,56 @@ import * as tf from '@tensorflow/tfjs';
 import * as speech from '@tensorflow-models/speech-commands';
 import { RecognitionEngine } from './RecognitionEngine';
 
+export interface TensorFlowRecognitionOptions {
+  modelType?: 'BROWSER_FFT' | '18W';
+  vocabulary?: 'directional4w' | 'directional8w' | 'digits' | 'general' | string[];
+  customModelUrl?: string;
+  scoreThreshold?: number;
+  includeSpectrogram?: boolean;
+  overlapFactor?: number;
+  probabilityThreshold?: number;
+  invokeCallbackOnNoiseAndUnknown?: boolean;
+  suppressionTimeMillis?: number;
+}
+
 export class TensorFlowRecognitionEngine implements RecognitionEngine {
   private model: speech.SpeechCommandRecognizer | null = null;
   private listening = false;
   private commandVocabulary: string[] = [];
+  private options: TensorFlowRecognitionOptions;
 
   public onResult: (text: string) => void = () => {};
   public onStateChange: (isListening: boolean) => void = () => {};
 
-  constructor() {
+  constructor(options: TensorFlowRecognitionOptions = {}) {
+    this.options = {
+      modelType: 'BROWSER_FFT',
+      vocabulary: 'general',
+      scoreThreshold: 0.75,
+      includeSpectrogram: false,
+      overlapFactor: 0.5,
+      probabilityThreshold: 0.75,
+      invokeCallbackOnNoiseAndUnknown: false,
+      suppressionTimeMillis: 100,
+      ...options,
+    };
+
     this.initModel();
   }
 
   private async initModel() {
     try {
-      this.model = speech.create('BROWSER_FFT');
+      await tf.ready();
+
+      const modelOptions: speech.SpeechCommandsRecognizerOptions = {
+        vocabulary: this.options.vocabulary as any,
+        customModelUrl: this.options.customModelUrl,
+      };
+
+      this.model = speech.create(this.options.modelType as any, undefined, modelOptions);
       await this.model.ensureModelLoaded();
       this.commandVocabulary = this.model.wordLabels();
-      this.model.params().scoreThreshold = 0.75;
-      // warmup
-      await tf.ready();
+      this.model.params().scoreThreshold = this.options.scoreThreshold || 0.75;
     } catch (error) {
       console.error('Failed to load TensorFlow.js speech model:', error);
     }
@@ -40,15 +70,17 @@ export class TensorFlowRecognitionEngine implements RecognitionEngine {
           const scores = Array.from(result.scores as Float32Array);
           const maxScore = Math.max(...scores);
           const maxIndex = scores.indexOf(maxScore);
-          if (maxScore > (this.model!.params().scoreThreshold || 0)) {
+          if (maxScore > (this.options.scoreThreshold || 0)) {
             const recognizedCommand = this.commandVocabulary[maxIndex];
             this.onResult(recognizedCommand);
           }
         },
         {
-          includeSpectrogram: false,
-          probabilityThreshold: 0.75,
-          overlapFactor: 0.5
+          includeSpectrogram: this.options.includeSpectrogram,
+          probabilityThreshold: this.options.probabilityThreshold,
+          overlapFactor: this.options.overlapFactor,
+          invokeCallbackOnNoiseAndUnknown: this.options.invokeCallbackOnNoiseAndUnknown,
+          suppressionTimeMillis: this.options.suppressionTimeMillis,
         }
       );
     }

--- a/packages/@smolitux/voice-control/src/index.ts
+++ b/packages/@smolitux/voice-control/src/index.ts
@@ -3,3 +3,4 @@ export { withVoiceControl } from './withVoiceControl';
 export type { VoiceControlProps } from './withVoiceControl';
 export { VoiceControlManager } from './VoiceControlManager';
 export type { EngineType } from './VoiceControlManager';
+export type { TensorFlowRecognitionOptions } from './engines/TensorFlowRecognitionEngine';


### PR DESCRIPTION
## Summary
- add TensorFlowRecognitionOptions and enhance TensorFlowRecognitionEngine
- allow passing tensorFlowOptions through VoiceControlManager and VoiceControlProvider
- export TensorFlowRecognitionOptions and test the new integration

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: lerna not found)*
- `cd docs && npm run build` *(fails: missing Docusaurus packages)*

------
https://chatgpt.com/codex/tasks/task_e_68446573175883249162961d9d6b5825