### PR TITLE
docs: resolve #175 #176 – add Storybook guide

### DIFF
--- a/docs/wiki/api/generated/README.md
+++ b/docs/wiki/api/generated/README.md
@@ -1,0 +1,4 @@
+# Automatisch generierte API-Dokumentation
+
+Diese Dateien werden von [TypeDoc](https://typedoc.org/) erzeugt.
+Führe `npm run docs:api` aus, um sie zu aktualisieren.

--- a/docs/wiki/api/reference.md
+++ b/docs/wiki/api/reference.md
@@ -293,3 +293,5 @@ function MyComponent() {
 | `themeMode` | `'light' \| 'dark'` | Der aktuelle Theme-Modus |
 | `setThemeMode` | `(mode: 'light' \| 'dark') => void` | Funktion zum Ändern des Theme-Modus |
 | `toggleThemeMode` | `() => void` | Funktion zum Umschalten des Theme-Modus |
+## Automatische API-Dokumentation
+Weitere Details findest du im Verzeichnis [generated](./generated). Führe `npm run docs:api` aus, um die Dokumentation zu aktualisieren.

--- a/docs/wiki/development/storybook-guide.md
+++ b/docs/wiki/development/storybook-guide.md
@@ -1,0 +1,62 @@
+# Storybook Leitfaden
+
+Storybook dient der interaktiven Dokumentation aller Komponenten von **Smolitux UI**. Dieses Dokument beschreibt die grundlegende Struktur der Stories und wie du Storybook nutzen kannst.
+
+## Storybook starten
+
+Führe im Projektverzeichnis folgenden Befehl aus:
+
+```bash
+npm run storybook
+```
+
+Anschließend ist die Oberfläche unter <http://localhost:6006> erreichbar.
+
+## Struktur der Stories
+
+- Alle Stories liegen neben den jeweiligen Komponenten und haben die Endung `.stories.tsx`.
+- Barrierefreiheits-Tests werden in Dateien mit `.a11y.stories.tsx` gepflegt.
+- Die globale Konfiguration befindet sich im Verzeichnis `.storybook/`.
+
+## Beispiel einer Story
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Core/Button',
+  component: Button,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Primärer Button für Benutzeraktionen',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: {
+    children: 'Klick mich',
+  },
+};
+```
+
+## Storybook bauen
+
+Um ein statisches Storybook zu erzeugen, nutze:
+
+```bash
+npm run build-storybook
+```
+
+Das Ergebnis findest du im Ordner `storybook-static`. Dieses Verzeichnis kann direkt auf einem Webserver bereitgestellt werden.
+
+## Weitere Links
+
+- [Dokumentationsstrategie](./documentation-strategy.md)
+- [API-Referenz](../api/reference.md)

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -73,6 +73,7 @@ Our component library is organized into functional categories for easy navigatio
 
 - **[Getting Started](guides/quickstart.md)** - Quick start guide to using our components
 - **[Development Guide](development/guide.md)** - Guide for developers working on the project
+- **[Storybook Guide](development/storybook-guide.md)** - Aufbau und Nutzung des Storybooks
 - **[Contributing](development/contributing.md)** - How to contribute to the project
 - **[Changelog](development/changelog.md)** - History of changes
 - **[Release Notes](development/releases/v0.2.2.md)** - Latest release notes

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "dev": "lerna run dev --parallel",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "docs:api": "typedoc"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
@@ -112,7 +113,9 @@
     "ts-jest": "^29.3.0",
     "tsup": "^6.7.0",
     "typescript": "^5.8.2",
-    "typescript-eslint": "^8.28.0"
+    "typescript-eslint": "^8.28.0",
+    "typedoc": "^0.25.2",
+    "typedoc-plugin-markdown": "^3.14.0"
   },
   "dependencies": {
     "esbuild": "^0.19.12",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+{
+  "entryPoints": [
+    "packages/@smolitux/core/src/index.ts",
+    "packages/@smolitux/layout/src/index.ts",
+    "packages/@smolitux/charts/src/index.ts",
+    "packages/@smolitux/theme/src/index.ts"
+  ],
+  "tsconfig": "./tsconfig.json",
+  "out": "docs/wiki/api/generated",
+  "name": "Smolitux UI",
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "includeVersion": true,
+  "plugin": ["typedoc-plugin-markdown"],
+  "readme": "none"
+}


### PR DESCRIPTION
## Summary
- configure typedoc via `typedoc.json` and `docs:api` script
- document generated API docs
- add new **Storybook Guide** to development docs
- link the Storybook guide from `index.md`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*
- `cd docs && npm run build` *(fails: cannot find @docusaurus/logger)*


------
https://chatgpt.com/codex/tasks/task_e_6844833851b8832486b9ed1887b50e3f