### PR TITLE
Fix wiki path references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert.
 
-> **Hinweis:** Die vollständige Dokumentation finden Sie im [Wiki](/docs/Wiki/index.md). Die aktuelle Version des Changelogs finden Sie [hier](/docs/Wiki/development/changelog.md).
+> **Hinweis:** Die vollständige Dokumentation finden Sie im [Wiki](/docs/wiki/index.md). Die aktuelle Version des Changelogs finden Sie [hier](/docs/wiki/development/changelog.md).
 
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/),
 und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 First off, thank you for considering contributing to this project! It's people like you that make this project such a great tool.
 
-> **Note:** The complete documentation can be found in the [Wiki](/docs/Wiki/index.md). The current version of the contribution guidelines can be found [here](/docs/Wiki/development/contributing.md).
+> **Note:** The complete documentation can be found in the [Wiki](/docs/wiki/index.md). The current version of the contribution guidelines can be found [here](/docs/wiki/development/contributing.md).
 
 ## Code of Conduct
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,4 +2,4 @@
 
 ## A big thank you and praise to JoGa90!!!
 
-> **Note:** The complete documentation can be found in the [Wiki](/docs/Wiki/index.md). The current version of the credits can be found [here](/docs/Wiki/development/credits.md).
+> **Note:** The complete documentation can be found in the [Wiki](/docs/wiki/index.md). The current version of the credits can be found [here](/docs/wiki/development/credits.md).

--- a/analysis/status-report.md
+++ b/analysis/status-report.md
@@ -110,7 +110,7 @@ Die Smolitux UI Bibliothek ist als Monorepo mit Lerna organisiert und enthalt me
 
 ## 4. Dokumentation
 
-- **Wiki**: Umfangreiche Dokumentation im docs/Wiki-Verzeichnis
+- **Wiki**: Umfangreiche Dokumentation im docs/wiki-Verzeichnis
 - **Testplan**: Detaillierter Testplan mit Phasen und Prioritaten
 - **Komponenten-Dokumentation**: Teilweise vorhanden, aber unvollstandig
 - **Barrierefreiheit**: Dokumentation vorhanden

--- a/docs/_archive/Wiki/development/Finanzierung/Kalkulation-v0.2.2.md
+++ b/docs/_archive/Wiki/development/Finanzierung/Kalkulation-v0.2.2.md
@@ -9,7 +9,7 @@
 
 ## Analyse des Umfangs für Version 0.2.2
 
-Basierend auf den Dokumenten lässt sich erkennen, dass Version 0.2.2 hauptsächlich eine kleinere Verbesserung darstellt. Laut [Changelog](https://github.com/EcoSphereNetwork/smolitux-ui/blob/main/docs/Wiki/development/changelog.md) enthält Version 0.2.2 folgende Änderungen:
+Basierend auf den Dokumenten lässt sich erkennen, dass Version 0.2.2 hauptsächlich eine kleinere Verbesserung darstellt. Laut [Changelog](https://github.com/EcoSphereNetwork/smolitux-ui/blob/main/docs/wiki/development/changelog.md) enthält Version 0.2.2 folgende Änderungen:
 
 ### Hinzugefügt
 - Button-Komponente: Unterstützung für `solid`-Variante als Alias für `primary`

--- a/docs/_archive/Wiki/development/cleanup-roadmap-files.sh
+++ b/docs/_archive/Wiki/development/cleanup-roadmap-files.sh
@@ -3,7 +3,7 @@
 # Dieses Skript bereinigt die Roadmap-Dateien und behält nur die konsolidierte Version
 
 # Sicherstellen, dass wir im richtigen Verzeichnis sind
-cd /workspace/smolitux-ui/docs/Wiki/development
+cd /workspace/smolitux-ui/docs/wiki/development
 
 # Erstellen eines Backup-Verzeichnisses für die alten Dateien
 mkdir -p archive

--- a/docs/_archive/Wiki/development/v0.2.2-release-notes.md
+++ b/docs/_archive/Wiki/development/v0.2.2-release-notes.md
@@ -27,7 +27,7 @@ Smolitux UI v0.2.2 is a maintenance release that focuses on improving code quali
 
 ## Component Status
 
-A comprehensive test status report has been added to the documentation. This report provides a detailed overview of the test coverage for all components in the library. See [Component Status Report](/docs/Wiki/development/component-status.md) for more details.
+A comprehensive test status report has been added to the documentation. This report provides a detailed overview of the test coverage for all components in the library. See [Component Status Report](/docs/wiki/development/component-status.md) for more details.
 
 ## Known Issues
 

--- a/docs/wiki/development/Finanzierung/Kalkulation-v0.2.2.md
+++ b/docs/wiki/development/Finanzierung/Kalkulation-v0.2.2.md
@@ -9,7 +9,7 @@
 
 ## Analyse des Umfangs für Version 0.2.2
 
-Basierend auf den Dokumenten lässt sich erkennen, dass Version 0.2.2 hauptsächlich eine kleinere Verbesserung darstellt. Laut [Changelog](https://github.com/EcoSphereNetwork/smolitux-ui/blob/main/docs/Wiki/development/changelog.md) enthält Version 0.2.2 folgende Änderungen:
+Basierend auf den Dokumenten lässt sich erkennen, dass Version 0.2.2 hauptsächlich eine kleinere Verbesserung darstellt. Laut [Changelog](https://github.com/EcoSphereNetwork/smolitux-ui/blob/main/docs/wiki/development/changelog.md) enthält Version 0.2.2 folgende Änderungen:
 
 ### Hinzugefügt
 - Button-Komponente: Unterstützung für `solid`-Variante als Alias für `primary`

--- a/docs/wiki/development/cleanup-roadmap-files.sh
+++ b/docs/wiki/development/cleanup-roadmap-files.sh
@@ -3,7 +3,7 @@
 # Dieses Skript bereinigt die Roadmap-Dateien und behält nur die konsolidierte Version
 
 # Sicherstellen, dass wir im richtigen Verzeichnis sind
-cd /workspace/smolitux-ui/docs/Wiki/development
+cd /workspace/smolitux-ui/docs/wiki/development
 
 # Erstellen eines Backup-Verzeichnisses für die alten Dateien
 mkdir -p archive

--- a/scripts/generate-coverage-report.js
+++ b/scripts/generate-coverage-report.js
@@ -2,7 +2,7 @@
 
 /**
  * Dieses Skript generiert einen Testabdeckungsbericht für die aktuelle Version
- * und speichert ihn im docs/Wiki/testing/coverage-reports Verzeichnis.
+ * und speichert ihn im docs/wiki/testing/coverage-reports Verzeichnis.
  */
 
 const fs = require('fs');
@@ -18,7 +18,7 @@ console.log(`Generating test coverage report for version ${version}...`);
 execSync('npm run test:coverage', { stdio: 'inherit' });
 
 // Erstelle das Verzeichnis für die Coverage-Berichte, falls es nicht existiert
-const reportsDir = path.join(__dirname, '..', 'docs', 'Wiki', 'testing', 'coverage-reports');
+const reportsDir = path.join(__dirname, '..', 'docs', 'wiki', 'testing', 'coverage-reports');
 if (!fs.existsSync(reportsDir)) {
   fs.mkdirSync(reportsDir, { recursive: true });
 }


### PR DESCRIPTION
## Summary
- update wiki links to use lowercase `docs/wiki`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: lerna not found)*
- `npm run test` *(fails: jest not found)*
- `cd docs && npm run build` *(fails: missing Docusaurus packages)*

------
https://chatgpt.com/codex/tasks/task_e_6845318c14388324982f4bd139cd3006