### PR TITLE
Implement Card type variants

### DIFF
--- a/docs/wiki/components/layout/card.md
+++ b/docs/wiki/components/layout/card.md
@@ -29,7 +29,7 @@ import { Card } from '@smolitux/core';
 ### Card mit Footer
 
 ```jsx
-<Card 
+<Card
   title="Meine Card"
   footer={
     <div className="flex justify-end">
@@ -44,12 +44,17 @@ import { Card } from '@smolitux/core';
 ### Card mit Header-Aktion
 
 ```jsx
-<Card 
+<Card
   title="Meine Card"
   headerAction={
     <button className="text-gray-500 hover:text-gray-700">
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+        />
       </svg>
     </button>
   }
@@ -87,36 +92,31 @@ import { Card } from '@smolitux/core';
 
 ## Props
 
-| Prop | Typ | Standard | Beschreibung |
-|------|-----|----------|-------------|
-| `children` | `ReactNode` | - | Der Inhalt der Card |
-| `title` | `string` | - | Der Titel der Card |
-| `className` | `string` | `''` | Zusätzliche CSS-Klassen |
-| `footer` | `ReactNode` | - | Der Inhalt des Footers |
-| `noPadding` | `boolean` | `false` | Entfernt das Padding im Inhaltsbereich |
-| `hoverable` | `boolean` | `false` | Aktiviert einen Hover-Effekt |
-| `bordered` | `boolean` | `true` | Zeigt einen Rand um die Card an |
-| `headerAction` | `ReactNode` | - | Aktion im Header (z.B. Button oder Icon) |
+| Prop           | Typ                                                                        | Standard | Beschreibung                             |
+| -------------- | -------------------------------------------------------------------------- | -------- | ---------------------------------------- |
+| `children`     | `ReactNode`                                                                | -        | Der Inhalt der Card                      |
+| `title`        | `string`                                                                   | -        | Der Titel der Card                       |
+| `className`    | `string`                                                                   | `''`     | Zusätzliche CSS-Klassen                  |
+| `footer`       | `ReactNode`                                                                | -        | Der Inhalt des Footers                   |
+| `noPadding`    | `boolean`                                                                  | `false`  | Entfernt das Padding im Inhaltsbereich   |
+| `hoverable`    | `boolean`                                                                  | `false`  | Aktiviert einen Hover-Effekt             |
+| `bordered`     | `boolean`                                                                  | `true`   | Zeigt einen Rand um die Card an          |
+| `headerAction` | `ReactNode`                                                                | -        | Aktion im Header (z.B. Button oder Icon) |
+| `type`         | `'primary' \| 'secondary' \| 'success' \| 'danger' \| 'warning' \| 'info'` | -        | Farbvariante der Card                    |
 
 ## Beispiele
 
 ### Produkt-Card
 
 ```jsx
-<Card 
-  noPadding 
-  hoverable
-  className="max-w-xs"
->
+<Card noPadding hoverable className="max-w-xs">
   <img src="/product-image.jpg" alt="Produkt" className="w-full h-48 object-cover" />
   <div className="p-4">
     <h3 className="text-lg font-semibold">Produktname</h3>
     <p className="text-gray-600 mt-1">Kurze Produktbeschreibung hier.</p>
     <div className="mt-4 flex items-center justify-between">
       <span className="text-xl font-bold">€49,99</span>
-      <button className="px-3 py-1 bg-primary-500 text-white rounded">
-        In den Warenkorb
-      </button>
+      <button className="px-3 py-1 bg-primary-500 text-white rounded">In den Warenkorb</button>
     </div>
   </div>
 </Card>
@@ -127,32 +127,24 @@ import { Card } from '@smolitux/core';
 ```jsx
 <Card className="max-w-md">
   <div className="flex items-center">
-    <img 
-      src="/avatar.jpg" 
-      alt="Profilbild" 
-      className="w-16 h-16 rounded-full object-cover"
-    />
+    <img src="/avatar.jpg" alt="Profilbild" className="w-16 h-16 rounded-full object-cover" />
     <div className="ml-4">
       <h3 className="text-lg font-semibold">Max Mustermann</h3>
       <p className="text-gray-600">Software-Entwickler</p>
     </div>
   </div>
-  
+
   <div className="mt-4">
     <h4 className="font-medium text-gray-700">Über mich</h4>
     <p className="mt-2 text-gray-600">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam auctor, 
-      nisl eget ultricies tincidunt, nisl nisl aliquam nisl.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam auctor, nisl eget ultricies
+      tincidunt, nisl nisl aliquam nisl.
     </p>
   </div>
-  
+
   <div className="mt-4 flex space-x-2">
-    <button className="px-3 py-1 bg-primary-500 text-white rounded">
-      Folgen
-    </button>
-    <button className="px-3 py-1 border border-gray-300 rounded">
-      Nachricht
-    </button>
+    <button className="px-3 py-1 bg-primary-500 text-white rounded">Folgen</button>
+    <button className="px-3 py-1 border border-gray-300 rounded">Nachricht</button>
   </div>
 </Card>
 ```
@@ -160,8 +152,8 @@ import { Card } from '@smolitux/core';
 ### Dashboard-Card
 
 ```jsx
-<Card 
-  title="Verkaufsübersicht" 
+<Card
+  title="Verkaufsübersicht"
   headerAction={
     <div className="flex space-x-2">
       <select className="text-sm border rounded px-2 py-1">
@@ -171,16 +163,17 @@ import { Card } from '@smolitux/core';
       </select>
       <button className="text-gray-500 hover:text-gray-700">
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+          />
         </svg>
       </button>
     </div>
   }
-  footer={
-    <div className="text-sm text-gray-500">
-      Letzte Aktualisierung: vor 5 Minuten
-    </div>
-  }
+  footer={<div className="text-sm text-gray-500">Letzte Aktualisierung: vor 5 Minuten</div>}
 >
   <div className="flex justify-between items-center">
     <div>
@@ -188,12 +181,10 @@ import { Card } from '@smolitux/core';
       <p className="text-2xl font-bold">€24.532</p>
       <p className="text-green-500 text-sm">+12% gegenüber Vorwoche</p>
     </div>
-    
+
     <div className="h-16 w-32 bg-gray-100 rounded">
       {/* Hier könnte ein Chart sein */}
-      <div className="h-full w-full flex items-center justify-center text-gray-400">
-        Chart
-      </div>
+      <div className="h-full w-full flex items-center justify-center text-gray-400">Chart</div>
     </div>
   </div>
 </Card>
@@ -204,32 +195,44 @@ import { Card } from '@smolitux/core';
 ```jsx
 function ExpandableCard() {
   const [isExpanded, setIsExpanded] = useState(false);
-  
+
   return (
-    <Card 
+    <Card
       title="Erweiterbarer Inhalt"
       headerAction={
-        <button 
+        <button
           onClick={() => setIsExpanded(!isExpanded)}
           className="text-gray-500 hover:text-gray-700"
         >
           {isExpanded ? (
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 15l7-7 7 7"
+              />
             </svg>
           ) : (
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
             </svg>
           )}
         </button>
       }
     >
       <p>Dies ist der immer sichtbare Inhalt.</p>
-      
+
       {isExpanded && (
         <div className="mt-4 pt-4 border-t">
-          <p>Dies ist der erweiterte Inhalt, der nur angezeigt wird, wenn die Card erweitert ist.</p>
+          <p>
+            Dies ist der erweiterte Inhalt, der nur angezeigt wird, wenn die Card erweitert ist.
+          </p>
           <p className="mt-2">Hier können weitere Details oder Informationen angezeigt werden.</p>
         </div>
       )}
@@ -245,23 +248,23 @@ function ExpandableCard() {
   <Card title="Card 1">
     <p>Inhalt für Card 1</p>
   </Card>
-  
+
   <Card title="Card 2">
     <p>Inhalt für Card 2</p>
   </Card>
-  
+
   <Card title="Card 3">
     <p>Inhalt für Card 3</p>
   </Card>
-  
+
   <Card title="Card 4">
     <p>Inhalt für Card 4</p>
   </Card>
-  
+
   <Card title="Card 5">
     <p>Inhalt für Card 5</p>
   </Card>
-  
+
   <Card title="Card 6">
     <p>Inhalt für Card 6</p>
   </Card>

--- a/packages/@smolitux/core/src/components/Card/Card.stories.tsx
+++ b/packages/@smolitux/core/src/components/Card/Card.stories.tsx
@@ -14,6 +14,10 @@ const meta: Meta<typeof Card> = {
       control: { type: 'select' },
       options: ['elevated', 'outlined', 'flat'],
     },
+    type: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'success', 'danger', 'warning', 'info'],
+    },
     padding: {
       control: { type: 'select' },
       options: ['none', 'small', 'medium', 'large'],
@@ -54,7 +58,11 @@ export const WithFooter: Story = {
   args: {
     title: 'Kartentitel',
     children: <p>Dies ist eine Karte mit einem Footer.</p>,
-    footer: <div className="flex justify-end"><button className="px-4 py-2 bg-blue-500 text-white rounded">Aktion</button></div>,
+    footer: (
+      <div className="flex justify-end">
+        <button className="px-4 py-2 bg-blue-500 text-white rounded">Aktion</button>
+      </div>
+    ),
   },
 };
 
@@ -83,6 +91,14 @@ export const Flat: Story = {
   },
 };
 
+export const Primary: Story = {
+  args: {
+    type: 'primary',
+    title: 'Primäre Karte',
+    children: <p>Diese Karte verwendet die Primärfarbe.</p>,
+  },
+};
+
 export const Hoverable: Story = {
   args: {
     title: 'Interaktive Karte',
@@ -102,7 +118,9 @@ export const CustomPadding: Story = {
 export const NoPadding: Story = {
   args: {
     title: 'Kein Padding',
-    children: <div className="bg-gray-100 p-4">Diese Karte hat kein Padding im Inhaltsbereich.</div>,
+    children: (
+      <div className="bg-gray-100 p-4">Diese Karte hat kein Padding im Inhaltsbereich.</div>
+    ),
     noPadding: true,
   },
 };
@@ -127,7 +145,9 @@ export const CustomSizing: Story = {
 export const CustomColors: Story = {
   args: {
     title: 'Benutzerdefinierte Farben',
-    children: <p className="text-white">Diese Karte hat benutzerdefinierte Hintergrund- und Randfarben.</p>,
+    children: (
+      <p className="text-white">Diese Karte hat benutzerdefinierte Hintergrund- und Randfarben.</p>
+    ),
     backgroundColor: '#4a5568',
     borderColor: '#2d3748',
   },
@@ -139,7 +159,12 @@ export const WithHeaderAction: Story = {
     children: <p>Diese Karte hat eine Aktion im Header-Bereich.</p>,
     headerAction: (
       <button className="text-gray-500 hover:text-gray-700">
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
           <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z" />
         </svg>
       </button>
@@ -153,19 +178,15 @@ export const ComplexContent: Story = {
     children: (
       <div>
         <div className="flex items-center mb-4">
-          <img 
-            src="https://via.placeholder.com/50" 
-            alt="Avatar" 
-            className="rounded-full mr-3"
-          />
+          <img src="https://via.placeholder.com/50" alt="Avatar" className="rounded-full mr-3" />
           <div>
             <h4 className="font-medium">Max Mustermann</h4>
             <p className="text-sm text-gray-500">Produktmanager</p>
           </div>
         </div>
         <p className="mb-4">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris.
-          Vivamus hendrerit arcu sed erat molestie vehicula.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus
+          hendrerit arcu sed erat molestie vehicula.
         </p>
         <div className="flex justify-between text-sm text-gray-500">
           <span>Vor 2 Stunden</span>
@@ -176,17 +197,40 @@ export const ComplexContent: Story = {
     footer: (
       <div className="flex justify-between">
         <button className="text-gray-500 hover:text-gray-700">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clipRule="evenodd" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
+              clipRule="evenodd"
+            />
           </svg>
         </button>
         <button className="text-gray-500 hover:text-gray-700">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clipRule="evenodd" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z"
+              clipRule="evenodd"
+            />
           </svg>
         </button>
         <button className="text-gray-500 hover:text-gray-700">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
             <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z" />
           </svg>
         </button>

--- a/packages/@smolitux/core/src/components/Card/Card.tsx
+++ b/packages/@smolitux/core/src/components/Card/Card.tsx
@@ -25,6 +25,8 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   headerAction?: ReactNode;
   /** Variante der Karte */
   variant?: 'elevated' | 'outlined' | 'flat' | 'default';
+  /** Farbvariante der Karte */
+  type?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info';
   /** Padding-Größe */
   padding?: 'none' | 'small' | 'medium' | 'large' | string;
   /** Randradius */
@@ -69,6 +71,7 @@ export const Card: React.FC<CardProps> = ({
   height,
   backgroundColor,
   borderColor,
+  type,
   size,
   shadow = false,
   rounded = false,
@@ -80,7 +83,7 @@ export const Card: React.FC<CardProps> = ({
     elevated: 'shadow-md',
     outlined: 'border border-gray-200 dark:border-gray-700',
     flat: '',
-    default: ''
+    default: '',
   };
 
   // Padding-Klassen
@@ -88,22 +91,31 @@ export const Card: React.FC<CardProps> = ({
     none: 'p-0',
     small: 'p-3',
     medium: 'p-4',
-    large: 'p-6'
+    large: 'p-6',
   };
-  
+
   // Größen-Klassen
   const sizeClasses = {
     sm: 'card-sm',
     md: 'card-md',
-    lg: 'card-lg'
+    lg: 'card-lg',
   };
+
+  const typeClasses = {
+    primary: 'card-primary border-t-4 border-primary-500',
+    secondary: 'card-secondary border-t-4 border-secondary-500',
+    success: 'card-success border-t-4 border-green-500',
+    danger: 'card-danger border-t-4 border-red-500',
+    warning: 'card-warning border-t-4 border-yellow-500',
+    info: 'card-info border-t-4 border-blue-500',
+  } as const;
 
   // Border-Radius-Klassen
   const borderRadiusClasses = {
     none: 'rounded-none',
     small: 'rounded-sm',
     medium: 'rounded-lg',
-    large: 'rounded-xl'
+    large: 'rounded-xl',
   };
 
   // Generiere eine eindeutige ID für ARIA-Attribute
@@ -111,30 +123,31 @@ export const Card: React.FC<CardProps> = ({
   const headerId = `${cardId}-header`;
   const contentId = `${cardId}-content`;
   const footerId = `${cardId}-footer`;
-  
+
   // Bestimme die richtige ARIA-Rolle
   const getAriaRole = () => {
     // Wenn die Karte klickbar ist (z.B. durch einen onClick-Handler), sollte sie als Button fungieren
     if (rest.onClick) {
       return 'button';
     }
-    
+
     // Standardmäßig verwenden wir 'region', um einen abgegrenzten Bereich zu kennzeichnen
     return 'region';
   };
-  
+
   // Bestimme, ob die Karte fokussierbar sein sollte
   const shouldBeFocusable = () => {
     return !!rest.onClick;
   };
-  
+
   // Bestimme den Padding-Wert
-  const paddingValue = typeof padding === 'string' && !['none', 'small', 'medium', 'large'].includes(padding) 
-    ? '' // Wenn es ein benutzerdefinierter String ist, verwenden wir ihn als Style
-    : paddingClasses[padding as 'none' | 'small' | 'medium' | 'large'];
+  const paddingValue =
+    typeof padding === 'string' && !['none', 'small', 'medium', 'large'].includes(padding)
+      ? '' // Wenn es ein benutzerdefinierter String ist, verwenden wir ihn als Style
+      : paddingClasses[padding as 'none' | 'small' | 'medium' | 'large'];
 
   return (
-    <div 
+    <div
       className={`
         card
         card-${variant}
@@ -146,6 +159,7 @@ export const Card: React.FC<CardProps> = ({
         ${variant === 'default' ? 'card-default' : ''}
         ${variant === 'outlined' ? 'card-outlined' : ''}
         ${variant === 'elevated' ? 'card-elevated' : ''}
+        ${type ? typeClasses[type] : ''}
         ${size ? sizeClasses[size] : ''}
         ${rounded ? 'card-rounded' : ''}
         ${noPadding ? '' : paddingValue}
@@ -154,8 +168,10 @@ export const Card: React.FC<CardProps> = ({
       style={{
         width: width,
         height: height,
-        ...(typeof padding === 'string' && !['none', 'small', 'medium', 'large'].includes(padding) ? { padding } : {}),
-        ...(bgColor ? { backgroundColor: bgColor } : {})
+        ...(typeof padding === 'string' && !['none', 'small', 'medium', 'large'].includes(padding)
+          ? { padding }
+          : {}),
+        ...(bgColor ? { backgroundColor: bgColor } : {}),
       }}
       id={cardId}
       role={getAriaRole()}
@@ -163,50 +179,53 @@ export const Card: React.FC<CardProps> = ({
       tabIndex={shouldBeFocusable() ? 0 : undefined}
       data-testid="card"
       data-variant={variant}
+      data-type={type}
       data-hoverable={hoverable ? 'true' : undefined}
       {...rest}
     >
       {header ? (
-        <div 
-          className="card-header flex justify-between items-center border-b border-gray-200 dark:border-gray-700 px-4 py-3" 
+        <div
+          className="card-header flex justify-between items-center border-b border-gray-200 dark:border-gray-700 px-4 py-3"
           data-testid="card-header"
           id={headerId}
         >
           {header}
         </div>
-      ) : title && (
-        <div 
-          className="card-header flex justify-between items-center border-b border-gray-200 dark:border-gray-700 px-4 py-3" 
-          data-testid="card-header"
-          id={headerId}
-        >
-          <div>
-            <h3 className="card-title font-medium text-gray-900 dark:text-white">{title}</h3>
-            {subtitle && <p className="card-subtitle text-sm text-gray-600 dark:text-gray-400">{subtitle}</p>}
+      ) : (
+        title && (
+          <div
+            className="card-header flex justify-between items-center border-b border-gray-200 dark:border-gray-700 px-4 py-3"
+            data-testid="card-header"
+            id={headerId}
+          >
+            <div>
+              <h3 className="card-title font-medium text-gray-900 dark:text-white">{title}</h3>
+              {subtitle && (
+                <p className="card-subtitle text-sm text-gray-600 dark:text-gray-400">{subtitle}</p>
+              )}
+            </div>
+            {headerAction && <div>{headerAction}</div>}
           </div>
-          {headerAction && (
-            <div>{headerAction}</div>
-          )}
-        </div>
+        )
       )}
-      
+
       {image && (
         <div className="card-image" data-testid="card-image">
           {image}
         </div>
       )}
-      
-      <div 
+
+      <div
         data-testid="card-content"
         id={contentId}
         className={noPadding ? '' : paddingClasses[padding]}
       >
         {children}
       </div>
-      
+
       {footer && (
-        <div 
-          className="card-footer border-t border-gray-200 dark:border-gray-700 px-4 py-3" 
+        <div
+          className="card-footer border-t border-gray-200 dark:border-gray-700 px-4 py-3"
           data-testid="card-footer"
           id={footerId}
         >

--- a/packages/@smolitux/core/src/components/Card/__tests__/Card.a11y.test.tsx
+++ b/packages/@smolitux/core/src/components/Card/__tests__/Card.a11y.test.tsx
@@ -5,15 +5,13 @@ import { Card } from '../Card';
 
 describe('Card Accessibility', () => {
   it('should not have accessibility violations in basic state', async () => {
-    const { violations } = await a11y.testA11y(
-      <Card>Test Card Content</Card>
-    );
+    const { violations } = await a11y.testA11y(<Card>Test Card Content</Card>);
     expect(violations).toHaveLength(0);
   });
 
   it('should have correct ARIA attributes for standard card', () => {
     render(<Card>Test Card Content</Card>);
-    
+
     const card = screen.getByTestId('card');
     expect(card).toHaveAttribute('role', 'region');
     expect(card).toHaveAttribute('id');
@@ -23,10 +21,10 @@ describe('Card Accessibility', () => {
 
   it('should have correct ARIA attributes for card with title', () => {
     render(<Card title="Card Title">Test Card Content</Card>);
-    
+
     const card = screen.getByTestId('card');
     const header = screen.getByTestId('card-header');
-    
+
     expect(card).toHaveAttribute('aria-labelledby');
     expect(card.getAttribute('aria-labelledby')).toBe(header.id);
   });
@@ -34,7 +32,7 @@ describe('Card Accessibility', () => {
   it('should be focusable when clickable', () => {
     const handleClick = jest.fn();
     render(<Card onClick={handleClick}>Clickable Card</Card>);
-    
+
     const card = screen.getByTestId('card');
     expect(card).toHaveAttribute('role', 'button');
     expect(card).toHaveAttribute('tabIndex', '0');
@@ -42,7 +40,7 @@ describe('Card Accessibility', () => {
 
   it('should not be focusable when not clickable', () => {
     render(<Card>Non-Clickable Card</Card>);
-    
+
     const card = screen.getByTestId('card');
     expect(card).not.toHaveAttribute('tabIndex');
   });
@@ -50,34 +48,31 @@ describe('Card Accessibility', () => {
   it('should support keyboard interaction when clickable', () => {
     const handleClick = jest.fn();
     render(<Card onClick={handleClick}>Clickable Card</Card>);
-    
+
     const card = screen.getByTestId('card');
-    
+
     // Test keyboard interaction
     fireEvent.keyDown(card, { key: 'Enter' });
     expect(handleClick).toHaveBeenCalledTimes(1);
-    
+
     fireEvent.keyDown(card, { key: ' ' });
     expect(handleClick).toHaveBeenCalledTimes(2);
   });
 
   it('should have correct IDs for header, content, and footer', () => {
     render(
-      <Card 
-        title="Card Title" 
-        footer="Card Footer"
-      >
+      <Card title="Card Title" footer="Card Footer">
         Card Content
       </Card>
     );
-    
+
     const card = screen.getByTestId('card');
     const header = screen.getByTestId('card-header');
     const content = screen.getByTestId('card-content');
     const footer = screen.getByTestId('card-footer');
-    
+
     const cardId = card.id;
-    
+
     expect(header.id).toBe(`${cardId}-header`);
     expect(content.id).toBe(`${cardId}-content`);
     expect(footer.id).toBe(`${cardId}-footer`);
@@ -86,17 +81,25 @@ describe('Card Accessibility', () => {
   it('should support different variants with correct attributes', () => {
     const { rerender } = render(<Card variant="elevated">Elevated Card</Card>);
     expect(screen.getByTestId('card')).toHaveAttribute('data-variant', 'elevated');
-    
+
     rerender(<Card variant="outlined">Outlined Card</Card>);
     expect(screen.getByTestId('card')).toHaveAttribute('data-variant', 'outlined');
-    
+
     rerender(<Card variant="flat">Flat Card</Card>);
     expect(screen.getByTestId('card')).toHaveAttribute('data-variant', 'flat');
   });
 
+  it('should support different types with correct attributes', () => {
+    const { rerender } = render(<Card type="primary">Primary</Card>);
+    expect(screen.getByTestId('card')).toHaveAttribute('data-type', 'primary');
+
+    rerender(<Card type="secondary">Secondary</Card>);
+    expect(screen.getByTestId('card')).toHaveAttribute('data-type', 'secondary');
+  });
+
   it('should indicate when card is hoverable', () => {
     render(<Card hoverable>Hoverable Card</Card>);
-    
+
     const card = screen.getByTestId('card');
     expect(card).toHaveAttribute('data-hoverable', 'true');
   });
@@ -104,10 +107,10 @@ describe('Card Accessibility', () => {
   it('should have visible focus indicators when focusable', () => {
     const handleClick = jest.fn();
     render(<Card onClick={handleClick}>Clickable Card</Card>);
-    
+
     const card = screen.getByTestId('card');
     card.focus();
-    
+
     expect(a11y.hasVisibleFocusIndicator(card)).toBe(true);
   });
 });

--- a/packages/@smolitux/core/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/@smolitux/core/src/components/Card/__tests__/Card.test.tsx
@@ -9,7 +9,7 @@ describe('Card', () => {
         <div>Card Content</div>
       </Card>
     );
-    
+
     expect(screen.getByText('Card Content')).toBeInTheDocument();
     const card = screen.getByTestId('card');
     expect(card).toBeInTheDocument();
@@ -22,10 +22,10 @@ describe('Card', () => {
         <div>Card Content</div>
       </Card>
     );
-    
+
     expect(screen.getByText('Card Title')).toBeInTheDocument();
     expect(screen.getByText('Card Content')).toBeInTheDocument();
-    
+
     const titleElement = screen.getByText('Card Title');
     expect(titleElement).toHaveClass('card-title');
   });
@@ -36,11 +36,11 @@ describe('Card', () => {
         <div>Card Content</div>
       </Card>
     );
-    
+
     expect(screen.getByText('Card Title')).toBeInTheDocument();
     expect(screen.getByText('Card Subtitle')).toBeInTheDocument();
     expect(screen.getByText('Card Content')).toBeInTheDocument();
-    
+
     const subtitleElement = screen.getByText('Card Subtitle');
     expect(subtitleElement).toHaveClass('card-subtitle');
   });
@@ -51,7 +51,7 @@ describe('Card', () => {
         <div>Card Content</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Card Content').closest('.card');
     expect(card).toHaveClass('custom-card');
   });
@@ -63,7 +63,7 @@ describe('Card', () => {
         <div>Card Content</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Card Content').closest('.card');
     expect(card).toHaveStyle('background-color: lightblue');
     expect(card).toHaveStyle('padding: 20px');
@@ -75,76 +75,99 @@ describe('Card', () => {
         <div>Default Card</div>
       </Card>
     );
-    
+
     let card = screen.getByText('Default Card').closest('.card');
     expect(card).toHaveClass('card-default');
-    
+
     rerender(
       <Card variant="outlined">
         <div>Outlined Card</div>
       </Card>
     );
-    
+
     card = screen.getByText('Outlined Card').closest('.card');
     expect(card).toHaveClass('card-outlined');
-    
+
     rerender(
       <Card variant="elevated">
         <div>Elevated Card</div>
       </Card>
     );
-    
+
     card = screen.getByText('Elevated Card').closest('.card');
     expect(card).toHaveClass('card-elevated');
   });
 
+  it('renders with different types', () => {
+    const { rerender } = render(
+      <Card type="primary">
+        <div>Primary Card</div>
+      </Card>
+    );
+
+    let card = screen.getByText('Primary Card').closest('.card');
+    expect(card).toHaveClass('card-primary');
+
+    rerender(
+      <Card type="secondary">
+        <div>Secondary Card</div>
+      </Card>
+    );
+
+    card = screen.getByText('Secondary Card').closest('.card');
+    expect(card).toHaveClass('card-secondary');
+
+    rerender(
+      <Card type="success">
+        <div>Success Card</div>
+      </Card>
+    );
+
+    card = screen.getByText('Success Card').closest('.card');
+    expect(card).toHaveClass('card-success');
+  });
+
   it('renders with header when provided', () => {
     render(
-      <Card
-        header={<div data-testid="custom-header">Custom Header</div>}
-      >
+      <Card header={<div data-testid="custom-header">Custom Header</div>}>
         <div>Card Content</div>
       </Card>
     );
-    
+
     expect(screen.getByTestId('custom-header')).toBeInTheDocument();
     expect(screen.getByText('Custom Header')).toBeInTheDocument();
     expect(screen.getByText('Card Content')).toBeInTheDocument();
-    
+
     const headerContainer = screen.getByTestId('card-header');
     expect(headerContainer).toHaveClass('card-header');
   });
 
   it('renders with footer when provided', () => {
     render(
-      <Card
-        footer={<div data-testid="custom-footer">Custom Footer</div>}
-      >
+      <Card footer={<div data-testid="custom-footer">Custom Footer</div>}>
         <div>Card Content</div>
       </Card>
     );
-    
+
     expect(screen.getByTestId('custom-footer')).toBeInTheDocument();
     expect(screen.getByText('Custom Footer')).toBeInTheDocument();
     expect(screen.getByText('Card Content')).toBeInTheDocument();
-    
+
     const footerContainer = screen.getByTestId('card-footer');
     expect(footerContainer).toHaveClass('card-footer');
   });
 
   it('renders with image when provided', () => {
     render(
-      <Card
-        image={<img src="card-image.jpg" alt="Card Image" data-testid="custom-image" />}
-      >
+      <Card image={<img src="card-image.jpg" alt="Card Image" data-testid="custom-image" />}>
         <div>Card Content</div>
       </Card>
     );
-    
+
     expect(screen.getByTestId('custom-image')).toBeInTheDocument();
     expect(screen.getByRole('img')).toHaveAttribute('alt', 'Card Image');
     expect(screen.getByText('Card Content')).toBeInTheDocument();
-    
+
     const imageContainer = screen.getByTestId('card-image');
     expect(imageContainer).toHaveClass('card-image');
   });
@@ -155,25 +178,25 @@ describe('Card', () => {
         <div>Small Card</div>
       </Card>
     );
-    
+
     let card = screen.getByText('Small Card').closest('.card');
     expect(card).toHaveClass('card-sm');
-    
+
     rerender(
       <Card size="md">
         <div>Medium Card</div>
       </Card>
     );
-    
+
     card = screen.getByText('Medium Card').closest('.card');
     expect(card).toHaveClass('card-md');
-    
+
     rerender(
       <Card size="lg">
         <div>Large Card</div>
       </Card>
     );
-    
+
     card = screen.getByText('Large Card').closest('.card');
     expect(card).toHaveClass('card-lg');
   });
@@ -184,7 +207,7 @@ describe('Card', () => {
         <div>Hoverable Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Hoverable Card').closest('.card');
     expect(card).toHaveClass('card-hoverable');
   });
@@ -196,7 +219,7 @@ describe('Card', () => {
         <div>Clickable Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Clickable Card').closest('.card');
     expect(card).toHaveClass('card-clickable');
   });
@@ -207,7 +230,7 @@ describe('Card', () => {
         <div>Bordered Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Bordered Card').closest('.card');
     expect(card).toHaveClass('card-bordered');
   });
@@ -218,7 +241,7 @@ describe('Card', () => {
         <div>Shadow Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Shadow Card').closest('.card');
     expect(card).toHaveClass('card-shadow');
   });
@@ -229,7 +252,7 @@ describe('Card', () => {
         <div>Rounded Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Rounded Card').closest('.card');
     expect(card).toHaveClass('card-rounded');
   });
@@ -240,7 +263,7 @@ describe('Card', () => {
         <div>Custom Width Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Custom Width Card').closest('.card');
     expect(card).toHaveStyle('width: 300px');
   });
@@ -251,7 +274,7 @@ describe('Card', () => {
         <div>Custom Height Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Custom Height Card').closest('.card');
     expect(card).toHaveStyle('height: 200px');
   });
@@ -262,7 +285,7 @@ describe('Card', () => {
         <div>Custom Padding Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Custom Padding Card').closest('.card');
     expect(card).toHaveStyle('padding: 30px');
   });
@@ -273,7 +296,7 @@ describe('Card', () => {
         <div>Custom Background Card</div>
       </Card>
     );
-    
+
     const card = screen.getByText('Custom Background Card').closest('.card');
     expect(card).toHaveStyle('background-color: #f0f0f0');
   });


### PR DESCRIPTION
## Summary
- extend Card props with `type` for color variants
- document new type property
- show primary card in Storybook
- update tests for new variants

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c5f8446c8324901207113313226f