### PR TITLE
Improve Footer tests and docs

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -37,9 +37,12 @@
 2. Identify missing/incomplete components
 3. Fix TypeScript errors
 4. Add missing tests (*.test.tsx)
-5. Add missing stories (*.stories.tsx)  
+5. Add missing stories (*.stories.tsx)
 6. Ensure accessibility compliance
 7. Update this file after each session
+
+### Recent Updates
+- ✅ @smolitux/layout Footer: tests and stories improved (2025-06-09)
 
 ---
 *Updated by Codex AI*

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -237,7 +237,7 @@ Dieser Bericht wird mit jeder Version aktualisiert, um den Fortschritt bei der T
 | @smolitux/layout | Container | ✅ Fertig |
 | @smolitux/layout | DashboardLayout | ❌ Offen |
 | @smolitux/layout | Flex | ✅ Fertig |
-| @smolitux/layout | Footer | ❌ Offen |
+| @smolitux/layout | Footer | ✅ Fertig |
 | @smolitux/layout | Grid | ✅ Fertig |
 | @smolitux/layout | Header | ❌ Offen |
 | @smolitux/layout | Sidebar | ✅ Fertig |

--- a/packages/@smolitux/layout/src/components/Footer/Footer.stories.tsx
+++ b/packages/@smolitux/layout/src/components/Footer/Footer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Footer } from './Footer';
 
 const meta: Meta<typeof Footer> = {
-  title: 'Components/Footer',
+  title: 'Layout/Footer',
   component: Footer,
   parameters: {
     layout: 'centered',
@@ -11,24 +11,34 @@ const meta: Meta<typeof Footer> = {
 };
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    children: 'Footer',
+    copyright: '© 2025 Smolitux',
+    links: <a href="/impressum">Impressum</a>,
   },
 };
 
-export const CustomStyle: Story = {
+export const Minimal: Story = {
   args: {
-    children: 'Custom Footer',
-    className: 'custom-style',
+    variant: 'minimal',
+    links: <a href="/datenschutz">Datenschutz</a>,
   },
 };
 
-export const Interactive: Story = {
+export const Colored: Story = {
   args: {
-    children: 'Interactive Footer',
-    onClick: () => alert('Clicked!'),
+    variant: 'colored',
+    color: 'secondary',
+    links: <a href="/kontakt">Kontakt</a>,
+  },
+};
+
+export const Fixed: Story = {
+  args: {
+    fixed: true,
+    links: <a href="/faq">FAQ</a>,
   },
 };

--- a/packages/@smolitux/layout/src/components/Footer/Footer.test.tsx
+++ b/packages/@smolitux/layout/src/components/Footer/Footer.test.tsx
@@ -3,19 +3,30 @@ import { render, screen } from '@testing-library/react';
 import { Footer } from './Footer';
 
 describe('Footer', () => {
-  it('renders without crashing', () => {
+  it('renders as contentinfo element', () => {
     render(<Footer />);
-    expect(screen.getByRole('button', { name: /Footer/i })).toBeInTheDocument();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
-    render(<Footer className="custom-class" />);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+    render(<Footer className="custom" />);
+    expect(screen.getByRole('contentinfo')).toHaveClass('custom');
   });
 
   it('forwards ref correctly', () => {
-    const ref = React.createRef<HTMLButtonElement>();
+    const ref = React.createRef<HTMLElement>();
     render(<Footer ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+
+  it('applies variant and color classes', () => {
+    render(<Footer variant="colored" color="secondary" data-testid="footer" />);
+    const footer = screen.getByTestId('footer');
+    expect(footer.className).toMatch('bg-secondary-600');
+  });
+
+  it('renders fixed footer when fixed prop is true', () => {
+    render(<Footer fixed data-testid="footer" />);
+    expect(screen.getByTestId('footer').className).toMatch('fixed');
   });
 });


### PR DESCRIPTION
## Summary
- update Footer stories with realistic props
- rewrite Footer tests for contentinfo element
- mark Footer done in status docs

## Testing
- `npm test --workspace=@smolitux/core` *(fails: Cannot find module '@testing-library/user-event', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845f5cf2138832489c099d91653804a