### PR TITLE
Add voice component documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Eine moderne React-Komponentenbibliothek für die einheitliche Gestaltung von MV
 - **@smolitux/icons**: Icon-Bibliothek
 - **@smolitux/layout**: Layout-Komponenten
 - **@smolitux/charts**: Diagramm-Komponenten
+- **@smolitux/voice-control**: Sprachsteuerung für UI-Elemente
 - **@smolitux/types**: Gemeinsame TypeScript-Typen
 
 ## 🚀 Installation
@@ -134,6 +135,14 @@ Die smolitux UI Bibliothek enthält folgende Komponenten:
 - BarChart
 - PieChart
 - AreaChart
+
+### Voice
+
+- VoiceButton
+- VoiceInput
+- VoiceSelect
+- VoiceCard
+- VoiceModal
 
 ## 🎨 Theme Anpassung
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -136,6 +136,12 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           items: ['components/resonance/index'],
         },
+        {
+          type: 'category',
+          label: 'Voice',
+          collapsed: true,
+          items: ['components/voice/index'],
+        },
       ],
     },
     {

--- a/docs/wiki/components/README.md
+++ b/docs/wiki/components/README.md
@@ -15,6 +15,7 @@ Diese Dokumentation beschreibt die verfügbaren Komponenten in der Smolitux UI-B
 - [KI-Komponenten](#ki-komponenten)
   - [TrendingTopics](#trendingtopics)
   - [EngagementScore](#engagementscore)
+  - [Voice-Komponenten](#voice-komponenten)
 - [Styling](#styling)
 - [Theming](#theming)
 - [Barrierefreiheit](#barrierefreiheit)
@@ -251,6 +252,10 @@ function Example() {
   );
 }
 ```
+
+## Voice-Komponenten
+
+Die Voice-Komponenten integrieren Sprachbefehle in Standard-UI-Elemente. Eine Übersicht befindet sich unter [Voice-Komponenten](/docs/components/voice/index).
 
 ## Styling
 

--- a/docs/wiki/components/overview.md
+++ b/docs/wiki/components/overview.md
@@ -97,3 +97,9 @@ Komponenten fuer die Anzeige von Medieninhalten.
 Komponenten zur Visualisierung von Daten.
 
 - [LineChart](/docs/components/charts/line-chart) - Liniendiagramm
+
+## Voice-Komponenten
+
+Komponenten mit integrierter Sprachsteuerung.
+
+- [Voice-Komponenten](/docs/components/voice/index) - Buttons, Inputs und mehr

--- a/docs/wiki/components/voice/index.md
+++ b/docs/wiki/components/voice/index.md
@@ -1,0 +1,46 @@
+# Voice-Komponenten
+
+Die Voice-Komponenten ermöglichen die Steuerung von UI-Elementen per Sprache. Grundlage ist der `VoiceControlProvider` aus `@smolitux/voice-control`.
+
+## VoiceButton
+
+```tsx
+import { VoiceButton } from '@smolitux/core';
+
+<VoiceButton id="submit" onClick={() => alert('gesendet')}>Sprechen oder klicken</VoiceButton>
+```
+
+## VoiceInput
+
+```tsx
+import { VoiceInput } from '@smolitux/core';
+
+<VoiceInput label="Nachricht" placeholder="Diktieren Sie Ihre Nachricht" />
+```
+
+## VoiceSelect
+
+```tsx
+import { VoiceSelect } from '@smolitux/core';
+
+<VoiceSelect label="Sprache" options={[{ value: 'de', label: 'Deutsch' }, { value: 'en', label: 'Englisch' }]} />
+```
+
+## VoiceCard
+
+```tsx
+import { VoiceCard } from '@smolitux/core';
+
+<VoiceCard voiceCommands={["öffnen", "open"]}>Inhalt</VoiceCard>
+```
+
+## VoiceModal
+
+```tsx
+import { VoiceModal, VoiceButton } from '@smolitux/core';
+
+<VoiceButton id="open-modal">Modal öffnen</VoiceButton>
+<VoiceModal triggerId="open-modal" voiceCommands={["schließen"]}>
+  <p>Sprachgesteuertes Modal</p>
+</VoiceModal>
+```

--- a/packages/@smolitux/core/src/components/TextArea/stories/TextArea.stories.tsx
+++ b/packages/@smolitux/core/src/components/TextArea/stories/TextArea.stories.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { TextArea } from '../TextArea';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'Core/Forms/TextArea',
+  component: TextArea,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text', description: 'Label des TextAreas' },
+    helperText: { control: 'text', description: 'Hilfetext unter dem Feld' },
+    error: { control: 'text', description: 'Fehlermeldung' },
+    size: {
+      control: { type: 'select', options: ['sm', 'md', 'lg'] },
+      description: 'Groesse des TextAreas',
+    },
+    variant: {
+      control: { type: 'select', options: ['outline', 'filled', 'unstyled', 'flushed'] },
+      description: 'Visuelle Variante',
+    },
+    fullWidth: { control: 'boolean', description: 'Breite 100% einnehmen' },
+    autoResize: { control: 'boolean', description: 'Passt Hoehe automatisch an' },
+    rows: { control: 'number', description: 'Anzahl der Zeilen' },
+    maxLength: { control: 'number', description: 'Maximale Zeichenanzahl' },
+    showCount: { control: 'boolean', description: 'Zeichenzahl anzeigen' },
+    placeholder: { control: 'text', description: 'Platzhaltertext' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+export const Basic: Story = {
+  args: {
+    label: 'Beschreibung',
+    placeholder: 'Geben Sie eine Beschreibung ein',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-80">
+      <TextArea size="sm" placeholder="Small" />
+      <TextArea size="md" placeholder="Medium" />
+      <TextArea size="lg" placeholder="Large" />
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4 w-80">
+      <TextArea variant="outline" placeholder="Outline" />
+      <TextArea variant="filled" placeholder="Filled" />
+      <TextArea variant="flushed" placeholder="Flushed" />
+      <TextArea variant="unstyled" placeholder="Unstyled" />
+    </div>
+  ),
+};
+
+export const WithCounter: Story = {
+  args: {
+    label: 'Kommentar',
+    maxLength: 100,
+    showCount: true,
+    placeholder: 'Maximal 100 Zeichen',
+  },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceButton.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceButton.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceButton } from '../VoiceButton';
+
+const meta: Meta<typeof VoiceButton> = {
+  title: 'Core/Voice/VoiceButton',
+  component: VoiceButton,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    children: { control: 'text', description: 'Buttoninhalt' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceButton>;
+
+export const Basic: Story = {
+  args: { children: 'Sprechen oder klicken' },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceCard.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceCard.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceCard } from '../VoiceCard';
+
+const meta: Meta<typeof VoiceCard> = {
+  title: 'Core/Voice/VoiceCard',
+  component: VoiceCard,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    collapsible: { control: 'boolean' },
+    expandable: { control: 'boolean' },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceCard>;
+
+export const Basic: Story = {
+  args: { children: 'Sprachgesteuerte Karte' },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceInput.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceInput.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceInput } from '../VoiceInput';
+
+const meta: Meta<typeof VoiceInput> = {
+  title: 'Core/Voice/VoiceInput',
+  component: VoiceInput,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: { control: 'text', description: 'Platzhaltertext' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceInput>;
+
+export const Basic: Story = {
+  args: { placeholder: 'Sprich einen Text' },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceModal.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceModal.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceModal } from '../VoiceModal';
+
+const meta: Meta<typeof VoiceModal> = {
+  title: 'Core/Voice/VoiceModal',
+  component: VoiceModal,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: { control: 'boolean', description: 'Modal geöffnet' },
+    children: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceModal>;
+
+export const Basic: Story = {
+  args: {
+    isOpen: true,
+    children: <div className="p-4">Sprich \"schließen\" um das Modal zu schließen.</div>,
+  },
+};

--- a/packages/@smolitux/core/src/components/voice/stories/VoiceSelect.stories.tsx
+++ b/packages/@smolitux/core/src/components/voice/stories/VoiceSelect.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceSelect } from '../VoiceSelect';
+
+const meta: Meta<typeof VoiceSelect> = {
+  title: 'Core/Voice/VoiceSelect',
+  component: VoiceSelect,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    options: { control: 'object', description: 'Auswahloptionen' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceSelect>;
+
+export const Basic: Story = {
+  args: {
+    options: ['Option 1', 'Option 2', 'Option 3'],
+  },
+};


### PR DESCRIPTION
## Summary
- document the `@smolitux/voice-control` package in the README
- list available Voice components
- link new voice documentation in the wiki
- add a Voice section in the docs sidebar

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*
- `cd docs && npm run build` *(fails: cannot find package '@docusaurus/logger')*

------
https://chatgpt.com/codex/tasks/task_e_684483b5031c832491dbf761db7869e3