### PR TITLE
docs: resolve #176 – add typedoc setup

### DIFF
--- a/docs/wiki/api/generated/README.md
+++ b/docs/wiki/api/generated/README.md
@@ -1,0 +1,4 @@
+# Automatisch generierte API-Dokumentation
+
+Diese Dateien werden von [TypeDoc](https://typedoc.org/) erzeugt.
+Führe `npm run docs:api` aus, um sie zu aktualisieren.

--- a/docs/wiki/api/reference.md
+++ b/docs/wiki/api/reference.md
@@ -293,3 +293,5 @@ function MyComponent() {
 | `themeMode` | `'light' \| 'dark'` | Der aktuelle Theme-Modus |
 | `setThemeMode` | `(mode: 'light' \| 'dark') => void` | Funktion zum Ändern des Theme-Modus |
 | `toggleThemeMode` | `() => void` | Funktion zum Umschalten des Theme-Modus |
+## Automatische API-Dokumentation
+Weitere Details findest du im Verzeichnis [generated](./generated). Führe `npm run docs:api` aus, um die Dokumentation zu aktualisieren.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "dev": "lerna run dev --parallel",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "docs:api": "typedoc"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
@@ -112,7 +113,9 @@
     "ts-jest": "^29.3.0",
     "tsup": "^6.7.0",
     "typescript": "^5.8.2",
-    "typescript-eslint": "^8.28.0"
+    "typescript-eslint": "^8.28.0",
+    "typedoc": "^0.25.2",
+    "typedoc-plugin-markdown": "^3.14.0"
   },
   "dependencies": {
     "esbuild": "^0.19.12",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+{
+  "entryPoints": [
+    "packages/@smolitux/core/src/index.ts",
+    "packages/@smolitux/layout/src/index.ts",
+    "packages/@smolitux/charts/src/index.ts",
+    "packages/@smolitux/theme/src/index.ts"
+  ],
+  "tsconfig": "./tsconfig.json",
+  "out": "docs/wiki/api/generated",
+  "name": "Smolitux UI",
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "includeVersion": true,
+  "plugin": ["typedoc-plugin-markdown"],
+  "readme": "none"
+}


### PR DESCRIPTION
## Summary
- configure typedoc and typedoc-plugin-markdown
- add `docs:api` script
- document generated API docs in wiki

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*
- `cd docs && npm run build` *(fails: cannot find @docusaurus/logger)*


------
https://chatgpt.com/codex/tasks/task_e_6844833851b8832486b9ed1887b50e3f