### PR TITLE
feat(layout): responsive sidebar

### DIFF
--- a/packages/@smolitux/layout/src/components/Sidebar/Sidebar.a11y.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/Sidebar.a11y.tsx
@@ -1,6 +1,7 @@
 // packages/@smolitux/layout/src/components/Sidebar/Sidebar.a11y.tsx
 import React, { useState, useEffect, forwardRef } from 'react';
 import { useTheme } from '@smolitux/theme';
+import { breakpoints } from '@smolitux/utils/styling';
 import { SidebarProps, SidebarItem } from './Sidebar';
 
 export interface SidebarA11yProps extends SidebarProps {
@@ -538,6 +539,8 @@ export const SidebarA11y = forwardRef<HTMLDivElement, SidebarA11yProps>(({
   isBusy = false,
   isFocusable = false,
   tabIndex,
+  responsive = false,
+  collapseBreakpoint = 'md',
   hasOrientation = false,
   orientation = 'vertical',
   isMultiselectable = false,
@@ -616,6 +619,20 @@ export const SidebarA11y = forwardRef<HTMLDivElement, SidebarA11yProps>(({
   useEffect(() => {
     setIsCollapsed(collapsed);
   }, [collapsed]);
+
+  useEffect(() => {
+    if (!responsive) return;
+    const bp = typeof collapseBreakpoint === 'number'
+      ? collapseBreakpoint
+      : parseInt(breakpoints[collapseBreakpoint], 10);
+    const check = () => {
+      const shouldCollapse = window.innerWidth < bp;
+      setIsCollapsed(shouldCollapse ? true : collapsed);
+    };
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, [responsive, collapseBreakpoint, collapsed]);
   
   // Behandle das Umschalten des Collapse-Status
   const handleToggleCollapse = () => {

--- a/packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 // packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
 import React, { useState, useEffect, forwardRef } from 'react';
 import { useTheme } from '@smolitux/theme';
+import { breakpoints } from '@smolitux/utils/styling';
 
 export interface SidebarItem {
   /** Eindeutige ID des Items */
@@ -52,6 +53,10 @@ export interface SidebarProps {
   width?: string | number;
   /** Breite der Sidebar (eingeklappt) */
   collapsedWidth?: string | number;
+  /** Responsive Verhalten aktivieren */
+  responsive?: boolean;
+  /** Breakpoint ab dem die Sidebar automatisch einklappt */
+  collapseBreakpoint?: keyof typeof breakpoints | number;
   /** Footer-Inhalt */
   footer?: React.ReactNode;
 }
@@ -83,6 +88,8 @@ export const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(({
   variant = 'default',
   width = 240,
   collapsedWidth = 64,
+  responsive = false,
+  collapseBreakpoint = 'md',
   footer,
   className = '',
   ...rest
@@ -90,6 +97,20 @@ export const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(({
   const { themeMode } = useTheme();
   const [isCollapsed, setIsCollapsed] = useState(collapsed);
   const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!responsive) return;
+    const bp = typeof collapseBreakpoint === 'number'
+      ? collapseBreakpoint
+      : parseInt(breakpoints[collapseBreakpoint], 10);
+    const handle = () => {
+      const shouldCollapse = window.innerWidth < bp;
+      setIsCollapsed(shouldCollapse ? true : collapsed);
+    };
+    handle();
+    window.addEventListener('resize', handle);
+    return () => window.removeEventListener('resize', handle);
+  }, [responsive, collapseBreakpoint, collapsed]);
   
   // Synchronisiere externen und internen Collapse-Status
   useEffect(() => {

--- a/packages/@smolitux/layout/src/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { Sidebar } from '../';
+
+describe('Sidebar responsive behaviour', () => {
+  beforeEach(() => {
+    (window as any).innerWidth = 1024;
+  });
+
+  test('collapses below breakpoint when responsive', () => {
+    const { container } = render(
+      <Sidebar items={[{ id: 'home', label: 'Home' }]} responsive collapseBreakpoint="md" />
+    );
+    const sidebar = container.firstChild as HTMLElement;
+    expect(sidebar.style.width).toBe('240px');
+    act(() => {
+      (window as any).innerWidth = 500;
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(sidebar.style.width).toBe('64px');
+  });
+
+  test('does not collapse when responsive is false', () => {
+    (window as any).innerWidth = 500;
+    const { container } = render(
+      <Sidebar items={[{ id: 'home', label: 'Home' }]} responsive={false} />
+    );
+    const sidebar = container.firstChild as HTMLElement;
+    expect(sidebar.style.width).toBe('240px');
+  });
+});

--- a/packages/@smolitux/layout/src/components/Sidebar/stories/Sidebar.a11y.stories.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/stories/Sidebar.a11y.stories.tsx
@@ -46,6 +46,15 @@ const meta: Meta<typeof Sidebar.A11y> = {
       options: ['default', 'light', 'dark', 'transparent'],
       description: 'Variante der Sidebar'
     },
+    responsive: {
+      control: 'boolean',
+      description: 'Automatisch einklappen bei kleinem Bildschirm'
+    },
+    collapseBreakpoint: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg', 'xl', '2xl'],
+      description: 'Breakpoint zum automatischen Einklappen'
+    },
     ariaLabel: {
       control: 'text',
       description: 'ARIA-Label für die Sidebar'
@@ -270,6 +279,22 @@ export const Collapsible: Story = {
         </div>
       </div>
     );
+  }
+};
+
+export const Responsive: Story = {
+  args: {
+    title: 'Navigation',
+    ariaLabel: 'Hauptnavigation',
+    isNavigation: true,
+    responsive: true,
+    collapseBreakpoint: 'md',
+    items: [
+      { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
+      { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
+      { id: 'users', label: 'Users', icon: <UsersIcon /> },
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- enhance Sidebar with responsive collapse
- expose breakpoint props to A11y variant
- update Sidebar stories for Storybook
- add regression tests

## Testing
- `npx prettier --write` (formatting)
- `npm run build` *(fails: tsup not found)*
- `npm run lint` *(fails: missing ESLint dependencies)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bbc909d08324859c0fe4a3a12cdd