### PR TITLE
Refine Grid typing and adjust jest config

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,6 +1,6 @@
 # Smolitux UI - Codex Progress
 
-**Started:** Sun Jun  8 20:13:59 UTC 2025
+**Started:** Sun Jun  8 20:18:39 UTC 2025
 **Strategy:** Work with existing codebase, no setup dependencies
 
 ## 🎯 Package Priority (from AGENTS.md):
@@ -41,11 +41,11 @@
 6. Ensure accessibility compliance
 7. Update this file after each session
 
-### Session Update (2025-06-08)
-- Refactored `WalletConnect` to remove `any` types and added `EthereumProvider` interface
-- Added `data-testid` attribute for easier testing
-- Fixed `Modal.test.tsx` to remove `@ts-ignore` by mocking `ReactDOM.createPortal`
-- Lint/test/build commands attempted but failed due to missing tools
+### Session 2025-06-08
+- Ran repository analyzer: overall test coverage at **80%**, story coverage at **83%**
+- Updated `Grid.tsx` to remove an `any` type using `ResponsiveProp` helper
+- Adjusted `@smolitux/core` Jest configuration for monorepo root
+- Test execution encountered numerous TypeScript errors across packages
 
 ---
 *Updated by Codex AI*

--- a/packages/@smolitux/core/jest.config.js
+++ b/packages/@smolitux/core/jest.config.js
@@ -1,6 +1,7 @@
+const path = require('path');
 const base = require('../../../jest.config');
 module.exports = {
   ...base,
-  rootDir: __dirname,
-  setupFilesAfterEnv: ['../../../jest.setup.js'],
+  rootDir: path.resolve(__dirname, '../../..'),
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/packages/@smolitux/core/src/components/Grid/Grid.tsx
+++ b/packages/@smolitux/core/src/components/Grid/Grid.tsx
@@ -9,6 +9,8 @@ export type GridFlow = 'row' | 'column' | 'row-dense' | 'column-dense';
 export type GridAutoFlow = 'auto' | 'min' | 'max' | 'fr';
 export type GridBreakpoint = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
+export type ResponsiveProp<T> = T | { [key in GridBreakpoint]?: T };
+
 export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Anzahl der Spalten
@@ -127,8 +129,8 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
     ref
   ) => {
     // Hilfsfunktion zum Generieren von Klassen für responsive Eigenschaften
-    const getResponsiveClasses = (
-      prop: any,
+    const getResponsiveClasses = <T extends string | number>(
+      prop: ResponsiveProp<T> | undefined,
       classPrefix: string,
       valueMap: Record<string, Record<string | number, string>>
     ): string => {


### PR DESCRIPTION
## Summary
- tweak Grid component typing with `ResponsiveProp`
- fix @smolitux/core jest config root path
- document analyzer results

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test --workspace=@smolitux/core` *(fails: multiple TypeScript errors)*
- `npm run build --workspace=@smolitux/core` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845efffdee8832494d671452c775a6e