### PR TITLE
Improve WalletConnect types and modal test

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,6 +1,6 @@
 # Smolitux UI - Codex Progress
 
-**Started:** Sun Jun  8 19:47:27 UTC 2025
+**Started:** Sun Jun  8 20:13:59 UTC 2025
 **Strategy:** Work with existing codebase, no setup dependencies
 
 ## 🎯 Package Priority (from AGENTS.md):
@@ -37,9 +37,15 @@
 2. Identify missing/incomplete components
 3. Fix TypeScript errors
 4. Add missing tests (*.test.tsx)
-5. Add missing stories (*.stories.tsx)  
+5. Add missing stories (*.stories.tsx)
 6. Ensure accessibility compliance
 7. Update this file after each session
+
+### Session Update (2025-06-08)
+- Refactored `WalletConnect` to remove `any` types and added `EthereumProvider` interface
+- Added `data-testid` attribute for easier testing
+- Fixed `Modal.test.tsx` to remove `@ts-ignore` by mocking `ReactDOM.createPortal`
+- Lint/test/build commands attempted but failed due to missing tools
 
 ---
 *Updated by Codex AI*

--- a/packages/@smolitux/core/src/components/Modal/Modal.test.tsx
+++ b/packages/@smolitux/core/src/components/Modal/Modal.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as ReactDOM from 'react-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -7,13 +8,15 @@ import Modal from './Modal';
 describe('Modal Component', () => {
   // Mock für createPortal
   beforeAll(() => {
-    // @ts-ignore
-    jest.spyOn(React, 'createPortal').mockImplementation((children) => children);
+    jest
+      .spyOn(ReactDOM, 'createPortal')
+      .mockImplementation(
+        (node: React.ReactNode) => node as unknown as React.ReactPortal
+      );
   });
 
   afterAll(() => {
-    // @ts-ignore
-    React.createPortal.mockRestore();
+    (ReactDOM.createPortal as jest.Mock).mockRestore();
   });
 
   test('renders modal when isOpen is true', () => {


### PR DESCRIPTION
## Summary
- refine WalletConnect by introducing `EthereumProvider` type and data-testid
- remove `any` usages in WalletConnect
- update Modal tests to mock ReactDOM.createPortal without ts-ignore
- document session details in COMPONENT_STATUS.md

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test --workspace=@smolitux/core` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eee3236883249b58a91872f51490