### PR TITLE
feat(layout): responsive sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "typedoc": "^0.28.5",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.28.0",
-    "typedoc": "^0.25.2",
     "typedoc-plugin-markdown": "^3.14.0"
   },
   "dependencies": {

--- a/packages/@smolitux/layout/src/components/Sidebar/Sidebar.a11y.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/Sidebar.a11y.tsx
@@ -1,6 +1,7 @@
 // packages/@smolitux/layout/src/components/Sidebar/Sidebar.a11y.tsx
 import React, { useState, useEffect, forwardRef } from 'react';
 import { useTheme } from '@smolitux/theme';
+import { breakpoints } from '@smolitux/utils/styling';
 import { SidebarProps, SidebarItem } from './Sidebar';
 
 export interface SidebarA11yProps extends SidebarProps {
@@ -8,477 +9,477 @@ export interface SidebarA11yProps extends SidebarProps {
    * ARIA-Label für die Sidebar
    */
   ariaLabel?: string;
-  
+
   /**
    * ARIA-Labelledby für die Sidebar
    */
   ariaLabelledby?: string;
-  
+
   /**
    * ARIA-Describedby für die Sidebar
    */
   ariaDescribedby?: string;
-  
+
   /**
    * ARIA-Rolle für die Sidebar
    */
   role?: string;
-  
+
   /**
    * Ob die Sidebar eine Navigation ist
    */
   isNavigation?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Landmark ist
    */
   isLandmark?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Region ist
    */
   isRegion?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Complementary ist
    */
   isComplementary?: boolean;
-  
+
   /**
    * Ob die Sidebar ein Menu ist
    */
   isMenu?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Toolbar ist
    */
   isToolbar?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Tablist ist
    */
   isTablist?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Tree ist
    */
   isTree?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Listbox ist
    */
   isListbox?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Menubar ist
    */
   isMenubar?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Radiogroup ist
    */
   isRadiogroup?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Tabpanel ist
    */
   isTabpanel?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Dialog ist
    */
   isDialog?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Alert ist
    */
   isAlert?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Status ist
    */
   isStatus?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Live-Region ist
    */
   isLiveRegion?: boolean;
-  
+
   /**
    * Politeness-Level für Live-Region
    */
   liveRegionPoliteness?: 'polite' | 'assertive' | 'off';
-  
+
   /**
    * Ob die Sidebar atomar ist
    */
   isAtomic?: boolean;
-  
+
   /**
    * Ob die Sidebar relevant ist
    */
   isRelevant?: boolean;
-  
+
   /**
    * Relevanz-Typ für die Sidebar
    */
   relevantType?: 'additions' | 'removals' | 'text' | 'all';
-  
+
   /**
    * Ob die Sidebar busy ist
    */
   isBusy?: boolean;
-  
+
   /**
    * Ob die Sidebar fokussierbar ist
    */
   isFocusable?: boolean;
-  
+
   /**
    * Tab-Index für die Sidebar
    */
   tabIndex?: number;
-  
+
   /**
    * Ob die Sidebar eine Orientation hat
    */
   hasOrientation?: boolean;
-  
+
   /**
    * Orientation der Sidebar
    */
   orientation?: 'horizontal' | 'vertical';
-  
+
   /**
    * Ob die Sidebar eine Multiselectable ist
    */
   isMultiselectable?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Required ist
    */
   isRequired?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Expanded ist
    */
   isExpanded?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Haspopup ist
    */
   hasPopup?: boolean;
-  
+
   /**
    * Popup-Typ der Sidebar
    */
   popupType?: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';
-  
+
   /**
    * Ob die Sidebar eine Controls hat
    */
   hasControls?: boolean;
-  
+
   /**
    * Controls-ID der Sidebar
    */
   controlsId?: string;
-  
+
   /**
    * Ob die Sidebar eine Owns hat
    */
   hasOwns?: boolean;
-  
+
   /**
    * Owns-ID der Sidebar
    */
   ownsId?: string;
-  
+
   /**
    * Ob die Sidebar eine Flowto hat
    */
   hasFlowto?: boolean;
-  
+
   /**
    * Flowto-ID der Sidebar
    */
   flowtoId?: string;
-  
+
   /**
    * Ob die Sidebar eine Keyshortcuts hat
    */
   hasKeyshortcuts?: boolean;
-  
+
   /**
    * Keyshortcuts der Sidebar
    */
   keyshortcuts?: string;
-  
+
   /**
    * Ob die Sidebar eine Roledescription hat
    */
   hasRoledescription?: boolean;
-  
+
   /**
    * Roledescription der Sidebar
    */
   roledescription?: string;
-  
+
   /**
    * Ob die Sidebar eine Activedescendant hat
    */
   hasActivedescendant?: boolean;
-  
+
   /**
    * Activedescendant-ID der Sidebar
    */
   activedescendantId?: string;
-  
+
   /**
    * Ob die Sidebar eine Colindex hat
    */
   hasColindex?: boolean;
-  
+
   /**
    * Colindex der Sidebar
    */
   colindex?: number;
-  
+
   /**
    * Ob die Sidebar eine Rowindex hat
    */
   hasRowindex?: boolean;
-  
+
   /**
    * Rowindex der Sidebar
    */
   rowindex?: number;
-  
+
   /**
    * Ob die Sidebar eine Colcount hat
    */
   hasColcount?: boolean;
-  
+
   /**
    * Colcount der Sidebar
    */
   colcount?: number;
-  
+
   /**
    * Ob die Sidebar eine Rowcount hat
    */
   hasRowcount?: boolean;
-  
+
   /**
    * Rowcount der Sidebar
    */
   rowcount?: number;
-  
+
   /**
    * Ob die Sidebar eine Posinset hat
    */
   hasPosinset?: boolean;
-  
+
   /**
    * Posinset der Sidebar
    */
   posinset?: number;
-  
+
   /**
    * Ob die Sidebar eine Setsize hat
    */
   hasSetsize?: boolean;
-  
+
   /**
    * Setsize der Sidebar
    */
   setsize?: number;
-  
+
   /**
    * Ob die Sidebar eine Level hat
    */
   hasLevel?: boolean;
-  
+
   /**
    * Level der Sidebar
    */
   level?: number;
-  
+
   /**
    * Ob die Sidebar eine Valuemin hat
    */
   hasValuemin?: boolean;
-  
+
   /**
    * Valuemin der Sidebar
    */
   valuemin?: number;
-  
+
   /**
    * Ob die Sidebar eine Valuemax hat
    */
   hasValuemax?: boolean;
-  
+
   /**
    * Valuemax der Sidebar
    */
   valuemax?: number;
-  
+
   /**
    * Ob die Sidebar eine Valuenow hat
    */
   hasValuenow?: boolean;
-  
+
   /**
    * Valuenow der Sidebar
    */
   valuenow?: number;
-  
+
   /**
    * Ob die Sidebar eine Valuetext hat
    */
   hasValuetext?: boolean;
-  
+
   /**
    * Valuetext der Sidebar
    */
   valuetext?: string;
-  
+
   /**
    * Ob die Sidebar eine Checked hat
    */
   hasChecked?: boolean;
-  
+
   /**
    * Checked-Status der Sidebar
    */
   checked?: boolean | 'mixed';
-  
+
   /**
    * Ob die Sidebar eine Selected hat
    */
   hasSelected?: boolean;
-  
+
   /**
    * Selected-Status der Sidebar
    */
   selected?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Current hat
    */
   hasCurrent?: boolean;
-  
+
   /**
    * Current-Status der Sidebar
    */
   current?: boolean | 'page' | 'step' | 'location' | 'date' | 'time';
-  
+
   /**
    * Ob die Sidebar eine Sort hat
    */
   hasSort?: boolean;
-  
+
   /**
    * Sort-Status der Sidebar
    */
   sort?: 'ascending' | 'descending' | 'other' | 'none';
-  
+
   /**
    * Ob die Sidebar eine Dropeffect hat
    */
   hasDropeffect?: boolean;
-  
+
   /**
    * Dropeffect der Sidebar
    */
   dropeffect?: 'copy' | 'move' | 'link' | 'execute' | 'popup' | 'none';
-  
+
   /**
    * Ob die Sidebar eine Grabbed hat
    */
   hasGrabbed?: boolean;
-  
+
   /**
    * Grabbed-Status der Sidebar
    */
   grabbed?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Hidden hat
    */
   hasHidden?: boolean;
-  
+
   /**
    * Hidden-Status der Sidebar
    */
   hidden?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Invalid hat
    */
   hasInvalid?: boolean;
-  
+
   /**
    * Invalid-Status der Sidebar
    */
   invalid?: boolean | 'grammar' | 'spelling';
-  
+
   /**
    * Ob die Sidebar eine Pressed hat
    */
   hasPressed?: boolean;
-  
+
   /**
    * Pressed-Status der Sidebar
    */
   pressed?: boolean | 'mixed';
-  
+
   /**
    * Ob die Sidebar eine Readonly hat
    */
   hasReadonly?: boolean;
-  
+
   /**
    * Readonly-Status der Sidebar
    */
   readonly?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Required hat
    */
   hasRequired?: boolean;
-  
+
   /**
    * Required-Status der Sidebar
    */
   required?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Disabled hat
    */
   hasDisabled?: boolean;
-  
+
   /**
    * Disabled-Status der Sidebar
    */
   disabled?: boolean;
-  
+
   /**
    * Ob die Sidebar eine Errormessage hat
    */
   hasErrormessage?: boolean;
-  
+
   /**
    * Errormessage-ID der Sidebar
    */
   errormessageId?: string;
-  
+
   /**
    * Ob die Sidebar eine Keyboardshortcut hat
    */
   hasKeyboardshortcut?: boolean;
-  
+
   /**
    * Keyboardshortcut der Sidebar
    */
@@ -487,7 +488,7 @@ export interface SidebarA11yProps extends SidebarProps {
 
 /**
  * Barrierefreie Sidebar-Komponente für Navigation und Menüs
- * 
+ *
  * @example
  * ```tsx
  * <SidebarA11y
@@ -500,365 +501,399 @@ export interface SidebarA11yProps extends SidebarProps {
  * />
  * ```
  */
-export const SidebarA11y = forwardRef<HTMLDivElement, SidebarA11yProps>(({
-  items,
-  title,
-  logo,
-  collapsed = false,
-  onCollapseChange,
-  htmlProps = {},
-  onSelect,
-  position = 'left',
-  fixed = false,
-  variant = 'default',
-  ariaLabel,
-  ariaLabelledby,
-  ariaDescribedby,
-  role,
-  isNavigation = false,
-  isLandmark = false,
-  isRegion = false,
-  isComplementary = false,
-  isMenu = false,
-  isToolbar = false,
-  isTablist = false,
-  isTree = false,
-  isListbox = false,
-  isMenubar = false,
-  isRadiogroup = false,
-  isTabpanel = false,
-  isDialog = false,
-  isAlert = false,
-  isStatus = false,
-  isLiveRegion = false,
-  liveRegionPoliteness = 'polite',
-  isAtomic = false,
-  isRelevant = false,
-  relevantType = 'additions',
-  isBusy = false,
-  isFocusable = false,
-  tabIndex,
-  hasOrientation = false,
-  orientation = 'vertical',
-  isMultiselectable = false,
-  isRequired = false,
-  isExpanded = false,
-  hasPopup = false,
-  popupType = 'menu',
-  hasControls = false,
-  controlsId,
-  hasOwns = false,
-  ownsId,
-  hasFlowto = false,
-  flowtoId,
-  hasKeyshortcuts = false,
-  keyshortcuts,
-  hasRoledescription = false,
-  roledescription,
-  hasActivedescendant = false,
-  activedescendantId,
-  hasColindex = false,
-  colindex,
-  hasRowindex = false,
-  rowindex,
-  hasColcount = false,
-  colcount,
-  hasRowcount = false,
-  rowcount,
-  hasPosinset = false,
-  posinset,
-  hasSetsize = false,
-  setsize,
-  hasLevel = false,
-  level,
-  hasValuemin = false,
-  valuemin,
-  hasValuemax = false,
-  valuemax,
-  hasValuenow = false,
-  valuenow,
-  hasValuetext = false,
-  valuetext,
-  hasChecked = false,
-  checked,
-  hasSelected = false,
-  selected,
-  hasCurrent = false,
-  current,
-  hasSort = false,
-  sort,
-  hasDropeffect = false,
-  dropeffect,
-  hasGrabbed = false,
-  grabbed,
-  hasHidden = false,
-  hidden,
-  hasInvalid = false,
-  invalid,
-  hasPressed = false,
-  pressed,
-  hasReadonly = false,
-  readonly,
-  hasRequired = false,
-  required,
-  hasDisabled = false,
-  disabled,
-  hasErrormessage = false,
-  errormessageId,
-  hasKeyboardshortcut = false,
-  keyboardshortcut,
-  ...rest
-}, ref) => {
-  const { theme } = useTheme();
-  const [isCollapsed, setIsCollapsed] = useState(collapsed);
-  
-  // Aktualisiere den Collapse-Status, wenn sich die Prop ändert
-  useEffect(() => {
-    setIsCollapsed(collapsed);
-  }, [collapsed]);
-  
-  // Behandle das Umschalten des Collapse-Status
-  const handleToggleCollapse = () => {
-    const newCollapsed = !isCollapsed;
-    setIsCollapsed(newCollapsed);
-    
-    if (onCollapseChange) {
-      onCollapseChange(newCollapsed);
-    }
-  };
-  
-  // Behandle die Auswahl eines Items
-  const handleSelect = (item: SidebarItem) => {
-    if (item.disabled) return;
-    
-    if (item.onClick) {
-      item.onClick();
-    }
-    
-    if (onSelect) {
-      onSelect(item);
-    }
-  };
-  
-  // Bestimme die Rolle basierend auf den Eigenschaften
-  const determineRole = () => {
-    if (role) return role;
-    if (isNavigation) return 'navigation';
-    if (isLandmark) return 'landmark';
-    if (isRegion) return 'region';
-    if (isComplementary) return 'complementary';
-    if (isMenu) return 'menu';
-    if (isToolbar) return 'toolbar';
-    if (isTablist) return 'tablist';
-    if (isTree) return 'tree';
-    if (isListbox) return 'listbox';
-    if (isMenubar) return 'menubar';
-    if (isRadiogroup) return 'radiogroup';
-    if (isTabpanel) return 'tabpanel';
-    if (isDialog) return 'dialog';
-    if (isAlert) return 'alert';
-    if (isStatus) return 'status';
-    return undefined;
-  };
-  
-  // Bestimme die ARIA-Live-Region-Eigenschaften
-  const determineAriaLive = () => {
-    if (!isLiveRegion) return undefined;
-    return liveRegionPoliteness;
-  };
-  
-  // Bestimme die ARIA-Relevant-Eigenschaft
-  const determineAriaRelevant = () => {
-    if (!isRelevant) return undefined;
-    return relevantType;
-  };
-  
-  // Rendere ein einzelnes Item
-  const renderItem = (item: SidebarItem, index: number) => {
-    const isActive = item.active;
-    const isItemDisabled = item.disabled || disabled;
-    
-    // Bestimme die Klassen für das Item
-    const itemClasses = [
-      'sidebar-item',
-      isActive ? 'sidebar-item-active' : '',
-      isItemDisabled ? 'sidebar-item-disabled' : '',
-      item.className || '',
-    ].filter(Boolean).join(' ');
-    
-    // Bestimme die ARIA-Attribute für das Item
-    const itemAriaProps: React.AriaAttributes = {
-      'aria-disabled': isItemDisabled ? true : undefined,
-      'aria-selected': hasSelected && isActive ? selected : undefined,
-      'aria-current': hasCurrent && isActive ? (typeof current === 'boolean' ? 'page' : current) : undefined,
-      'aria-haspopup': item.children && item.children.length > 0 ? 'true' : undefined,
-      'aria-expanded': item.children && item.children.length > 0 ? String(!!isActive) : undefined,
-      'aria-controls': item.children && item.children.length > 0 && isActive ? `${item.id}-submenu` : undefined,
-      'aria-label': item.label,
+export const SidebarA11y = forwardRef<HTMLDivElement, SidebarA11yProps>(
+  (
+    {
+      items,
+      title,
+      logo,
+      collapsed = false,
+      onCollapseChange,
+      htmlProps = {},
+      onSelect,
+      position = 'left',
+      fixed = false,
+      variant = 'default',
+      ariaLabel,
+      ariaLabelledby,
+      ariaDescribedby,
+      role,
+      isNavigation = false,
+      isLandmark = false,
+      isRegion = false,
+      isComplementary = false,
+      isMenu = false,
+      isToolbar = false,
+      isTablist = false,
+      isTree = false,
+      isListbox = false,
+      isMenubar = false,
+      isRadiogroup = false,
+      isTabpanel = false,
+      isDialog = false,
+      isAlert = false,
+      isStatus = false,
+      isLiveRegion = false,
+      liveRegionPoliteness = 'polite',
+      isAtomic = false,
+      isRelevant = false,
+      relevantType = 'additions',
+      isBusy = false,
+      isFocusable = false,
+      tabIndex,
+      responsive = false,
+      collapseBreakpoint = 'md',
+      hasOrientation = false,
+      orientation = 'vertical',
+      isMultiselectable = false,
+      isRequired = false,
+      isExpanded = false,
+      hasPopup = false,
+      popupType = 'menu',
+      hasControls = false,
+      controlsId,
+      hasOwns = false,
+      ownsId,
+      hasFlowto = false,
+      flowtoId,
+      hasKeyshortcuts = false,
+      keyshortcuts,
+      hasRoledescription = false,
+      roledescription,
+      hasActivedescendant = false,
+      activedescendantId,
+      hasColindex = false,
+      colindex,
+      hasRowindex = false,
+      rowindex,
+      hasColcount = false,
+      colcount,
+      hasRowcount = false,
+      rowcount,
+      hasPosinset = false,
+      posinset,
+      hasSetsize = false,
+      setsize,
+      hasLevel = false,
+      level,
+      hasValuemin = false,
+      valuemin,
+      hasValuemax = false,
+      valuemax,
+      hasValuenow = false,
+      valuenow,
+      hasValuetext = false,
+      valuetext,
+      hasChecked = false,
+      checked,
+      hasSelected = false,
+      selected,
+      hasCurrent = false,
+      current,
+      hasSort = false,
+      sort,
+      hasDropeffect = false,
+      dropeffect,
+      hasGrabbed = false,
+      grabbed,
+      hasHidden = false,
+      hidden,
+      hasInvalid = false,
+      invalid,
+      hasPressed = false,
+      pressed,
+      hasReadonly = false,
+      readonly,
+      hasRequired = false,
+      required,
+      hasDisabled = false,
+      disabled,
+      hasErrormessage = false,
+      errormessageId,
+      hasKeyboardshortcut = false,
+      keyboardshortcut,
+      ...rest
+    },
+    ref
+  ) => {
+    const { theme } = useTheme();
+    const [isCollapsed, setIsCollapsed] = useState(collapsed);
+
+    // Aktualisiere den Collapse-Status, wenn sich die Prop ändert
+    useEffect(() => {
+      setIsCollapsed(collapsed);
+    }, [collapsed]);
+
+    useEffect(() => {
+      if (!responsive) return;
+      const bp =
+        typeof collapseBreakpoint === 'number'
+          ? collapseBreakpoint
+          : parseInt(breakpoints[collapseBreakpoint], 10);
+      const check = () => {
+        const shouldCollapse = window.innerWidth < bp;
+        setIsCollapsed(shouldCollapse ? true : collapsed);
+      };
+      check();
+      window.addEventListener('resize', check);
+      return () => window.removeEventListener('resize', check);
+    }, [responsive, collapseBreakpoint, collapsed]);
+
+    // Behandle das Umschalten des Collapse-Status
+    const handleToggleCollapse = () => {
+      const newCollapsed = !isCollapsed;
+      setIsCollapsed(newCollapsed);
+
+      if (onCollapseChange) {
+        onCollapseChange(newCollapsed);
+      }
     };
-    
-    // Rendere das Item als Link oder Button
-    const itemContent = (
-      <>
-        {item.icon && <span className="sidebar-item-icon" aria-hidden="true">{item.icon}</span>}
-        <span className="sidebar-item-label">{item.label}</span>
-        {item.badge && (
-          <span className={`sidebar-item-badge sidebar-item-badge-${item.badgeColor || 'primary'}`}>
-            {item.badge}
-          </span>
-        )}
-        {item.children && item.children.length > 0 && (
-          <span className="sidebar-item-arrow" aria-hidden="true">
-            {isActive ? '▼' : '▶'}
-          </span>
-        )}
-      </>
-    );
-    
-    // Rendere das Item
+
+    // Behandle die Auswahl eines Items
+    const handleSelect = (item: SidebarItem) => {
+      if (item.disabled) return;
+
+      if (item.onClick) {
+        item.onClick();
+      }
+
+      if (onSelect) {
+        onSelect(item);
+      }
+    };
+
+    // Bestimme die Rolle basierend auf den Eigenschaften
+    const determineRole = () => {
+      if (role) return role;
+      if (isNavigation) return 'navigation';
+      if (isLandmark) return 'landmark';
+      if (isRegion) return 'region';
+      if (isComplementary) return 'complementary';
+      if (isMenu) return 'menu';
+      if (isToolbar) return 'toolbar';
+      if (isTablist) return 'tablist';
+      if (isTree) return 'tree';
+      if (isListbox) return 'listbox';
+      if (isMenubar) return 'menubar';
+      if (isRadiogroup) return 'radiogroup';
+      if (isTabpanel) return 'tabpanel';
+      if (isDialog) return 'dialog';
+      if (isAlert) return 'alert';
+      if (isStatus) return 'status';
+      return undefined;
+    };
+
+    // Bestimme die ARIA-Live-Region-Eigenschaften
+    const determineAriaLive = () => {
+      if (!isLiveRegion) return undefined;
+      return liveRegionPoliteness;
+    };
+
+    // Bestimme die ARIA-Relevant-Eigenschaft
+    const determineAriaRelevant = () => {
+      if (!isRelevant) return undefined;
+      return relevantType;
+    };
+
+    // Rendere ein einzelnes Item
+    const renderItem = (item: SidebarItem, index: number) => {
+      const isActive = item.active;
+      const isItemDisabled = item.disabled || disabled;
+
+      // Bestimme die Klassen für das Item
+      const itemClasses = [
+        'sidebar-item',
+        isActive ? 'sidebar-item-active' : '',
+        isItemDisabled ? 'sidebar-item-disabled' : '',
+        item.className || '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      // Bestimme die ARIA-Attribute für das Item
+      const itemAriaProps: React.AriaAttributes = {
+        'aria-disabled': isItemDisabled ? true : undefined,
+        'aria-selected': hasSelected && isActive ? selected : undefined,
+        'aria-current':
+          hasCurrent && isActive ? (typeof current === 'boolean' ? 'page' : current) : undefined,
+        'aria-haspopup': item.children && item.children.length > 0 ? 'true' : undefined,
+        'aria-expanded': item.children && item.children.length > 0 ? String(!!isActive) : undefined,
+        'aria-controls':
+          item.children && item.children.length > 0 && isActive ? `${item.id}-submenu` : undefined,
+        'aria-label': item.label,
+      };
+
+      // Rendere das Item als Link oder Button
+      const itemContent = (
+        <>
+          {item.icon && (
+            <span className="sidebar-item-icon" aria-hidden="true">
+              {item.icon}
+            </span>
+          )}
+          <span className="sidebar-item-label">{item.label}</span>
+          {item.badge && (
+            <span
+              className={`sidebar-item-badge sidebar-item-badge-${item.badgeColor || 'primary'}`}
+            >
+              {item.badge}
+            </span>
+          )}
+          {item.children && item.children.length > 0 && (
+            <span className="sidebar-item-arrow" aria-hidden="true">
+              {isActive ? '▼' : '▶'}
+            </span>
+          )}
+        </>
+      );
+
+      // Rendere das Item
+      return (
+        <li key={item.id} className="sidebar-item-wrapper">
+          {item.href ? (
+            <a
+              href={item.href}
+              className={itemClasses}
+              onClick={(e) => {
+                if (isItemDisabled) {
+                  e.preventDefault();
+                  return;
+                }
+                handleSelect(item);
+              }}
+              {...itemAriaProps}
+            >
+              {itemContent}
+            </a>
+          ) : (
+            <button
+              type="button"
+              className={itemClasses}
+              onClick={() => handleSelect(item)}
+              disabled={isItemDisabled}
+              {...itemAriaProps}
+            >
+              {itemContent}
+            </button>
+          )}
+
+          {/* Untermenü */}
+          {item.children && item.children.length > 0 && isActive && (
+            <ul
+              id={`${item.id}-submenu`}
+              className="sidebar-submenu"
+              role="menu"
+              aria-label={`${item.label} Untermenü`}
+            >
+              {item.children.map((child, childIndex) => renderItem(child, childIndex))}
+            </ul>
+          )}
+        </li>
+      );
+    };
+
+    // Bestimme die Klassen für die Sidebar
+    const sidebarClasses = [
+      'sidebar',
+      `sidebar-${position}`,
+      `sidebar-${variant}`,
+      isCollapsed ? 'sidebar-collapsed' : '',
+      fixed ? 'sidebar-fixed' : '',
+      htmlProps.className || '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    // Bestimme die ARIA-Attribute für die Sidebar
+    const sidebarAriaProps: React.AriaAttributes = {
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledby,
+      'aria-describedby': ariaDescribedby,
+      'aria-orientation': hasOrientation ? orientation : undefined,
+      'aria-multiselectable': isMultiselectable ? 'true' : undefined,
+      'aria-required': hasRequired ? String(required) : undefined,
+      'aria-expanded': isExpanded ? 'true' : undefined,
+      'aria-haspopup': hasPopup ? popupType : undefined,
+      'aria-controls': hasControls ? controlsId : undefined,
+      'aria-owns': hasOwns ? ownsId : undefined,
+      'aria-flowto': hasFlowto ? flowtoId : undefined,
+      'aria-keyshortcuts': hasKeyshortcuts ? keyshortcuts : undefined,
+      'aria-roledescription': hasRoledescription ? roledescription : undefined,
+      'aria-activedescendant': hasActivedescendant ? activedescendantId : undefined,
+      'aria-colindex': hasColindex ? String(colindex) : undefined,
+      'aria-rowindex': hasRowindex ? String(rowindex) : undefined,
+      'aria-colcount': hasColcount ? String(colcount) : undefined,
+      'aria-rowcount': hasRowcount ? String(rowcount) : undefined,
+      'aria-posinset': hasPosinset ? String(posinset) : undefined,
+      'aria-setsize': hasSetsize ? String(setsize) : undefined,
+      'aria-level': hasLevel ? String(level) : undefined,
+      'aria-valuemin': hasValuemin ? String(valuemin) : undefined,
+      'aria-valuemax': hasValuemax ? String(valuemax) : undefined,
+      'aria-valuenow': hasValuenow ? String(valuenow) : undefined,
+      'aria-valuetext': hasValuetext ? valuetext : undefined,
+      'aria-checked': hasChecked ? String(checked) : undefined,
+      'aria-selected': hasSelected ? String(selected) : undefined,
+      'aria-current': hasCurrent ? String(current) : undefined,
+      'aria-sort': hasSort ? sort : undefined,
+      'aria-dropeffect': hasDropeffect ? dropeffect : undefined,
+      'aria-grabbed': hasGrabbed ? String(grabbed) : undefined,
+      'aria-hidden': hasHidden ? String(hidden) : undefined,
+      'aria-invalid': hasInvalid ? String(invalid) : undefined,
+      'aria-pressed': hasPressed ? String(pressed) : undefined,
+      'aria-readonly': hasReadonly ? String(readonly) : undefined,
+      'aria-required': hasRequired ? String(required) : undefined,
+      'aria-disabled': hasDisabled ? String(disabled) : undefined,
+      'aria-errormessage': hasErrormessage ? errormessageId : undefined,
+      'aria-keyboardshortcut': hasKeyboardshortcut ? keyboardshortcut : undefined,
+      'aria-live': determineAriaLive(),
+      'aria-atomic': isLiveRegion && isAtomic ? 'true' : undefined,
+      'aria-relevant': determineAriaRelevant(),
+      'aria-busy': isBusy ? 'true' : undefined,
+    };
+
+    // Rendere die Sidebar
     return (
-      <li key={item.id} className="sidebar-item-wrapper">
-        {item.href ? (
-          <a
-            href={item.href}
-            className={itemClasses}
-            onClick={(e) => {
-              if (isItemDisabled) {
-                e.preventDefault();
-                return;
-              }
-              handleSelect(item);
-            }}
-            {...itemAriaProps}
-          >
-            {itemContent}
-          </a>
-        ) : (
-          <button
-            type="button"
-            className={itemClasses}
-            onClick={() => handleSelect(item)}
-            disabled={isItemDisabled}
-            {...itemAriaProps}
-          >
-            {itemContent}
-          </button>
+      <div
+        ref={ref}
+        className={sidebarClasses}
+        role={determineRole()}
+        tabIndex={isFocusable ? tabIndex || 0 : undefined}
+        {...sidebarAriaProps}
+        {...htmlProps}
+      >
+        {/* Header */}
+        {(logo || title) && (
+          <div className="sidebar-header">
+            {logo && <div className="sidebar-logo">{logo}</div>}
+            {title && !isCollapsed && <div className="sidebar-title">{title}</div>}
+
+            {/* Collapse-Button */}
+            <button
+              type="button"
+              className="sidebar-collapse-button"
+              onClick={handleToggleCollapse}
+              aria-label={isCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
+              aria-expanded={!isCollapsed}
+              aria-controls="sidebar-content"
+            >
+              <span aria-hidden="true">{isCollapsed ? '▶' : '◀'}</span>
+            </button>
+          </div>
         )}
-        
-        {/* Untermenü */}
-        {item.children && item.children.length > 0 && isActive && (
+
+        {/* Inhalt */}
+        <div id="sidebar-content" className="sidebar-content">
           <ul
-            id={`${item.id}-submenu`}
-            className="sidebar-submenu"
-            role="menu"
-            aria-label={`${item.label} Untermenü`}
+            className="sidebar-items"
+            role={isNavigation ? 'menu' : isTree ? 'tree' : isListbox ? 'listbox' : undefined}
           >
-            {item.children.map((child, childIndex) => renderItem(child, childIndex))}
+            {items.map((item, index) => renderItem(item, index))}
           </ul>
-        )}
-      </li>
-    );
-  };
-  
-  // Bestimme die Klassen für die Sidebar
-  const sidebarClasses = [
-    'sidebar',
-    `sidebar-${position}`,
-    `sidebar-${variant}`,
-    isCollapsed ? 'sidebar-collapsed' : '',
-    fixed ? 'sidebar-fixed' : '',
-    htmlProps.className || '',
-  ].filter(Boolean).join(' ');
-  
-  // Bestimme die ARIA-Attribute für die Sidebar
-  const sidebarAriaProps: React.AriaAttributes = {
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledby,
-    'aria-describedby': ariaDescribedby,
-    'aria-orientation': hasOrientation ? orientation : undefined,
-    'aria-multiselectable': isMultiselectable ? 'true' : undefined,
-    'aria-required': hasRequired ? String(required) : undefined,
-    'aria-expanded': isExpanded ? 'true' : undefined,
-    'aria-haspopup': hasPopup ? popupType : undefined,
-    'aria-controls': hasControls ? controlsId : undefined,
-    'aria-owns': hasOwns ? ownsId : undefined,
-    'aria-flowto': hasFlowto ? flowtoId : undefined,
-    'aria-keyshortcuts': hasKeyshortcuts ? keyshortcuts : undefined,
-    'aria-roledescription': hasRoledescription ? roledescription : undefined,
-    'aria-activedescendant': hasActivedescendant ? activedescendantId : undefined,
-    'aria-colindex': hasColindex ? String(colindex) : undefined,
-    'aria-rowindex': hasRowindex ? String(rowindex) : undefined,
-    'aria-colcount': hasColcount ? String(colcount) : undefined,
-    'aria-rowcount': hasRowcount ? String(rowcount) : undefined,
-    'aria-posinset': hasPosinset ? String(posinset) : undefined,
-    'aria-setsize': hasSetsize ? String(setsize) : undefined,
-    'aria-level': hasLevel ? String(level) : undefined,
-    'aria-valuemin': hasValuemin ? String(valuemin) : undefined,
-    'aria-valuemax': hasValuemax ? String(valuemax) : undefined,
-    'aria-valuenow': hasValuenow ? String(valuenow) : undefined,
-    'aria-valuetext': hasValuetext ? valuetext : undefined,
-    'aria-checked': hasChecked ? String(checked) : undefined,
-    'aria-selected': hasSelected ? String(selected) : undefined,
-    'aria-current': hasCurrent ? String(current) : undefined,
-    'aria-sort': hasSort ? sort : undefined,
-    'aria-dropeffect': hasDropeffect ? dropeffect : undefined,
-    'aria-grabbed': hasGrabbed ? String(grabbed) : undefined,
-    'aria-hidden': hasHidden ? String(hidden) : undefined,
-    'aria-invalid': hasInvalid ? String(invalid) : undefined,
-    'aria-pressed': hasPressed ? String(pressed) : undefined,
-    'aria-readonly': hasReadonly ? String(readonly) : undefined,
-    'aria-required': hasRequired ? String(required) : undefined,
-    'aria-disabled': hasDisabled ? String(disabled) : undefined,
-    'aria-errormessage': hasErrormessage ? errormessageId : undefined,
-    'aria-keyboardshortcut': hasKeyboardshortcut ? keyboardshortcut : undefined,
-    'aria-live': determineAriaLive(),
-    'aria-atomic': isLiveRegion && isAtomic ? 'true' : undefined,
-    'aria-relevant': determineAriaRelevant(),
-    'aria-busy': isBusy ? 'true' : undefined,
-  };
-  
-  // Rendere die Sidebar
-  return (
-    <div
-      ref={ref}
-      className={sidebarClasses}
-      role={determineRole()}
-      tabIndex={isFocusable ? (tabIndex || 0) : undefined}
-      {...sidebarAriaProps}
-      {...htmlProps}
-    >
-      {/* Header */}
-      {(logo || title) && (
-        <div className="sidebar-header">
-          {logo && <div className="sidebar-logo">{logo}</div>}
-          {title && !isCollapsed && <div className="sidebar-title">{title}</div>}
-          
-          {/* Collapse-Button */}
-          <button
-            type="button"
-            className="sidebar-collapse-button"
-            onClick={handleToggleCollapse}
-            aria-label={isCollapsed ? 'Sidebar ausklappen' : 'Sidebar einklappen'}
-            aria-expanded={!isCollapsed}
-            aria-controls="sidebar-content"
-          >
-            <span aria-hidden="true">{isCollapsed ? '▶' : '◀'}</span>
-          </button>
         </div>
-      )}
-      
-      {/* Inhalt */}
-      <div id="sidebar-content" className="sidebar-content">
-        <ul
-          className="sidebar-items"
-          role={isNavigation ? 'menu' : isTree ? 'tree' : isListbox ? 'listbox' : undefined}
-        >
-          {items.map((item, index) => renderItem(item, index))}
-        </ul>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 SidebarA11y.displayName = 'SidebarA11y';
 

--- a/packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 // packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
 import React, { useState, useEffect, forwardRef } from 'react';
 import { useTheme } from '@smolitux/theme';
+import { breakpoints } from '@smolitux/utils/styling';
 
 export interface SidebarItem {
   /** Eindeutige ID des Items */
@@ -52,13 +53,17 @@ export interface SidebarProps {
   width?: string | number;
   /** Breite der Sidebar (eingeklappt) */
   collapsedWidth?: string | number;
+  /** Responsive Verhalten aktivieren */
+  responsive?: boolean;
+  /** Breakpoint ab dem die Sidebar automatisch einklappt */
+  collapseBreakpoint?: keyof typeof breakpoints | number;
   /** Footer-Inhalt */
   footer?: React.ReactNode;
 }
 
 /**
  * Sidebar-Komponente für Navigation
- * 
+ *
  * @example
  * ```tsx
  * <Sidebar
@@ -71,271 +76,283 @@ export interface SidebarProps {
  * />
  * ```
  */
-export const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(({
-  items,
-  title,
-  logo,
-  collapsed = false,
-  onCollapseChange,
-  onSelect,
-  position = 'left',
-  fixed = true,
-  variant = 'default',
-  width = 240,
-  collapsedWidth = 64,
-  footer,
-  className = '',
-  ...rest
-}, ref) => {
-  const { themeMode } = useTheme();
-  const [isCollapsed, setIsCollapsed] = useState(collapsed);
-  const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
-  
-  // Synchronisiere externen und internen Collapse-Status
-  useEffect(() => {
-    setIsCollapsed(collapsed);
-  }, [collapsed]);
-  
-  // Umschalten des Collapse-Status
-  const toggleCollapse = () => {
-    const newState = !isCollapsed;
-    setIsCollapsed(newState);
-    if (onCollapseChange) {
-      onCollapseChange(newState);
-    }
-  };
-  
-  // Umschalten eines Submenüs
-  const toggleSubmenu = (itemId: string, event: React.MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    setOpenSubmenu(openSubmenu === itemId ? null : itemId);
-  };
-  
-  // Behandeln der Auswahl eines Items
-  const handleItemClick = (item: SidebarItem, event: React.MouseEvent) => {
-    if (item.disabled) {
+export const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(
+  (
+    {
+      items,
+      title,
+      logo,
+      collapsed = false,
+      onCollapseChange,
+      onSelect,
+      position = 'left',
+      fixed = true,
+      variant = 'default',
+      width = 240,
+      collapsedWidth = 64,
+      responsive = false,
+      collapseBreakpoint = 'md',
+      footer,
+      className = '',
+      ...rest
+    },
+    ref
+  ) => {
+    const { themeMode } = useTheme();
+    const [isCollapsed, setIsCollapsed] = useState(collapsed);
+    const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
+
+    useEffect(() => {
+      if (!responsive) return;
+      const bp =
+        typeof collapseBreakpoint === 'number'
+          ? collapseBreakpoint
+          : parseInt(breakpoints[collapseBreakpoint], 10);
+      const handle = () => {
+        const shouldCollapse = window.innerWidth < bp;
+        setIsCollapsed(shouldCollapse ? true : collapsed);
+      };
+      handle();
+      window.addEventListener('resize', handle);
+      return () => window.removeEventListener('resize', handle);
+    }, [responsive, collapseBreakpoint, collapsed]);
+
+    // Synchronisiere externen und internen Collapse-Status
+    useEffect(() => {
+      setIsCollapsed(collapsed);
+    }, [collapsed]);
+
+    // Umschalten des Collapse-Status
+    const toggleCollapse = () => {
+      const newState = !isCollapsed;
+      setIsCollapsed(newState);
+      if (onCollapseChange) {
+        onCollapseChange(newState);
+      }
+    };
+
+    // Umschalten eines Submenüs
+    const toggleSubmenu = (itemId: string, event: React.MouseEvent) => {
       event.preventDefault();
-      return;
-    }
-    
-    if (item.children && item.children.length > 0) {
-      toggleSubmenu(item.id, event);
-    } else if (onSelect) {
-      onSelect(item);
-    }
-    
-    if (item.onClick) {
-      item.onClick();
-    }
-  };
-  
-  // Varianten-spezifische Klassen
-  const variantClasses = {
-    default: 'bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-r border-gray-200 dark:border-gray-700',
-    light: 'bg-gray-50 text-gray-800 border-r border-gray-200',
-    dark: 'bg-gray-900 text-gray-200 border-r border-gray-800',
-    transparent: 'bg-transparent text-current'
-  };
-  
-  // CSS-Klassen zusammenstellen
-  const classes = [
-    // Basis-Klassen
-    'flex flex-col',
-    
-    // Variante
-    variantClasses[variant],
-    
-    // Position
-    position === 'left' ? 'left-0' : 'right-0',
-    
-    // Fixierung
-    fixed ? 'fixed top-0 bottom-0 z-40' : 'relative',
-    
-    // Transition für Animation
-    'transition-all duration-300 ease-in-out',
-    
-    // Benutzerdefinierte Klassen
-    className
-  ].filter(Boolean).join(' ');
-  
-  // Styles für dynamische Werte (Breite)
-  const dynamicStyles = {
-    width: isCollapsed 
-      ? typeof collapsedWidth === 'number' ? `${collapsedWidth}px` : collapsedWidth
-      : typeof width === 'number' ? `${width}px` : width,
-    minWidth: isCollapsed 
-      ? typeof collapsedWidth === 'number' ? `${collapsedWidth}px` : collapsedWidth
-      : typeof width === 'number' ? `${width}px` : width,
-  };
-  
-  // Rendert ein einzelnes Navigations-Item
-  const renderItem = (item: SidebarItem, level = 0) => {
-    const hasChildren = item.children && item.children.length > 0;
-    const isOpen = openSubmenu === item.id;
-    
-    // Item-Klassen basierend auf Status und Verschachtelung
-    const itemClasses = [
-      'flex items-center px-4 py-2',
-      'text-sm cursor-pointer select-none',
-      'transition-colors duration-200',
-      level > 0 ? 'pl-8' : '',
-      item.active 
-        ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300' 
-        : 'hover:bg-gray-100 dark:hover:bg-gray-700',
-      item.disabled ? 'opacity-50 cursor-not-allowed' : '',
-      item.className || ''
-    ].filter(Boolean).join(' ');
-    
-    return (
-      <div key={item.id} className="w-full">
-        {/* Haupteintrag */}
-        <div
-          className={itemClasses}
-          onClick={(e) => handleItemClick(item, e)}
-          role="button"
-          tabIndex={0}
-        >
-          {/* Icon */}
-          {item.icon && (
-            <div className="mr-3 flex-shrink-0">
-              {item.icon}
-            </div>
-          )}
-          
-          {/* Label */}
-          {!isCollapsed && (
-            <div className="flex-grow truncate">
-              {item.label}
-            </div>
-          )}
-          
-          {/* Badge */}
-          {!isCollapsed && item.badge && (
-            <div className={`
+      event.stopPropagation();
+      setOpenSubmenu(openSubmenu === itemId ? null : itemId);
+    };
+
+    // Behandeln der Auswahl eines Items
+    const handleItemClick = (item: SidebarItem, event: React.MouseEvent) => {
+      if (item.disabled) {
+        event.preventDefault();
+        return;
+      }
+
+      if (item.children && item.children.length > 0) {
+        toggleSubmenu(item.id, event);
+      } else if (onSelect) {
+        onSelect(item);
+      }
+
+      if (item.onClick) {
+        item.onClick();
+      }
+    };
+
+    // Varianten-spezifische Klassen
+    const variantClasses = {
+      default:
+        'bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 border-r border-gray-200 dark:border-gray-700',
+      light: 'bg-gray-50 text-gray-800 border-r border-gray-200',
+      dark: 'bg-gray-900 text-gray-200 border-r border-gray-800',
+      transparent: 'bg-transparent text-current',
+    };
+
+    // CSS-Klassen zusammenstellen
+    const classes = [
+      // Basis-Klassen
+      'flex flex-col',
+
+      // Variante
+      variantClasses[variant],
+
+      // Position
+      position === 'left' ? 'left-0' : 'right-0',
+
+      // Fixierung
+      fixed ? 'fixed top-0 bottom-0 z-40' : 'relative',
+
+      // Transition für Animation
+      'transition-all duration-300 ease-in-out',
+
+      // Benutzerdefinierte Klassen
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    // Styles für dynamische Werte (Breite)
+    const dynamicStyles = {
+      width: isCollapsed
+        ? typeof collapsedWidth === 'number'
+          ? `${collapsedWidth}px`
+          : collapsedWidth
+        : typeof width === 'number'
+          ? `${width}px`
+          : width,
+      minWidth: isCollapsed
+        ? typeof collapsedWidth === 'number'
+          ? `${collapsedWidth}px`
+          : collapsedWidth
+        : typeof width === 'number'
+          ? `${width}px`
+          : width,
+    };
+
+    // Rendert ein einzelnes Navigations-Item
+    const renderItem = (item: SidebarItem, level = 0) => {
+      const hasChildren = item.children && item.children.length > 0;
+      const isOpen = openSubmenu === item.id;
+
+      // Item-Klassen basierend auf Status und Verschachtelung
+      const itemClasses = [
+        'flex items-center px-4 py-2',
+        'text-sm cursor-pointer select-none',
+        'transition-colors duration-200',
+        level > 0 ? 'pl-8' : '',
+        item.active
+          ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+          : 'hover:bg-gray-100 dark:hover:bg-gray-700',
+        item.disabled ? 'opacity-50 cursor-not-allowed' : '',
+        item.className || '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      return (
+        <div key={item.id} className="w-full">
+          {/* Haupteintrag */}
+          <div
+            className={itemClasses}
+            onClick={(e) => handleItemClick(item, e)}
+            role="button"
+            tabIndex={0}
+          >
+            {/* Icon */}
+            {item.icon && <div className="mr-3 flex-shrink-0">{item.icon}</div>}
+
+            {/* Label */}
+            {!isCollapsed && <div className="flex-grow truncate">{item.label}</div>}
+
+            {/* Badge */}
+            {!isCollapsed && item.badge && (
+              <div
+                className={`
               ml-2 px-2 py-0.5 text-xs rounded-full
               ${getBadgeColorClass(item.badgeColor)}
-            `}>
-              {item.badge}
-            </div>
-          )}
-          
-          {/* Dropdown-Pfeil für Submenüs */}
-          {!isCollapsed && hasChildren && (
-            <div className="ml-2">
-              <svg
-                className={`h-4 w-4 transition-transform ${isOpen ? 'transform rotate-180' : ''}`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+            `}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
+                {item.badge}
+              </div>
+            )}
+
+            {/* Dropdown-Pfeil für Submenüs */}
+            {!isCollapsed && hasChildren && (
+              <div className="ml-2">
+                <svg
+                  className={`h-4 w-4 transition-transform ${isOpen ? 'transform rotate-180' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </div>
+            )}
+          </div>
+
+          {/* Untermenü-Items */}
+          {!isCollapsed && hasChildren && isOpen && (
+            <div className="pl-4 pr-2 pb-2">
+              {item.children!.map((child) => renderItem(child, level + 1))}
             </div>
           )}
         </div>
-        
-        {/* Untermenü-Items */}
-        {!isCollapsed && hasChildren && isOpen && (
-          <div className="pl-4 pr-2 pb-2">
-            {item.children!.map(child => renderItem(child, level + 1))}
+      );
+    };
+
+    // Hilfsfunktion für Badge-Farben
+    const getBadgeColorClass = (color?: SidebarItem['badgeColor']) => {
+      switch (color) {
+        case 'primary':
+          return 'bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300';
+        case 'secondary':
+          return 'bg-secondary-100 text-secondary-800 dark:bg-secondary-900/30 dark:text-secondary-300';
+        case 'success':
+          return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+        case 'warning':
+          return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
+        case 'error':
+          return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+        case 'info':
+          return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
+        default:
+          return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+      }
+    };
+
+    return (
+      <div ref={ref} className={classes} style={dynamicStyles} {...rest}>
+        {/* Header-Bereich */}
+        {(logo || title) && (
+          <div className="flex items-center p-4 border-b border-gray-200 dark:border-gray-700">
+            {/* Logo */}
+            {logo && <div className="flex-shrink-0">{logo}</div>}
+
+            {/* Titel */}
+            {!isCollapsed && title && (
+              <div className="ml-2 text-lg font-semibold truncate">{title}</div>
+            )}
+
+            {/* Collapse-Toggle (nur im Desktop-Modus) */}
+            <div className="ml-auto">
+              <button
+                type="button"
+                className="p-1 rounded-md text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus:outline-none"
+                onClick={toggleCollapse}
+                aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              >
+                <svg
+                  className={`h-5 w-5 transition-transform ${position === 'left' ? (isCollapsed ? '' : 'transform rotate-180') : isCollapsed ? 'transform rotate-180' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d={position === 'left' ? 'M15 19l-7-7 7-7' : 'M9 5l7 7-7 7'}
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
+        )}
+
+        {/* Hauptnavigation */}
+        <div className="flex-1 overflow-y-auto py-2">{items.map((item) => renderItem(item))}</div>
+
+        {/* Footer-Bereich */}
+        {footer && !isCollapsed && (
+          <div className="mt-auto border-t border-gray-200 dark:border-gray-700 p-4">{footer}</div>
         )}
       </div>
     );
-  };
-  
-  // Hilfsfunktion für Badge-Farben
-  const getBadgeColorClass = (color?: SidebarItem['badgeColor']) => {
-    switch (color) {
-      case 'primary':
-        return 'bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300';
-      case 'secondary':
-        return 'bg-secondary-100 text-secondary-800 dark:bg-secondary-900/30 dark:text-secondary-300';
-      case 'success':
-        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
-      case 'warning':
-        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
-      case 'error':
-        return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
-      case 'info':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
-      default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
-    }
-  };
-  
-  return (
-    <div
-      ref={ref}
-      className={classes}
-      style={dynamicStyles}
-      {...rest}
-    >
-      {/* Header-Bereich */}
-      {(logo || title) && (
-        <div className="flex items-center p-4 border-b border-gray-200 dark:border-gray-700">
-          {/* Logo */}
-          {logo && (
-            <div className="flex-shrink-0">
-              {logo}
-            </div>
-          )}
-          
-          {/* Titel */}
-          {!isCollapsed && title && (
-            <div className="ml-2 text-lg font-semibold truncate">
-              {title}
-            </div>
-          )}
-          
-          {/* Collapse-Toggle (nur im Desktop-Modus) */}
-          <div className="ml-auto">
-            <button
-              type="button"
-              className="p-1 rounded-md text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus:outline-none"
-              onClick={toggleCollapse}
-              aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            >
-              <svg
-                className={`h-5 w-5 transition-transform ${position === 'left' ? (isCollapsed ? '' : 'transform rotate-180') : (isCollapsed ? 'transform rotate-180' : '')}`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d={position === 'left' 
-                    ? "M15 19l-7-7 7-7" 
-                    : "M9 5l7 7-7 7"}
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      )}
-      
-      {/* Hauptnavigation */}
-      <div className="flex-1 overflow-y-auto py-2">
-        {items.map(item => renderItem(item))}
-      </div>
-      
-      {/* Footer-Bereich */}
-      {footer && !isCollapsed && (
-        <div className="mt-auto border-t border-gray-200 dark:border-gray-700 p-4">
-          {footer}
-        </div>
-      )}
-    </div>
-  );
-});
+  }
+);
 
 Sidebar.displayName = 'Sidebar';
 

--- a/packages/@smolitux/layout/src/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { Sidebar } from '../';
+
+describe('Sidebar responsive behaviour', () => {
+  beforeEach(() => {
+    (window as any).innerWidth = 1024;
+  });
+
+  test('collapses below breakpoint when responsive', () => {
+    const { container } = render(
+      <Sidebar items={[{ id: 'home', label: 'Home' }]} responsive collapseBreakpoint="md" />
+    );
+    const sidebar = container.firstChild as HTMLElement;
+    expect(sidebar.style.width).toBe('240px');
+    act(() => {
+      (window as any).innerWidth = 500;
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(sidebar.style.width).toBe('64px');
+  });
+
+  test('does not collapse when responsive is false', () => {
+    (window as any).innerWidth = 500;
+    const { container } = render(
+      <Sidebar items={[{ id: 'home', label: 'Home' }]} responsive={false} />
+    );
+    const sidebar = container.firstChild as HTMLElement;
+    expect(sidebar.style.width).toBe('240px');
+  });
+});

--- a/packages/@smolitux/layout/src/components/Sidebar/stories/Sidebar.a11y.stories.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/stories/Sidebar.a11y.stories.tsx
@@ -19,88 +19,98 @@ const meta: Meta<typeof Sidebar.A11y> = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: 'Eine barrierefreie Version der Sidebar-Komponente mit verbesserten ARIA-Attributen und Screenreader-Unterstuetzung.'
-      }
-    }
+        component:
+          'Eine barrierefreie Version der Sidebar-Komponente mit verbesserten ARIA-Attributen und Screenreader-Unterstuetzung.',
+      },
+    },
   },
   argTypes: {
     title: {
       control: 'text',
-      description: 'Titel der Sidebar'
+      description: 'Titel der Sidebar',
     },
     collapsed: {
       control: 'boolean',
-      description: 'Ist die Sidebar eingeklappt?'
+      description: 'Ist die Sidebar eingeklappt?',
     },
     position: {
       control: { type: 'select' },
       options: ['left', 'right'],
-      description: 'Position der Sidebar'
+      description: 'Position der Sidebar',
     },
     fixed: {
       control: 'boolean',
-      description: 'Feste Sidebar (nicht scrollbar)'
+      description: 'Feste Sidebar (nicht scrollbar)',
     },
     variant: {
       control: { type: 'select' },
       options: ['default', 'light', 'dark', 'transparent'],
-      description: 'Variante der Sidebar'
+      description: 'Variante der Sidebar',
+    },
+    responsive: {
+      control: 'boolean',
+      description: 'Automatisch einklappen bei kleinem Bildschirm',
+    },
+    collapseBreakpoint: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg', 'xl', '2xl'],
+      description: 'Breakpoint zum automatischen Einklappen',
     },
     ariaLabel: {
       control: 'text',
-      description: 'ARIA-Label für die Sidebar'
+      description: 'ARIA-Label für die Sidebar',
     },
     isNavigation: {
       control: 'boolean',
-      description: 'Ob die Sidebar eine Navigation ist'
+      description: 'Ob die Sidebar eine Navigation ist',
     },
     isComplementary: {
       control: 'boolean',
-      description: 'Ob die Sidebar eine Complementary ist'
+      description: 'Ob die Sidebar eine Complementary ist',
     },
     isLandmark: {
       control: 'boolean',
-      description: 'Ob die Sidebar eine Landmark ist'
+      description: 'Ob die Sidebar eine Landmark ist',
     },
     isRegion: {
       control: 'boolean',
-      description: 'Ob die Sidebar eine Region ist'
+      description: 'Ob die Sidebar eine Region ist',
     },
     isMenu: {
       control: 'boolean',
-      description: 'Ob die Sidebar ein Menu ist'
+      description: 'Ob die Sidebar ein Menu ist',
     },
     isLiveRegion: {
       control: 'boolean',
-      description: 'Ob die Sidebar eine Live-Region ist'
+      description: 'Ob die Sidebar eine Live-Region ist',
     },
     liveRegionPoliteness: {
       control: { type: 'select' },
       options: ['polite', 'assertive', 'off'],
-      description: 'Politeness-Level für Live-Region'
+      description: 'Politeness-Level für Live-Region',
     },
     isAtomic: {
       control: 'boolean',
-      description: 'Ob die Sidebar atomar ist'
+      description: 'Ob die Sidebar atomar ist',
     },
     isBusy: {
       control: 'boolean',
-      description: 'Ob die Sidebar busy ist'
+      description: 'Ob die Sidebar busy ist',
     },
     isFocusable: {
       control: 'boolean',
-      description: 'Ob die Sidebar fokussierbar ist'
+      description: 'Ob die Sidebar fokussierbar ist',
     },
     hasOrientation: {
       control: 'boolean',
-      description: 'Ob die Sidebar eine Orientation hat'
+      description: 'Ob die Sidebar eine Orientation hat',
     },
     orientation: {
       control: { type: 'select' },
       options: ['horizontal', 'vertical'],
-      description: 'Orientation der Sidebar'
-    }
-  }
+      description: 'Orientation der Sidebar',
+    },
+  },
 };
 
 export default meta;
@@ -115,9 +125,9 @@ export const Default: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
       { id: 'users', label: 'Users', icon: <UsersIcon /> },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };
 
 export const WithSubmenu: Story = {
@@ -127,28 +137,28 @@ export const WithSubmenu: Story = {
     isNavigation: true,
     items: [
       { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
-      { 
-        id: 'users', 
-        label: 'Users', 
+      {
+        id: 'users',
+        label: 'Users',
         icon: <UsersIcon />,
         children: [
           { id: 'users-list', label: 'User List' },
           { id: 'users-add', label: 'Add User' },
-          { id: 'users-groups', label: 'User Groups' }
-        ]
+          { id: 'users-groups', label: 'User Groups' },
+        ],
       },
-      { 
-        id: 'settings', 
-        label: 'Settings', 
+      {
+        id: 'settings',
+        label: 'Settings',
         icon: <SettingsIcon />,
         children: [
           { id: 'settings-general', label: 'General' },
           { id: 'settings-security', label: 'Security' },
-          { id: 'settings-notifications', label: 'Notifications' }
-        ]
-      }
-    ]
-  }
+          { id: 'settings-notifications', label: 'Notifications' },
+        ],
+      },
+    ],
+  },
 };
 
 export const WithBadges: Story = {
@@ -159,11 +169,23 @@ export const WithBadges: Story = {
     items: [
       { id: 'home', label: 'Home', icon: <HomeIcon /> },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
-      { id: 'notifications', label: 'Notifications', icon: <NotificationsIcon />, badge: 5, badgeColor: 'error' },
-      { id: 'messages', label: 'Messages', icon: <NotificationsIcon />, badge: 'New', badgeColor: 'primary' },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
-    ]
-  }
+      {
+        id: 'notifications',
+        label: 'Notifications',
+        icon: <NotificationsIcon />,
+        badge: 5,
+        badgeColor: 'error',
+      },
+      {
+        id: 'messages',
+        label: 'Messages',
+        icon: <NotificationsIcon />,
+        badge: 'New',
+        badgeColor: 'primary',
+      },
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };
 
 export const WithDisabledItems: Story = {
@@ -175,9 +197,9 @@ export const WithDisabledItems: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon /> },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon />, disabled: true },
       { id: 'users', label: 'Users', icon: <UsersIcon /> },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon />, disabled: true }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon />, disabled: true },
+    ],
+  },
 };
 
 export const WithLinks: Story = {
@@ -189,9 +211,9 @@ export const WithLinks: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon />, href: '#home' },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon />, href: '#dashboard' },
       { id: 'users', label: 'Users', icon: <UsersIcon />, href: '#users' },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon />, href: '#settings' }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon />, href: '#settings' },
+    ],
+  },
 };
 
 export const DarkVariant: Story = {
@@ -204,9 +226,9 @@ export const DarkVariant: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
       { id: 'users', label: 'Users', icon: <UsersIcon /> },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };
 
 export const LightVariant: Story = {
@@ -219,9 +241,9 @@ export const LightVariant: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
       { id: 'users', label: 'Users', icon: <UsersIcon /> },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };
 
 export const RightPosition: Story = {
@@ -234,19 +256,19 @@ export const RightPosition: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
       { id: 'users', label: 'Users', icon: <UsersIcon /> },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };
 
 export const Collapsible: Story = {
   render: () => {
     const [collapsed, setCollapsed] = useState(false);
-    
+
     const handleCollapseChange = (isCollapsed: boolean) => {
       setCollapsed(isCollapsed);
     };
-    
+
     return (
       <div className="h-screen">
         <Sidebar.A11y
@@ -259,18 +281,37 @@ export const Collapsible: Story = {
             { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
             { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
             { id: 'users', label: 'Users', icon: <UsersIcon /> },
-            { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
+            { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
           ]}
         />
-        
+
         <div className="ml-64 p-4">
           <h1 className="text-2xl font-bold mb-4">Hauptinhalt</h1>
-          <p>Die Sidebar kann ein- und ausgeklappt werden. Klicken Sie auf den Pfeil in der Sidebar, um sie ein- oder auszuklappen.</p>
+          <p>
+            Die Sidebar kann ein- und ausgeklappt werden. Klicken Sie auf den Pfeil in der Sidebar,
+            um sie ein- oder auszuklappen.
+          </p>
           <p>Aktueller Status: {collapsed ? 'Eingeklappt' : 'Ausgeklappt'}</p>
         </div>
       </div>
     );
-  }
+  },
+};
+
+export const Responsive: Story = {
+  args: {
+    title: 'Navigation',
+    ariaLabel: 'Hauptnavigation',
+    isNavigation: true,
+    responsive: true,
+    collapseBreakpoint: 'md',
+    items: [
+      { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
+      { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
+      { id: 'users', label: 'Users', icon: <UsersIcon /> },
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };
 
 export const AsComplementary: Story = {
@@ -280,11 +321,17 @@ export const AsComplementary: Story = {
     isComplementary: true,
     items: [
       { id: 'profile', label: 'Profile', icon: <ProfileIcon /> },
-      { id: 'notifications', label: 'Notifications', icon: <NotificationsIcon />, badge: 3, badgeColor: 'error' },
+      {
+        id: 'notifications',
+        label: 'Notifications',
+        icon: <NotificationsIcon />,
+        badge: 3,
+        badgeColor: 'error',
+      },
       { id: 'help', label: 'Help', icon: <HelpIcon /> },
-      { id: 'logout', label: 'Logout', icon: <LogoutIcon /> }
-    ]
-  }
+      { id: 'logout', label: 'Logout', icon: <LogoutIcon /> },
+    ],
+  },
 };
 
 export const AsMenu: Story = {
@@ -296,9 +343,9 @@ export const AsMenu: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon /> },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
       { id: 'users', label: 'Users', icon: <UsersIcon /> },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };
 
 export const WithLiveRegion: Story = {
@@ -311,9 +358,9 @@ export const WithLiveRegion: Story = {
     items: [
       { id: 'success', label: 'Erfolgreich gespeichert', icon: <span>✅</span> },
       { id: 'warning', label: 'Warnung: Sitzung läuft ab', icon: <span>⚠️</span> },
-      { id: 'error', label: 'Fehler: Verbindung verloren', icon: <span>❌</span> }
-    ]
-  }
+      { id: 'error', label: 'Fehler: Verbindung verloren', icon: <span>❌</span> },
+    ],
+  },
 };
 
 export const WithCustomOrientation: Story = {
@@ -327,7 +374,7 @@ export const WithCustomOrientation: Story = {
       { id: 'home', label: 'Home', icon: <HomeIcon />, active: true },
       { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
       { id: 'users', label: 'Users', icon: <UsersIcon /> },
-      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> }
-    ]
-  }
+      { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
+    ],
+  },
 };

--- a/packages/@smolitux/voice-control/README.md
+++ b/packages/@smolitux/voice-control/README.md
@@ -1,0 +1,21 @@
+# @smolitux/voice-control
+
+This package provides the foundational voice control infrastructure for Smolitux UI.
+
+It exposes a `VoiceControlProvider` to wrap your application and a `withVoiceControl` higher order component to enable voice commands on individual components.
+
+The default implementation uses the Web Speech API but you can also opt-in to a TensorFlow.js based engine for offline recognition.
+
+```tsx
+import { VoiceControlProvider, withVoiceControl } from '@smolitux/voice-control';
+
+const ButtonWithVoice = withVoiceControl('button', ['click']);
+
+function App() {
+  return (
+    <VoiceControlProvider>
+      <ButtonWithVoice onClick={() => alert('clicked!')}>Click me</ButtonWithVoice>
+    </VoiceControlProvider>
+  );
+}
+```

--- a/packages/@smolitux/voice-control/__tests__/VoiceControlManager.test.ts
+++ b/packages/@smolitux/voice-control/__tests__/VoiceControlManager.test.ts
@@ -1,0 +1,36 @@
+import { VoiceControlManager } from '../src/VoiceControlManager';
+import { WebSpeechRecognitionEngine } from '../src/engines/WebSpeechRecognitionEngine';
+
+describe('VoiceControlManager', () => {
+  test('registers components and processes commands', () => {
+    const manager = new VoiceControlManager('webSpeech');
+    // stub recognition engine methods to avoid browser APIs
+    (manager as any).recognitionEngine = {
+      onResult: () => {},
+      onStateChange: () => {},
+      start: jest.fn(),
+      stop: jest.fn(),
+      cleanup: jest.fn(),
+      isSupported: () => true,
+    } as WebSpeechRecognitionEngine;
+
+    manager.registerComponent('test', ['click']);
+    let recognizedCommand = '';
+    let target = '';
+    manager.onCommandRecognized = (command, targetId) => {
+      recognizedCommand = command;
+      target = targetId;
+    };
+
+    (manager as any).commandProcessor.processCommand = jest.fn().mockReturnValue({
+      command: 'click',
+      targetId: 'test',
+    });
+
+    // simulate result event
+    (manager as any).recognitionEngine.onResult('click');
+
+    expect(recognizedCommand).toBe('click');
+    expect(target).toBe('test');
+  });
+});


### PR DESCRIPTION
## Summary
- enhance Sidebar with responsive collapse
- expose breakpoint props to A11y variant
- update Sidebar stories for Storybook
- add regression tests
- merge PR #263 and PR #264
- add README and unit test for voice control
- remove duplicate typedoc entry in package.json

## Testing
- `npm run lint` *(fails: 41 errors)
- `npm run test` *(fails: multiple failing suites)
- `npm run build` *(fails during tests)*


------
https://chatgpt.com/codex/tasks/task_e_6844bbc909d08324859c0fe4a3a12cdd