### PR TITLE
Add coverage dashboard

### DIFF
--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -1,0 +1,18 @@
+# Test Coverage Dashboard
+
+| Paket | Status | Statements | Branches | Functions | Lines |
+|-------|--------|-----------|----------|-----------|-------|
+| @smolitux/core | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/theme | ✅ Getestet | – | – | – | – |
+| @smolitux/layout | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/charts | ✅ Getestet | – | – | – | – |
+| @smolitux/ai | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/blockchain | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/community | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/federation | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/media | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/resonance | ⚠️ Teilweise | – | – | – | – |
+| @smolitux/utils | ✅ Getestet | – | – | – | – |
+| @smolitux/voice-control | ❌ Offen | – | – | – | – |
+
+> Letzte Aktualisierung: 7. Juni 2025

--- a/docs/wiki/testing/test-strategy.md
+++ b/docs/wiki/testing/test-strategy.md
@@ -394,6 +394,7 @@ Nach jedem Testlauf werden Berichte generiert:
 - Axe Accessibility Report
 - Visual Regression Report
 - E2E Test Report
+- Test Coverage Dashboard (docs/wiki/testing/test-coverage-dashboard.md)
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- add coverage dashboard in docs
- reference dashboard from test strategy

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459f925fe08324a4d07ca121c6fc0b