### PR TITLE
Add tests & stories for theme and utils components

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,10 +1,53 @@
-# Smolitux UI Component Status - Sun Jun  8 17:14:31 UTC 2025
+# Smolitux UI - Codex Progress
 
-| Paket | Komponenten | Tests | Coverage | Status | Letzte Bearbeitung |
-|-------|-------------|-------|----------|--------|---------------------|
+**Started:** Sun Jun  8 18:04:28 UTC 2025
+**Strategy:** Work with existing codebase, no setup dependencies
 
-## Session Update - core analysis
-- Identified missing stories for majority of components
-- TypeScript compile blocked by missing @types/react and @types/node
-- Excluded duplicate Textarea component from tsconfig
-- Added typeRoots override
+## 🎯 Package Priority (from AGENTS.md):
+
+### Tier 1: Foundation (START HERE)
+- [ ] **@smolitux/core** (60+ components) - Button, Modal, Table, Input, etc.
+- [ ] **@smolitux/theme** (design tokens)
+- [ ] **@smolitux/utils** (utilities)
+- [ ] **@smolitux/testing** (test helpers)
+
+### Tier 2: Layout & Visualization
+- [ ] **@smolitux/layout** (Container, Grid, Flex)
+- [ ] **@smolitux/charts** (AreaChart, BarChart, PieChart, etc.)
+
+### Tier 3: Advanced Features  
+- [ ] **@smolitux/media** (AudioPlayer, VideoPlayer)
+- [ ] **@smolitux/community** (ActivityFeed, UserProfile)
+
+### Tier 4: Specialized
+- [ ] **@smolitux/ai** (ContentAnalytics, SentimentDisplay)
+- [ ] **@smolitux/blockchain** (WalletConnect, TokenDisplay)
+- [ ] **@smolitux/resonance** (governance, monetization)
+- [ ] **@smolitux/federation** (cross-platform)
+- [ ] **@smolitux/voice-control** (voice engines)
+
+## 📊 Current Status:
+- **Total Packages:** 13
+- **Estimated Components:** 200+
+- **Coverage Goal:** ≥90% per component
+- **Focus:** TypeScript + Tests + Stories + Accessibility
+
+## 🚀 Next Actions:
+1. Analyze packages/@smolitux/core structure
+2. Identify missing/incomplete components
+3. Fix TypeScript errors
+4. Add missing tests (*.test.tsx)
+5. Add missing stories (*.stories.tsx)  
+6. Ensure accessibility compliance
+7. Update this file after each session
+
+## ✅ Completed Components
+- @smolitux/theme/ThemeProvider
+- @smolitux/utils/Box (stories)
+- @smolitux/utils/Flex
+- @smolitux/utils/Grid
+- @smolitux/utils/Text
+- @smolitux/community/ActivityFeed
+
+---
+*Updated by Codex AI*

--- a/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.stories.tsx
+++ b/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActivityFeed, ActivityItem } from './ActivityFeed';
+
+const meta: Meta<typeof ActivityFeed> = {
+  title: 'Community/ActivityFeed',
+  component: ActivityFeed,
+};
+export default meta;
+
+type Story = StoryObj<typeof ActivityFeed>;
+
+const sample: ActivityItem[] = [
+  {
+    id: '1',
+    type: 'post',
+    user: { id: 'u1', name: 'User', username: 'user' },
+    timestamp: new Date(),
+  },
+];
+
+export const Basic: Story = {
+  render: () => <ActivityFeed activities={sample} />,
+};

--- a/packages/@smolitux/community/src/components/ActivityFeed/__tests__/ActivityFeed.test.tsx
+++ b/packages/@smolitux/community/src/components/ActivityFeed/__tests__/ActivityFeed.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ActivityFeed, ActivityItem } from '../ActivityFeed';
+
+const activities: ActivityItem[] = [
+  {
+    id: '1',
+    type: 'post',
+    user: { id: 'u1', name: 'User', username: 'user' },
+    timestamp: new Date(),
+  },
+];
+
+describe('ActivityFeed', () => {
+  it('renders activities and triggers callbacks', async () => {
+    const handleClick = jest.fn();
+    render(
+      <ActivityFeed activities={activities} onActivityClick={handleClick} />
+    );
+    await userEvent.click(screen.getByText('User'));
+    expect(handleClick).toHaveBeenCalledWith(activities[0]);
+  });
+});

--- a/packages/@smolitux/theme/src/ThemeProvider.stories.tsx
+++ b/packages/@smolitux/theme/src/ThemeProvider.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ThemeProvider, useTheme } from './theme-provider';
+
+const meta: Meta = {
+  title: 'Theme/ThemeProvider',
+  component: ThemeProvider,
+};
+export default meta;
+
+type Story = StoryObj;
+
+const Demo = () => {
+  const { themeMode, toggleTheme } = useTheme();
+  return (
+    <button onClick={toggleTheme} style={{ padding: 8 }}>
+      Current: {themeMode}
+    </button>
+  );
+};
+
+export const Default: Story = {
+  render: () => (
+    <ThemeProvider>
+      <Demo />
+    </ThemeProvider>
+  ),
+};

--- a/packages/@smolitux/theme/src/__tests__/theme-provider.test.tsx
+++ b/packages/@smolitux/theme/src/__tests__/theme-provider.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ThemeProvider, useTheme } from '../theme-provider';
+
+function TestComponent() {
+  const { themeMode, toggleTheme } = useTheme();
+  return (
+    <button onClick={toggleTheme} data-testid="mode">
+      {themeMode}
+    </button>
+  );
+}
+
+describe('ThemeProvider', () => {
+  test('provides default light mode and toggles', async () => {
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    );
+    const btn = screen.getByTestId('mode');
+    expect(btn).toHaveTextContent('light');
+    await userEvent.click(btn);
+    expect(btn).toHaveTextContent('dark');
+  });
+});

--- a/packages/@smolitux/utils/src/components/primitives/Box.stories.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Box.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from './Box';
+
+const meta: Meta<typeof Box> = {
+  title: 'Utils/Primitives/Box',
+  component: Box,
+};
+export default meta;
+
+type Story = StoryObj<typeof Box>;
+
+export const Default: Story = {
+  render: () => <Box style={{ padding: 16, background: '#eee' }}>Box</Box>,
+};

--- a/packages/@smolitux/utils/src/components/primitives/Flex.stories.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Flex.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Flex } from './Flex';
+import { Box } from './Box';
+
+const meta: Meta<typeof Flex> = {
+  title: 'Utils/Primitives/Flex',
+  component: Flex,
+};
+export default meta;
+
+type Story = StoryObj<typeof Flex>;
+
+export const Row: Story = {
+  render: () => (
+    <Flex gap={8}>
+      <Box style={{ background: '#eee', padding: 8 }}>Item 1</Box>
+      <Box style={{ background: '#eee', padding: 8 }}>Item 2</Box>
+    </Flex>
+  ),
+};

--- a/packages/@smolitux/utils/src/components/primitives/Grid.stories.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Grid.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Grid } from './Grid';
+import { Box } from './Box';
+
+const meta: Meta<typeof Grid> = {
+  title: 'Utils/Primitives/Grid',
+  component: Grid,
+};
+export default meta;
+
+type Story = StoryObj<typeof Grid>;
+
+export const TwoColumns: Story = {
+  render: () => (
+    <Grid columns={2} gap={8}>
+      <Box style={{ background: '#eee', padding: 8 }}>1</Box>
+      <Box style={{ background: '#eee', padding: 8 }}>2</Box>
+    </Grid>
+  ),
+};

--- a/packages/@smolitux/utils/src/components/primitives/Text.stories.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Text.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Text } from './Text';
+
+const meta: Meta<typeof Text> = {
+  title: 'Utils/Primitives/Text',
+  component: Text,
+};
+export default meta;
+
+type Story = StoryObj<typeof Text>;
+
+export const Basic: Story = {
+  render: () => <Text size="lg" weight="bold">Hello</Text>,
+};

--- a/packages/@smolitux/utils/src/components/primitives/__tests__/Flex.test.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/__tests__/Flex.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Flex } from '../Flex';
+
+describe('Flex', () => {
+  it('renders with flex styles', () => {
+    const { container } = render(<Flex data-testid="flex" gap={4} />);
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveStyle({ display: 'flex' });
+    expect(div).toHaveStyle({ gap: '4' });
+  });
+});

--- a/packages/@smolitux/utils/src/components/primitives/__tests__/Grid.test.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/__tests__/Grid.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Grid } from '../Grid';
+
+describe('Grid', () => {
+  it('renders with grid styles', () => {
+    const { container } = render(<Grid columns={2} gap={8} />);
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveStyle({ display: 'grid' });
+    expect(div.style.gridTemplateColumns).toBe('repeat(2, 1fr)');
+  });
+});

--- a/packages/@smolitux/utils/src/components/primitives/__tests__/Text.test.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/__tests__/Text.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Text } from '../Text';
+
+describe('Text', () => {
+  it('renders with typographic styles', () => {
+    const { container } = render(<Text weight="bold" size="lg">Hello</Text>);
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveStyle({ fontWeight: 'bold' });
+    expect(el).toHaveStyle({ fontSize: 'lg' });
+  });
+});


### PR DESCRIPTION
## Summary
- add ThemeProvider tests and storybook entry
- add stories for Box, Flex, Grid, Text primitives
- add tests for Flex, Grid and Text primitives
- add ActivityFeed test and story
- update component progress list

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d08a63188324a8babd1f14e6dbd3