### PR TITLE
Add missing Storybook stories

### DIFF
--- a/packages/@smolitux/core/src/components/TextArea/stories/TextArea.stories.tsx
+++ b/packages/@smolitux/core/src/components/TextArea/stories/TextArea.stories.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { TextArea } from '../TextArea';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'Core/Forms/TextArea',
+  component: TextArea,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text', description: 'Label des TextAreas' },
+    helperText: { control: 'text', description: 'Hilfetext unter dem Feld' },
+    error: { control: 'text', description: 'Fehlermeldung' },
+    size: {
+      control: { type: 'select', options: ['sm', 'md', 'lg'] },
+      description: 'Groesse des TextAreas',
+    },
+    variant: {
+      control: { type: 'select', options: ['outline', 'filled', 'unstyled', 'flushed'] },
+      description: 'Visuelle Variante',
+    },
+    fullWidth: { control: 'boolean', description: 'Breite 100% einnehmen' },
+    autoResize: { control: 'boolean', description: 'Passt Hoehe automatisch an' },
+    rows: { control: 'number', description: 'Anzahl der Zeilen' },
+    maxLength: { control: 'number', description: 'Maximale Zeichenanzahl' },
+    showCount: { control: 'boolean', description: 'Zeichenzahl anzeigen' },
+    placeholder: { control: 'text', description: 'Platzhaltertext' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+export const Basic: Story = {
+  args: {
+    label: 'Beschreibung',
+    placeholder: 'Geben Sie eine Beschreibung ein',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-80">
+      <TextArea size="sm" placeholder="Small" />
+      <TextArea size="md" placeholder="Medium" />
+      <TextArea size="lg" placeholder="Large" />
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-80">
+      <TextArea variant="outline" placeholder="Outline" />
+      <TextArea variant="filled" placeholder="Filled" />
+      <TextArea variant="flushed" placeholder="Flushed" />
+      <TextArea variant="unstyled" placeholder="Unstyled" />
+    </div>
+  ),
+};
+
+export const WithCounter: Story = {
+  args: {
+    label: 'Kommentar',
+    maxLength: 100,
+    showCount: true,
+    placeholder: 'Maximal 100 Zeichen',
+  },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceButton.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceButton.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceButton } from '../VoiceButton';
+
+const meta: Meta<typeof VoiceButton> = {
+  title: 'Core/Voice/VoiceButton',
+  component: VoiceButton,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    children: { control: 'text', description: 'Buttoninhalt' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceButton>;
+
+export const Basic: Story = {
+  args: { children: 'Sprechen oder klicken' },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceCard.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceCard.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceCard } from '../VoiceCard';
+
+const meta: Meta<typeof VoiceCard> = {
+  title: 'Core/Voice/VoiceCard',
+  component: VoiceCard,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    collapsible: { control: 'boolean' },
+    expandable: { control: 'boolean' },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceCard>;
+
+export const Basic: Story = {
+  args: { children: 'Sprachgesteuerte Karte' },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceInput.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceInput.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceInput } from '../VoiceInput';
+
+const meta: Meta<typeof VoiceInput> = {
+  title: 'Core/Voice/VoiceInput',
+  component: VoiceInput,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: { control: 'text', description: 'Platzhaltertext' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceInput>;
+
+export const Basic: Story = {
+  args: { placeholder: 'Sprich einen Text' },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceModal.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceModal.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceModal } from '../VoiceModal';
+
+const meta: Meta<typeof VoiceModal> = {
+  title: 'Core/Voice/VoiceModal',
+  component: VoiceModal,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: { control: 'boolean', description: 'Modal geöffnet' },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceModal>;
+
+export const Basic: Story = {
+  args: {
+    isOpen: true,
+    children: <div className="p-4">Sprich \"schließen\" um das Modal zu schließen.</div>,
+  },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceSelect.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceSelect.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceSelect } from '../VoiceSelect';
+
+const meta: Meta<typeof VoiceSelect> = {
+  title: 'Core/Voice/VoiceSelect',
+  component: VoiceSelect,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    options: { control: 'object', description: 'Auswahloptionen' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceSelect>;
+
+export const Basic: Story = {
+  args: {
+    options: ['Option 1', 'Option 2', 'Option 3'],
+  },
+};


### PR DESCRIPTION
## Summary
- add stories for TextArea component
- add basic stories for voice components

## Testing
- `npx eslint --config eslint.config.js "packages/**/*.{ts,tsx}"` *(fails: 1195 problems)*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*
- `cd docs && npm run build` *(fails: cannot find package '@docusaurus/logger')*

------
https://chatgpt.com/codex/tasks/task_e_684483b5031c832491dbf761db7869e3