### PR TITLE
Fix tsconfig and update component status

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -2,3 +2,9 @@
 
 | Paket | Komponenten | Tests | Coverage | Status | Letzte Bearbeitung |
 |-------|-------------|-------|----------|--------|---------------------|
+
+## Session Update - core analysis
+- Identified missing stories for majority of components
+- TypeScript compile blocked by missing @types/react and @types/node
+- Excluded duplicate Textarea component from tsconfig
+- Added typeRoots override

--- a/packages/@smolitux/core/tsconfig.json
+++ b/packages/@smolitux/core/tsconfig.json
@@ -2,8 +2,18 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["react", "node"],
+    "typeRoots": ["../../../node_modules/@types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "src/components/Textarea/**/*",
+    "**/*.stories.tsx",
+    "**/__tests__/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- adjust tsconfig in `@smolitux/core` to skip unused Textarea component
- set type information to avoid conflicts and exclude test and story files
- record analysis progress in `COMPONENT_STATUS.md`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test --workspace=@smolitux/core -- --coverage --maxWorkers=2` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*


------
https://chatgpt.com/codex/tasks/task_e_6845cd3ce08c8324bdffa2b5d4e9485c