### PR TITLE
feat: resolve #179 – add voice control docs

### DIFF
--- a/docs/wiki/accessibility/README.md
+++ b/docs/wiki/accessibility/README.md
@@ -4,7 +4,7 @@
 
 Die Smolitux UI Bibliothek wurde mit einem starken Fokus auf Barrierefreiheit entwickelt, um sicherzustellen, dass alle Benutzer, unabhängig von ihren Fähigkeiten oder Einschränkungen, die Komponenten effektiv nutzen können. Diese Dokumentation bietet einen Überblick über die implementierten Barrierefreiheitsverbesserungen und bewährte Praktiken.
 
-Weitere Hinweise findest du im Dokument [Best Practices für barrierefreie Komponenten](./best-practices.md).
+Weitere Hinweise findest du im Dokument [Best Practices für barrierefreie Komponenten](./best-practices.md) und in der [Barrierefreiheits-Checkliste](./checklist.md).
 
 ## Implementierte Komponenten
 

--- a/docs/wiki/accessibility/checklist.md
+++ b/docs/wiki/accessibility/checklist.md
@@ -1,0 +1,33 @@
+# Barrierefreiheits-Checkliste
+
+Diese Checkliste hilft dabei, Smolitux UI Komponenten auf WCAG 2.1 AA-Konformität zu prüfen.
+
+## Semantik und Struktur
+- [ ] Korrekte HTML-Elemente werden verwendet
+- [ ] Semantische Struktur ist logisch
+- [ ] Überschriften werden korrekt verwendet
+
+## ARIA-Attribute
+- [ ] Korrekte ARIA-Rollen werden verwendet
+- [ ] ARIA-Attribute werden korrekt gesetzt
+- [ ] ARIA-Zustände werden aktualisiert (z.B. `aria-expanded`, `aria-selected`)
+
+## Tastaturnavigation
+- [ ] Alle interaktiven Elemente sind mit der Tastatur bedienbar
+- [ ] Fokusreihenfolge ist logisch
+- [ ] Fokusindikator ist deutlich sichtbar
+- [ ] Keine Tastaturfallen
+
+## Visuelles Design
+- [ ] Ausreichender Farbkontrast
+- [ ] Informationen werden nicht nur durch Farbe vermittelt
+- [ ] Text ist auf 200% vergrößerbar ohne Funktionsverlust
+- [ ] Responsive Design funktioniert bei verschiedenen Viewport-Größen
+
+## Screenreader-Unterstützung
+- [ ] Alle Inhalte sind für Screenreader zugänglich
+- [ ] Alternative Texte für Bilder und Icons
+- [ ] Statusänderungen werden angekündigt
+- [ ] Komplexe Komponenten haben klare Anweisungen
+
+Weitere Hinweise zu automatisierten Tests findest du im Dokument [Accessibility Tests](../testing/implementation/accessibility-tests.md).

--- a/docs/wiki/features/voice-control/voice-control-architecture.md
+++ b/docs/wiki/features/voice-control/voice-control-architecture.md
@@ -474,6 +474,24 @@ Die Sprachsteuerung verbessert die Barrierefreiheit durch:
 - Akustisches Feedback für Benutzerinteraktionen
 - Visuelle Indikatoren für den Spracherkennungsstatus
 
+### Theme-Integration
+
+Das visuelle Feedback der Sprachsteuerung kann über das Smolitux-Theme
+angepasst werden. Der `voice-feedback` Container nutzt standardmäßig die
+Primär- und Graupaletten des aktiven Themes. Entwickelnde können die Farben
+einfach überschreiben:
+
+```css
+#voice-feedback.listening {
+  background-color: var(--color-primary-500);
+}
+
+#voice-feedback {
+  background-color: var(--color-gray-500);
+  color: var(--color-white);
+}
+```
+
 ## Leistungsoptimierung
 
 ### Lazy Loading

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -98,6 +98,7 @@ Our component library is organized into functional categories for easy navigatio
 
 - **[Accessibility](accessibility/README.md)** - Accessibility standards and practices
 - **[Accessibility Guidelines](guidelines/accessibility.md)** - Detailed accessibility guidelines
+- **[Accessibility Checklist](accessibility/checklist.md)** - Checklist for accessible components
 - **[Best Practices](guidelines/best-practices.md)** - Development best practices
 - **[Coding Standards](guidelines/coding-standards.md)** - Code style and standards
 - **[Component Structure](guidelines/component-structure.md)** - How to structure components

--- a/packages/@smolitux/core/src/components/voice/VoiceButton.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, ButtonProps } from '../Button';
+import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';
+
+export type VoiceButtonProps = ButtonProps & VoiceControlProps;
+
+const Base = withVoiceControl(Button, ['klick', 'click', 'drücken', 'press']);
+
+export const VoiceButton: React.FC<VoiceButtonProps> = ({ onVoiceCommand, onClick, ...props }) => {
+  const handleVoiceCommand = (command: string) => {
+    const lower = command.toLowerCase();
+    if (['klick', 'click', 'drücken', 'press'].includes(lower)) {
+      const btn = document.getElementById(props.id || '');
+      if (btn) {
+        (btn as HTMLButtonElement).click();
+      }
+    }
+    onVoiceCommand?.(command);
+  };
+
+  return <Base onClick={onClick} onVoiceCommand={handleVoiceCommand} {...props} />;
+};

--- a/packages/@smolitux/core/src/components/voice/VoiceCard.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceCard.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { Card, CardProps } from '../Card';
+import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';
+
+export type VoiceCardProps = CardProps &
+  VoiceControlProps & {
+    collapsible?: boolean;
+    expandable?: boolean;
+    onExpand?: () => void;
+    onCollapse?: () => void;
+  };
+
+const Base = withVoiceControl(Card, [
+  'einklappen',
+  'collapse',
+  'ausklappen',
+  'expand',
+  'maximieren',
+  'maximize',
+  'minimieren',
+  'minimize',
+]);
+
+export const VoiceCard: React.FC<VoiceCardProps> = ({
+  onVoiceCommand,
+  children,
+  collapsible = false,
+  expandable = false,
+  onExpand,
+  onCollapse,
+  ...props
+}) => {
+  const [collapsed, setCollapsed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const handleVoiceCommand = (command: string) => {
+    const lower = command.toLowerCase();
+    if (collapsible && (lower === 'einklappen' || lower === 'collapse')) {
+      setCollapsed(true);
+      onCollapse?.();
+    } else if (collapsible && (lower === 'ausklappen' || lower === 'expand')) {
+      setCollapsed(false);
+    } else if (expandable && (lower === 'maximieren' || lower === 'maximize')) {
+      setExpanded(true);
+      onExpand?.();
+    } else if (expandable && (lower === 'minimieren' || lower === 'minimize')) {
+      setExpanded(false);
+    }
+    onVoiceCommand?.(command);
+  };
+
+  return (
+    <Base
+      {...props}
+      className={`${props.className || ''} ${collapsed ? 'collapsed' : ''} ${expanded ? 'expanded' : ''}`}
+      onVoiceCommand={handleVoiceCommand}
+    >
+      {!collapsed && children}
+    </Base>
+  );
+};

--- a/packages/@smolitux/core/src/components/voice/VoiceInput.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceInput.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import { Input, InputProps } from '../Input';
+import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';
+
+export type VoiceInputProps = InputProps & VoiceControlProps;
+
+const Base = withVoiceControl(Input, ['eingabe', 'input', 'löschen', 'clear']);
+
+export const VoiceInput: React.FC<VoiceInputProps> = ({
+  onVoiceCommand,
+  onChange,
+  value: propValue,
+  ...props
+}) => {
+  const [value, setValue] = useState(propValue || '');
+
+  useEffect(() => {
+    if (propValue !== undefined) {
+      setValue(propValue);
+    }
+  }, [propValue]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    onChange?.(e);
+  };
+
+  const handleVoiceCommand = (command: string) => {
+    const lower = command.toLowerCase();
+    if (lower.startsWith('eingabe ') || lower.startsWith('input ')) {
+      const text = command.substring(lower.startsWith('eingabe ') ? 8 : 6);
+      setValue(text);
+      const el = document.getElementById(props.id || '') as HTMLInputElement | null;
+      if (el) {
+        el.value = text;
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      onChange?.({
+        target: { value: text },
+        currentTarget: { value: text },
+      } as React.ChangeEvent<HTMLInputElement>);
+    } else if (lower === 'löschen' || lower === 'clear') {
+      setValue('');
+      const el = document.getElementById(props.id || '') as HTMLInputElement | null;
+      if (el) {
+        el.value = '';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      onChange?.({
+        target: { value: '' },
+        currentTarget: { value: '' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    }
+    onVoiceCommand?.(command);
+  };
+
+  return (
+    <Base value={value} onChange={handleChange} onVoiceCommand={handleVoiceCommand} {...props} />
+  );
+};

--- a/packages/@smolitux/core/src/components/voice/VoiceModal.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceModal.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Modal, ModalProps } from '../Modal';
+import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';
+
+export type VoiceModalProps = ModalProps & VoiceControlProps;
+
+const Base = withVoiceControl(Modal, ['schließen', 'close', 'abbrechen', 'cancel']);
+
+export const VoiceModal: React.FC<VoiceModalProps> = ({ onVoiceCommand, onClose, ...props }) => {
+  const handleVoiceCommand = (command: string) => {
+    const lower = command.toLowerCase();
+    if (['schließen', 'close', 'abbrechen', 'cancel'].includes(lower)) {
+      onClose?.();
+    }
+    onVoiceCommand?.(command);
+  };
+
+  return <Base onClose={onClose} onVoiceCommand={handleVoiceCommand} {...props} />;
+};

--- a/packages/@smolitux/core/src/components/voice/VoiceSelect.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceSelect.tsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { Select, SelectProps } from '../Select';
+import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';
+
+export type VoiceSelectProps = SelectProps & VoiceControlProps;
+
+const Base = withVoiceControl(Select, ['wähle', 'select', 'wählen', 'auswählen']);
+
+export const VoiceSelect: React.FC<VoiceSelectProps> = ({
+  onVoiceCommand,
+  onChange,
+  value: propValue,
+  options = [],
+  ...props
+}) => {
+  const [value, setValue] = useState(propValue);
+
+  useEffect(() => {
+    if (propValue !== undefined) {
+      setValue(propValue);
+    }
+  }, [propValue]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setValue(e.target.value);
+    onChange?.(e);
+  };
+
+  const handleVoiceCommand = (command: string) => {
+    const lower = command.toLowerCase();
+    if (
+      lower.startsWith('wähle ') ||
+      lower.startsWith('select ') ||
+      lower.includes(' wählen') ||
+      lower.includes(' auswählen')
+    ) {
+      let optionName = '';
+      if (lower.startsWith('wähle ')) optionName = command.substring(6).toLowerCase();
+      else if (lower.startsWith('select ')) optionName = command.substring(7).toLowerCase();
+      else if (lower.includes(' wählen')) optionName = command.split(' wählen')[0].toLowerCase();
+      else if (lower.includes(' auswählen'))
+        optionName = command.split(' auswählen')[0].toLowerCase();
+
+      const matching = options.find((o) => {
+        const label = typeof o === 'string' ? o.toLowerCase() : (o.label || '').toLowerCase();
+        return label === optionName;
+      });
+      if (matching) {
+        const val = typeof matching === 'string' ? matching : matching.value;
+        setValue(val);
+        const el = document.getElementById(props.id || '') as HTMLSelectElement | null;
+        if (el) {
+          el.value = val;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        onChange?.({
+          target: { value: val },
+          currentTarget: { value: val },
+        } as React.ChangeEvent<HTMLSelectElement>);
+      }
+    }
+    onVoiceCommand?.(command);
+  };
+
+  return (
+    <Base
+      value={value}
+      onChange={handleChange}
+      options={options}
+      onVoiceCommand={handleVoiceCommand}
+      {...props}
+    />
+  );
+};

--- a/packages/@smolitux/core/src/components/voice/__tests__/VoiceComponents.test.tsx
+++ b/packages/@smolitux/core/src/components/voice/__tests__/VoiceComponents.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { VoiceButton } from '../VoiceButton';
+import { VoiceInput } from '../VoiceInput';
+import { VoiceSelect } from '../VoiceSelect';
+import { VoiceModal } from '../VoiceModal';
+import { VoiceCard } from '../VoiceCard';
+import { useVoiceControl } from '@smolitux/voice-control';
+
+jest.mock('@smolitux/voice-control', () => {
+  const actual = jest.requireActual('@smolitux/voice-control');
+  return {
+    ...actual,
+    useVoiceControl: jest.fn(),
+  };
+});
+
+const context: any = {
+  isListening: false,
+  startListening: jest.fn(),
+  stopListening: jest.fn(),
+  recognizedText: '',
+  lastCommand: '',
+  targetComponent: null,
+  registerComponent: jest.fn(),
+  unregisterComponent: jest.fn(),
+};
+
+beforeEach(() => {
+  (useVoiceControl as jest.Mock).mockImplementation(() => context);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  cleanup();
+  context.lastCommand = '';
+  context.targetComponent = null;
+});
+
+describe('voice component registration', () => {
+  const components = [VoiceButton, VoiceInput, VoiceSelect, VoiceModal, VoiceCard];
+
+  test.each(components)('%p registers on mount', (Component) => {
+    render(<Component />);
+    expect(context.registerComponent).toHaveBeenCalledTimes(1);
+    context.registerComponent.mockClear();
+  });
+
+  test.each(components)('%p unregisters on unmount', (Component) => {
+    const { unmount } = render(<Component />);
+    unmount();
+    expect(context.unregisterComponent).toHaveBeenCalledTimes(1);
+    context.unregisterComponent.mockClear();
+  });
+});
+
+describe('VoiceButton command handling', () => {
+  test('triggers click on recognized command', () => {
+    const onClick = jest.fn();
+    const { container, rerender } = render(<VoiceButton id="btn" onClick={onClick} />);
+    const id = context.registerComponent.mock.calls[0][0];
+    context.lastCommand = 'klick';
+    context.targetComponent = id;
+    rerender(<VoiceButton id="btn" onClick={onClick} />);
+    expect(onClick).toHaveBeenCalled();
+    expect(container.querySelector('button')).toBeTruthy();
+  });
+});

--- a/packages/@smolitux/core/src/index.ts
+++ b/packages/@smolitux/core/src/index.ts
@@ -2,23 +2,30 @@
 // Core UI Components
 
 // Animation exports
-export { default as AnimatePresence, type AnimatePresenceProps } from './animations/AnimatePresence';
+export {
+  default as AnimatePresence,
+  type AnimatePresenceProps,
+} from './animations/AnimatePresence';
 export { default as Motion, type MotionProps, type MotionVariants } from './animations/Motion';
 export { default as keyframes, type KeyframeAnimation } from './animations/keyframes';
-export { 
-  default as transitions, 
-  type TransitionPreset, 
-  type TransitionPresetName, 
+export {
+  default as transitions,
+  type TransitionPreset,
+  type TransitionPresetName,
   type TransitionVariant,
   createTransition,
-  createMultiTransition
+  createMultiTransition,
 } from './animations/transitions';
-export { default as useAnimation, type AnimationOptions, type AnimationControls } from './animations/useAnimation';
-export { 
-  default as useTransition, 
-  type TransitionState, 
-  type TransitionOptions, 
-  type TransitionResult 
+export {
+  default as useAnimation,
+  type AnimationOptions,
+  type AnimationControls,
+} from './animations/useAnimation';
+export {
+  default as useTransition,
+  type TransitionState,
+  type TransitionOptions,
+  type TransitionResult,
 } from './animations/useTransition';
 export { default as Alert, type AlertProps, type AlertType } from './components/Alert/Alert';
 export { default as Badge, type BadgeProps } from './components/Badge/Badge';
@@ -27,20 +34,34 @@ export { default as Card, type CardProps } from './components/Card/Card';
 export { default as Input, type InputProps } from './components/Input/Input';
 export { default as Modal, type ModalProps } from './components/Modal/Modal';
 export { default as Select, type SelectProps, type SelectOption } from './components/Select/Select';
+export { VoiceButton } from './components/voice/VoiceButton';
+export { VoiceInput } from './components/voice/VoiceInput';
+export { VoiceSelect } from './components/voice/VoiceSelect';
+export { VoiceModal } from './components/voice/VoiceModal';
+export { VoiceCard } from './components/voice/VoiceCard';
 export { default as TabView, type TabViewProps, type TabItem } from './components/TabView';
-export { default as Table, type TableProps, type TableColumn, type SortDirection } from './components/Table/Table';
+export {
+  default as Table,
+  type TableProps,
+  type TableColumn,
+  type SortDirection,
+} from './components/Table/Table';
 export { default as Checkbox, type CheckboxProps } from './components/Checkbox/Checkbox';
 export { default as Radio, type RadioProps } from './components/Radio/Radio';
-export { default as RadioGroup, type RadioGroupProps, type RadioOption } from './components/RadioGroup/RadioGroup';
+export {
+  default as RadioGroup,
+  type RadioGroupProps,
+  type RadioOption,
+} from './components/RadioGroup/RadioGroup';
 export { default as Tooltip, type TooltipProps } from './components/Tooltip/Tooltip';
-export { 
-  Toast, 
-  ToastProvider, 
-  useToast, 
-  useToastMethods, 
-  type ToastProps, 
-  type ToastType, 
-  type ToastProviderProps 
+export {
+  Toast,
+  ToastProvider,
+  useToast,
+  useToastMethods,
+  type ToastProps,
+  type ToastType,
+  type ToastProviderProps,
 } from './components/Toast';
 export { default as ProgressBar, type ProgressBarProps } from './components/ProgressBar';
 export { default as Pagination, type PaginationProps } from './components/Pagination';
@@ -48,23 +69,55 @@ export { default as Skeleton, type SkeletonProps } from './components/Skeleton';
 export { default as TimePicker, type TimePickerProps } from './components/TimePicker';
 
 // New components
-export { default as FormControl, type FormControlProps, useFormControl } from './components/FormControl/FormControl';
+export {
+  default as FormControl,
+  type FormControlProps,
+  useFormControl,
+} from './components/FormControl/FormControl';
 export { default as Form, type FormProps } from './components/Form/Form';
 export { default as FormField, type FormFieldProps } from './components/FormField/FormField';
 export { default as TextArea, type TextAreaProps } from './components/TextArea/TextArea';
 export { default as Switch, type SwitchProps } from './components/Switch/Switch';
-export { default as Breadcrumb, type BreadcrumbProps, type BreadcrumbItemData } from './components/Breadcrumb/Breadcrumb';
-export { default as ColorPicker, type ColorPickerProps } from './components/ColorPicker/ColorPicker';
-export { default as Carousel, type CarouselProps, type CarouselItem } from './components/Carousel/Carousel';
+export {
+  default as Breadcrumb,
+  type BreadcrumbProps,
+  type BreadcrumbItemData,
+} from './components/Breadcrumb/Breadcrumb';
+export {
+  default as ColorPicker,
+  type ColorPickerProps,
+} from './components/ColorPicker/ColorPicker';
+export {
+  default as Carousel,
+  type CarouselProps,
+  type CarouselItem,
+} from './components/Carousel/Carousel';
 export { default as Menu, type MenuProps } from './components/Menu/Menu';
 export { default as MenuItem, type MenuItemProps } from './components/Menu/MenuItem';
 export { default as MenuDivider, type MenuDividerProps } from './components/Menu/MenuDivider';
 export { default as MenuDropdown, type MenuDropdownProps } from './components/Menu/MenuDropdown';
-export { default as Drawer, type DrawerProps, type DrawerPlacement } from './components/Drawer/Drawer';
+export {
+  default as Drawer,
+  type DrawerProps,
+  type DrawerPlacement,
+} from './components/Drawer/Drawer';
 export { default as Dialog, type DialogProps } from './components/Dialog/Dialog';
-export { default as Popover, type PopoverProps, type PopoverPlacement } from './components/Popover/Popover';
-export { default as FileUpload, type FileUploadProps, type FileInfo } from './components/FileUpload/FileUpload';
-export { MediaPlayer, type MediaPlayerProps, type MediaSource, type MediaTrack } from './components/MediaPlayer/MediaPlayer';
+export {
+  default as Popover,
+  type PopoverProps,
+  type PopoverPlacement,
+} from './components/Popover/Popover';
+export {
+  default as FileUpload,
+  type FileUploadProps,
+  type FileInfo,
+} from './components/FileUpload/FileUpload';
+export {
+  MediaPlayer,
+  type MediaPlayerProps,
+  type MediaSource,
+  type MediaTrack,
+} from './components/MediaPlayer/MediaPlayer';
 export { default as DatePicker, type DatePickerProps } from './components/DatePicker/DatePicker';
 
 // Animation components
@@ -84,6 +137,9 @@ export * from './validation/types';
 // Internationalization
 export { default as I18nProvider, useI18n, type I18nProviderProps } from './i18n/I18nProvider';
 export { default as useTranslation } from './i18n/useTranslation';
-export { default as LanguageSwitcher, type LanguageSwitcherProps } from './components/LanguageSwitcher/LanguageSwitcher';
+export {
+  default as LanguageSwitcher,
+  type LanguageSwitcherProps,
+} from './components/LanguageSwitcher/LanguageSwitcher';
 export * from './i18n/types';
 export * from './i18n/constants';

--- a/packages/@smolitux/voice-control/__tests__/CommandProcessor.test.ts
+++ b/packages/@smolitux/voice-control/__tests__/CommandProcessor.test.ts
@@ -1,0 +1,28 @@
+import { CommandProcessor } from '../src/CommandProcessor';
+
+describe('CommandProcessor', () => {
+  let processor: CommandProcessor;
+  let registeredComponents: Map<string, string[]>;
+
+  beforeEach(() => {
+    processor = new CommandProcessor();
+    registeredComponents = new Map();
+    registeredComponents.set('button1', ['klick', 'drücken']);
+    registeredComponents.set('input1', ['eingabe', 'löschen']);
+  });
+
+  test('should identify command and target for exact match', () => {
+    const result = processor.processCommand('klick', registeredComponents);
+    expect(result).toEqual({ command: 'klick', targetId: 'button1' });
+  });
+
+  test('should identify command and target for partial match', () => {
+    const result = processor.processCommand('bitte klick den button', registeredComponents);
+    expect(result).toEqual({ command: 'klick', targetId: 'button1' });
+  });
+
+  test('should return null for unrecognized commands', () => {
+    const result = processor.processCommand('unbekannter befehl', registeredComponents);
+    expect(result).toEqual({ command: null, targetId: null });
+  });
+});

--- a/packages/@smolitux/voice-control/__tests__/WebSpeechRecognitionEngine.test.ts
+++ b/packages/@smolitux/voice-control/__tests__/WebSpeechRecognitionEngine.test.ts
@@ -1,0 +1,8 @@
+import { WebSpeechRecognitionEngine } from '../src/engines/WebSpeechRecognitionEngine';
+
+describe('WebSpeechRecognitionEngine', () => {
+  test('isSupported returns boolean', () => {
+    const engine = new WebSpeechRecognitionEngine();
+    expect(typeof engine.isSupported()).toBe('boolean');
+  });
+});

--- a/packages/@smolitux/voice-control/jest.config.js
+++ b/packages/@smolitux/voice-control/jest.config.js
@@ -1,0 +1,2 @@
+const base = require('../../jest.config');
+module.exports = { ...base, rootDir: __dirname };

--- a/packages/@smolitux/voice-control/package.json
+++ b/packages/@smolitux/voice-control/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@smolitux/voice-control",
+  "version": "0.2.1",
+  "description": "Voice control utilities for Smolitux UI",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "build:js": "tsup src/index.ts --format cjs,esm",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test": "jest",
+    "build:types": "tsc --emitDeclarationOnly"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "tsup": "^8.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
+  },
+  "dependencies": {
+    "@tensorflow/tfjs": "^4.22.0",
+    "@tensorflow-models/speech-commands": "^0.5.4"
+  }
+}

--- a/packages/@smolitux/voice-control/src/CommandProcessor.ts
+++ b/packages/@smolitux/voice-control/src/CommandProcessor.ts
@@ -1,0 +1,16 @@
+export class CommandProcessor {
+  processCommand(
+    text: string,
+    registeredComponents: Map<string, string[]>
+  ): { command: string; targetId: string } | { command: null; targetId: null } {
+    const normalized = text.toLowerCase().trim();
+    for (const [componentId, commands] of registeredComponents.entries()) {
+      for (const command of commands) {
+        if (normalized.includes(command.toLowerCase())) {
+          return { command, targetId: componentId };
+        }
+      }
+    }
+    return { command: null, targetId: null };
+  }
+}

--- a/packages/@smolitux/voice-control/src/FeedbackManager.ts
+++ b/packages/@smolitux/voice-control/src/FeedbackManager.ts
@@ -1,0 +1,62 @@
+export class FeedbackManager {
+  private audioContext: AudioContext | null = null;
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      document.addEventListener(
+        'click',
+        () => {
+          if (!this.audioContext) {
+            this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+          }
+        },
+        { once: true }
+      );
+    }
+  }
+
+  provideFeedback(type: 'start' | 'stop' | 'command', command?: string) {
+    this.provideVisualFeedback(type, command);
+    this.provideAudioFeedback(type);
+  }
+
+  private provideVisualFeedback(type: 'start' | 'stop' | 'command', command?: string) {
+    const el = document.getElementById('voice-feedback');
+    if (!el) return;
+    switch (type) {
+      case 'start':
+        el.textContent = 'Spracherkennung aktiv';
+        el.classList.add('listening');
+        break;
+      case 'stop':
+        el.textContent = 'Spracherkennung gestoppt';
+        el.classList.remove('listening');
+        break;
+      case 'command':
+        el.textContent = `Befehl erkannt: ${command}`;
+        break;
+    }
+  }
+
+  private provideAudioFeedback(type: 'start' | 'stop' | 'command') {
+    if (!this.audioContext) return;
+    const oscillator = this.audioContext.createOscillator();
+    const gainNode = this.audioContext.createGain();
+    oscillator.connect(gainNode);
+    gainNode.connect(this.audioContext.destination);
+    switch (type) {
+      case 'start':
+        oscillator.frequency.value = 880;
+        break;
+      case 'stop':
+        oscillator.frequency.value = 440;
+        break;
+      case 'command':
+        oscillator.frequency.value = 660;
+        break;
+    }
+    gainNode.gain.value = 0.1;
+    oscillator.start();
+    setTimeout(() => oscillator.stop(), 100);
+  }
+}

--- a/packages/@smolitux/voice-control/src/VoiceControlManager.ts
+++ b/packages/@smolitux/voice-control/src/VoiceControlManager.ts
@@ -1,0 +1,83 @@
+import { RecognitionEngine } from './engines/RecognitionEngine';
+import { WebSpeechRecognitionEngine } from './engines/WebSpeechRecognitionEngine';
+import { TensorFlowRecognitionEngine } from './engines/TensorFlowRecognitionEngine';
+import { CommandProcessor } from './CommandProcessor';
+import { FeedbackManager } from './FeedbackManager';
+
+export type EngineType = 'webSpeech' | 'tensorFlow' | 'external';
+
+export class VoiceControlManager {
+  private recognitionEngine: RecognitionEngine;
+  private commandProcessor: CommandProcessor;
+  private feedbackManager: FeedbackManager;
+  private registeredComponents: Map<string, string[]> = new Map();
+
+  public onRecognitionResult: (text: string) => void = () => {};
+  public onCommandRecognized: (command: string, target: string) => void = () => {};
+  public onListeningStateChanged: (isListening: boolean) => void = () => {};
+
+  constructor(engineType: EngineType = 'webSpeech', language = 'de-DE') {
+    switch (engineType) {
+      case 'tensorFlow':
+        this.recognitionEngine = new TensorFlowRecognitionEngine();
+        break;
+      case 'external':
+        this.recognitionEngine = new WebSpeechRecognitionEngine(language);
+        break;
+      case 'webSpeech':
+      default:
+        this.recognitionEngine = new WebSpeechRecognitionEngine(language);
+        break;
+    }
+
+    if (!this.recognitionEngine.isSupported()) {
+      console.warn('Selected recognition engine not supported, falling back to Web Speech API.');
+      this.recognitionEngine = new WebSpeechRecognitionEngine(language);
+    }
+
+    this.commandProcessor = new CommandProcessor();
+    this.feedbackManager = new FeedbackManager();
+
+    this.setupEventListeners();
+  }
+
+  private setupEventListeners() {
+    this.recognitionEngine.onResult = (text) => {
+      this.onRecognitionResult(text);
+      const { command, targetId } = this.commandProcessor.processCommand(
+        text,
+        this.registeredComponents
+      );
+      if (command && targetId) {
+        this.onCommandRecognized(command, targetId);
+        this.feedbackManager.provideFeedback('command', command);
+      }
+    };
+
+    this.recognitionEngine.onStateChange = (isListening) => {
+      this.onListeningStateChanged(isListening);
+    };
+  }
+
+  public startListening() {
+    this.recognitionEngine.start();
+    this.feedbackManager.provideFeedback('start');
+  }
+
+  public stopListening() {
+    this.recognitionEngine.stop();
+    this.feedbackManager.provideFeedback('stop');
+  }
+
+  public registerComponent(id: string, commands: string[]) {
+    this.registeredComponents.set(id, commands);
+  }
+
+  public unregisterComponent(id: string) {
+    this.registeredComponents.delete(id);
+  }
+
+  public cleanup() {
+    this.recognitionEngine.cleanup();
+  }
+}

--- a/packages/@smolitux/voice-control/src/VoiceControlProvider.tsx
+++ b/packages/@smolitux/voice-control/src/VoiceControlProvider.tsx
@@ -1,0 +1,88 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { VoiceControlManager, EngineType } from './VoiceControlManager';
+
+interface VoiceControlContextType {
+  isListening: boolean;
+  startListening: () => void;
+  stopListening: () => void;
+  recognizedText: string;
+  lastCommand: string;
+  targetComponent: string | null;
+  registerComponent: (id: string, commands: string[]) => void;
+  unregisterComponent: (id: string) => void;
+}
+
+interface VoiceControlProviderProps {
+  children: ReactNode;
+  engineType?: EngineType;
+  language?: string;
+  debug?: boolean;
+}
+
+const VoiceControlContext = createContext<VoiceControlContextType | undefined>(undefined);
+
+export const VoiceControlProvider: React.FC<VoiceControlProviderProps> = ({
+  children,
+  engineType = 'webSpeech',
+  language = 'de-DE',
+  debug = false,
+}) => {
+  const [manager] = useState(() => new VoiceControlManager(engineType, language));
+  const [isListening, setIsListening] = useState(false);
+  const [recognizedText, setRecognizedText] = useState('');
+  const [lastCommand, setLastCommand] = useState('');
+  const [targetComponent, setTargetComponent] = useState<string | null>(null);
+
+  useEffect(() => {
+    manager.onRecognitionResult = (text) => {
+      setRecognizedText(text);
+      if (debug) console.log('Recognized text:', text);
+    };
+
+    manager.onCommandRecognized = (command, target) => {
+      setLastCommand(command);
+      setTargetComponent(target);
+      if (debug) console.log(`Command recognized: ${command}, Target: ${target}`);
+    };
+
+    manager.onListeningStateChanged = (listening) => {
+      setIsListening(listening);
+      if (debug) console.log('Listening state changed:', listening);
+    };
+
+    return () => {
+      manager.cleanup();
+    };
+  }, [manager, debug]);
+
+  const startListening = () => manager.startListening();
+  const stopListening = () => manager.stopListening();
+  const registerComponent = (id: string, commands: string[]) => manager.registerComponent(id, commands);
+  const unregisterComponent = (id: string) => manager.unregisterComponent(id);
+
+  return (
+    <VoiceControlContext.Provider
+      value={{
+        isListening,
+        startListening,
+        stopListening,
+        recognizedText,
+        lastCommand,
+        targetComponent,
+        registerComponent,
+        unregisterComponent,
+      }}
+    >
+      {children}
+      <div id="voice-feedback" aria-live="polite" style={{ position: 'absolute', top: -9999 }} />
+    </VoiceControlContext.Provider>
+  );
+};
+
+export const useVoiceControl = () => {
+  const context = useContext(VoiceControlContext);
+  if (context === undefined) {
+    throw new Error('useVoiceControl must be used within a VoiceControlProvider');
+  }
+  return context;
+};

--- a/packages/@smolitux/voice-control/src/engines/RecognitionEngine.ts
+++ b/packages/@smolitux/voice-control/src/engines/RecognitionEngine.ts
@@ -1,0 +1,8 @@
+export interface RecognitionEngine {
+  onResult: (text: string) => void;
+  onStateChange: (isListening: boolean) => void;
+  start(): void;
+  stop(): void;
+  cleanup(): void;
+  isSupported(): boolean;
+}

--- a/packages/@smolitux/voice-control/src/engines/TensorFlowRecognitionEngine.ts
+++ b/packages/@smolitux/voice-control/src/engines/TensorFlowRecognitionEngine.ts
@@ -1,0 +1,75 @@
+import * as tf from '@tensorflow/tfjs';
+import * as speech from '@tensorflow-models/speech-commands';
+import { RecognitionEngine } from './RecognitionEngine';
+
+export class TensorFlowRecognitionEngine implements RecognitionEngine {
+  private model: speech.SpeechCommandRecognizer | null = null;
+  private listening = false;
+  private commandVocabulary: string[] = [];
+
+  public onResult: (text: string) => void = () => {};
+  public onStateChange: (isListening: boolean) => void = () => {};
+
+  constructor() {
+    this.initModel();
+  }
+
+  private async initModel() {
+    try {
+      this.model = speech.create('BROWSER_FFT');
+      await this.model.ensureModelLoaded();
+      this.commandVocabulary = this.model.wordLabels();
+      (this.model.params() as any).scoreThreshold = 0.75;
+      // warmup
+      await tf.ready();
+    } catch (error) {
+      console.error('Failed to load TensorFlow.js speech model:', error);
+    }
+  }
+
+  public async start() {
+    if (!this.model) {
+      await this.initModel();
+    }
+
+    if (this.model && !this.listening) {
+      this.listening = true;
+      this.onStateChange(true);
+      this.model.listen(
+        (result) => {
+          const scores = Array.from(result.scores as Float32Array);
+          const maxScore = Math.max(...scores);
+          const maxIndex = scores.indexOf(maxScore);
+          if (maxScore > ((this.model!.params() as any).scoreThreshold || 0)) {
+            const recognizedCommand = this.commandVocabulary[maxIndex];
+            this.onResult(recognizedCommand);
+          }
+        },
+        {
+          includeSpectrogram: false,
+          probabilityThreshold: 0.75,
+          overlapFactor: 0.5,
+        }
+      );
+    }
+  }
+
+  public stop() {
+    if (this.model && this.listening) {
+      this.model.stopListening();
+      this.listening = false;
+      this.onStateChange(false);
+    }
+  }
+
+  public cleanup() {
+    this.stop();
+    if (this.model) {
+      this.model.stopListening();
+    }
+  }
+
+  public isSupported() {
+    return true;
+  }
+}

--- a/packages/@smolitux/voice-control/src/engines/WebSpeechRecognitionEngine.ts
+++ b/packages/@smolitux/voice-control/src/engines/WebSpeechRecognitionEngine.ts
@@ -1,0 +1,85 @@
+import { RecognitionEngine } from './RecognitionEngine';
+
+export class WebSpeechRecognitionEngine implements RecognitionEngine {
+  private recognition: any = null;
+  private listening = false;
+  private supported = false;
+
+  public onResult: (text: string) => void = () => {};
+  public onStateChange: (isListening: boolean) => void = () => {};
+
+  constructor(language = 'de-DE') {
+    const SpeechRecognitionConstructor =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (SpeechRecognitionConstructor) {
+      this.supported = true;
+      this.recognition = new SpeechRecognitionConstructor();
+      this.recognition.lang = language;
+      this.recognition.continuous = true;
+      this.recognition.interimResults = false;
+      this.setupEventListeners();
+    } else {
+      this.supported = false;
+      console.warn('Speech recognition is not supported in this browser.');
+    }
+  }
+
+  private setupEventListeners() {
+    if (!this.recognition) return;
+    this.recognition.onresult = (event: any) => {
+      const last = event.results.length - 1;
+      const text = event.results[last][0].transcript;
+      this.onResult(text);
+    };
+
+    this.recognition.onstart = () => {
+      this.listening = true;
+      this.onStateChange(true);
+    };
+
+    this.recognition.onend = () => {
+      this.listening = false;
+      this.onStateChange(false);
+    };
+
+    this.recognition.onerror = (event: any) => {
+      console.error('Speech recognition error', event.error);
+      this.listening = false;
+      this.onStateChange(false);
+    };
+  }
+
+  public start() {
+    if (!this.supported) {
+      this.onStateChange(false);
+      return;
+    }
+    if (this.recognition && !this.listening) {
+      this.recognition.start();
+    }
+  }
+
+  public stop() {
+    if (!this.supported) {
+      this.onStateChange(false);
+      return;
+    }
+    if (this.recognition && this.listening) {
+      this.recognition.stop();
+    }
+  }
+
+  public cleanup() {
+    this.stop();
+    if (this.recognition) {
+      this.recognition.onresult = null;
+      this.recognition.onstart = null;
+      this.recognition.onend = null;
+      this.recognition.onerror = null;
+    }
+  }
+
+  public isSupported() {
+    return this.supported;
+  }
+}

--- a/packages/@smolitux/voice-control/src/index.ts
+++ b/packages/@smolitux/voice-control/src/index.ts
@@ -1,0 +1,7 @@
+export { VoiceControlProvider, useVoiceControl } from './VoiceControlProvider';
+export { withVoiceControl } from './withVoiceControl';
+export type { VoiceControlProps } from './withVoiceControl';
+export { VoiceControlManager } from './VoiceControlManager';
+export type { EngineType } from './VoiceControlManager';
+export { WebSpeechRecognitionEngine } from './engines/WebSpeechRecognitionEngine';
+export { TensorFlowRecognitionEngine } from './engines/TensorFlowRecognitionEngine';

--- a/packages/@smolitux/voice-control/src/withVoiceControl.tsx
+++ b/packages/@smolitux/voice-control/src/withVoiceControl.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useId } from 'react';
+import { useVoiceControl } from './VoiceControlProvider';
+
+export interface VoiceControlProps {
+  voiceCommands?: string[];
+  voiceEnabled?: boolean;
+  onVoiceCommand?: (command: string) => void;
+}
+
+export function withVoiceControl<P extends object>(
+  Component: React.ComponentType<P>,
+  defaultCommands: string[] = []
+) {
+  return React.forwardRef<unknown, P & VoiceControlProps>((props, ref) => {
+    const { voiceCommands = defaultCommands, voiceEnabled = true, onVoiceCommand, ...rest } = props;
+    const id = useId();
+    const { registerComponent, unregisterComponent, targetComponent, lastCommand } = useVoiceControl();
+    const componentRef = useRef<HTMLElement>(null);
+
+    useEffect(() => {
+      if (voiceEnabled && voiceCommands.length > 0) {
+        registerComponent(id, voiceCommands);
+      }
+      return () => {
+        if (voiceEnabled) {
+          unregisterComponent(id);
+        }
+      };
+    }, [id, registerComponent, unregisterComponent, voiceEnabled, voiceCommands]);
+
+    useEffect(() => {
+      if (targetComponent === id && lastCommand && onVoiceCommand) {
+        onVoiceCommand(lastCommand);
+      }
+    }, [id, lastCommand, onVoiceCommand, targetComponent]);
+
+    return <Component ref={ref || componentRef} {...(rest as P)} />;
+  });
+}

--- a/packages/@smolitux/voice-control/tsconfig.json
+++ b/packages/@smolitux/voice-control/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary
- document theme integration for the voice-control architecture

## Testing
- `npm run lint` *(fails: Cannot find module 'typescript')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: lerna not found)*
- `cd docs && npm run build` *(fails to find docusaurus package)*

------
https://chatgpt.com/codex/tasks/task_e_684465a4f710832487a13af2593f569c