### PR TITLE
Fix jest configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ const config = {
     // CSS-Module-Mocking
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     // SVG und andere Assets
-    '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/packages/@smolitux/testing/mocks/fileMock.js',
+    '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/test-utils/fileMock.js',
     // Alias-Auflösung für '@smolitux/'
     '^@smolitux/(.*)$': '<rootDir>/packages/@smolitux/$1/src',
     '^jest-matcher-utils$': '<rootDir>/node_modules/jest-matcher-utils',


### PR DESCRIPTION
## Summary
- update path to `fileMock` in `jest.config.js`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684536eed974832494189e6105ee13d1