### PR TITLE
Fix Storybook compiler dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@storybook/addon-onboarding": "^1.0.11",
     "@storybook/addon-toolbars": "^7.6.17",
     "@storybook/addon-viewport": "^7.6.17",
-    "@storybook/addon-webpack5-compiler-swc": "^7.6.17",
     "@storybook/blocks": "^7.6.17",
     "@storybook/builder-webpack5": "^7.6.17",
     "@storybook/react": "^7.6.17",


### PR DESCRIPTION
## Summary
- remove invalid `@storybook/addon-webpack5-compiler-swc` entry from `package.json`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'aria-query' etc.)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68454358fd5c8324bb14b0d1f505273d