### PR TITLE
Fix TypeScript any usages

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,6 +1,6 @@
 # Smolitux UI - Codex Progress
 
-**Started:** Sun Jun  8 21:09:03 UTC 2025
+**Started:** Sun Jun  8 21:14:50 UTC 2025
 **Strategy:** Work with existing codebase, no setup dependencies
 
 ## 🎯 Package Priority (from AGENTS.md):
@@ -43,8 +43,7 @@
 
 ---
 *Updated by Codex AI*
-
-### Update 2025-06-08
-Repository analyzer confirms **100%** test and story coverage across all packages.
-However, **156 validation issues** remain (missing exports, `any` types, missing test IDs).
-Next focus: resolve these validation issues and ensure strict TypeScript compliance.
+## Update 2025-06-09
+- Replaced Record<string, any> with Record<string, unknown> for strict typing.
+- Updated ActivityStream and FederatedSearch components.
+- Next: fix validation issues in core.

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -267,3 +267,7 @@ Latest analyzer run reports **100%** test and story coverage for all packages.
 Identified **156 validation issues**: missing exports, `any` types and missing
 `data-testid` attributes. Manual refinements are required to achieve strict
 TypeScript compliance and resolve all validation warnings.
+### Update 2025-06-09 (Codex Session)
+- Replaced `Record<string, any>` with `Record<string, unknown>` for stricter typing.
+- Updated ActivityStream and FederatedSearch components to avoid 'any'.
+- Next: address remaining validation issues in core package.

--- a/packages/@smolitux/ai/src/components/RecommendationCarousel/RecommendationCarousel.tsx
+++ b/packages/@smolitux/ai/src/components/RecommendationCarousel/RecommendationCarousel.tsx
@@ -24,7 +24,7 @@ export interface RecommendationItem {
   /** Grund für die Empfehlung */
   reason?: string;
   /** Zusätzliche Metadaten zum empfohlenen Element */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface RecommendationGroup {

--- a/packages/@smolitux/blockchain/src/components/TokenDistributionChart/TokenDistributionChart.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenDistributionChart/TokenDistributionChart.tsx
@@ -11,7 +11,7 @@ export interface TokenDistributionSegment {
   /** Beschreibung des Segments */
   description?: string;
   /** Zusätzliche Metadaten zum Segment */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface TokenDistributionChartProps {

--- a/packages/@smolitux/charts/src/components/AreaChart/AreaChart.tsx
+++ b/packages/@smolitux/charts/src/components/AreaChart/AreaChart.tsx
@@ -15,7 +15,7 @@ export interface AreaChartDataPoint {
   /** Optional: Kategorie für Multi-Serien Charts */
   category?: string;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface AreaChartSeries {

--- a/packages/@smolitux/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/@smolitux/charts/src/components/BarChart/BarChart.tsx
@@ -10,7 +10,7 @@ export interface BarChartDataPoint {
   /** Optional: Farbe des Balkens */
   color?: string;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface BarChartSeries {

--- a/packages/@smolitux/charts/src/components/Heatmap/Heatmap.tsx
+++ b/packages/@smolitux/charts/src/components/Heatmap/Heatmap.tsx
@@ -10,7 +10,7 @@ export interface HeatmapDataPoint {
   /** Wert für die Farbintensität */
   value: number;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface HeatmapColorScale {

--- a/packages/@smolitux/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/@smolitux/charts/src/components/LineChart/LineChart.tsx
@@ -16,7 +16,7 @@ export interface LineChartDataPoint {
   /** Optional: Kategorie für Multi-Serien Charts */
   category?: string;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface LineChartSeries {

--- a/packages/@smolitux/charts/src/components/PieChart/PieChart.tsx
+++ b/packages/@smolitux/charts/src/components/PieChart/PieChart.tsx
@@ -16,7 +16,7 @@ export interface PieChartDataPoint {
   /** Optional: Farbe des Segments */
   color?: string;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface PieChartProps extends React.SVGProps<SVGSVGElement> {

--- a/packages/@smolitux/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/@smolitux/charts/src/components/RadarChart/RadarChart.tsx
@@ -8,7 +8,7 @@ export interface RadarChartDataPoint {
   /** Wert für die Achse */
   value: number;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface RadarChartSeries {

--- a/packages/@smolitux/charts/src/components/ScatterPlot/ScatterPlot.old.tsx
+++ b/packages/@smolitux/charts/src/components/ScatterPlot/ScatterPlot.old.tsx
@@ -16,7 +16,7 @@ export interface ScatterPlotDataPoint {
   /** Optional: Kategorie für Gruppierung */
   category?: string;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ScatterPlotSeries {

--- a/packages/@smolitux/charts/src/components/ScatterPlot/ScatterPlot.tsx
+++ b/packages/@smolitux/charts/src/components/ScatterPlot/ScatterPlot.tsx
@@ -16,7 +16,7 @@ export interface ScatterPlotDataPoint {
   /** Optional: Kategorie für Gruppierung */
   category?: string;
   /** Optional: Metadata für Tooltips etc. */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ScatterPlotSeries {

--- a/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
@@ -36,7 +36,7 @@ export interface ActivityItem {
     thumbnailUrl?: string;
   };
   /** Zusätzliche Metadaten zur Aktivität */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ActivityFeedProps {

--- a/packages/@smolitux/core/src/animations/Motion.tsx
+++ b/packages/@smolitux/core/src/animations/Motion.tsx
@@ -48,7 +48,7 @@ export type MotionProps = {
   /**
    * Die Keyframe-Animation, die angewendet werden soll
    */
-  animate?: KeyframeAnimation | Record<string, any>;
+  animate?: KeyframeAnimation | Record<string, unknown>;
 
   /**
    * Die Übergangseinstellungen

--- a/packages/@smolitux/core/src/animations/useAnimation.ts
+++ b/packages/@smolitux/core/src/animations/useAnimation.ts
@@ -3,7 +3,7 @@ import { keyframes, KeyframeAnimation } from './keyframes';
 import { TransitionPreset, transitions, TransitionPresetName } from './transitions';
 
 export type AnimationOptions = {
-  keyframe: KeyframeAnimation | Record<string, any>;
+  keyframe: KeyframeAnimation | Record<string, unknown>;
   transition?: TransitionPresetName | TransitionPreset;
   delay?: number;
   duration?: number;

--- a/packages/@smolitux/core/src/components/Carousel/Carousel.original.tsx
+++ b/packages/@smolitux/core/src/components/Carousel/Carousel.original.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useRef, useMemo, forwardRef, useCallback } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/Carousel/Carousel.tsx
+++ b/packages/@smolitux/core/src/components/Carousel/Carousel.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useRef, useMemo, forwardRef, useCallback } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@smolitux/core/src/components/ColorPicker/ColorPicker.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo, forwardRef } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/@smolitux/core/src/components/DatePicker/DatePicker.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, useState, useRef, useEffect, useCallback } from 'rea
 import ReactDOM from 'react-dom';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/Dialog/Dialog.tsx
+++ b/packages/@smolitux/core/src/components/Dialog/Dialog.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/Drawer/Drawer.tsx
+++ b/packages/@smolitux/core/src/components/Drawer/Drawer.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/@smolitux/core/src/components/FileUpload/FileUpload.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, useState, useRef, useEffect } from 'react';
 import { useFormControl } from '../FormControl/FormControl';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -20,7 +20,7 @@ try {
 }
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/MediaPlayer/MediaPlayer.tsx
+++ b/packages/@smolitux/core/src/components/MediaPlayer/MediaPlayer.tsx
@@ -2,7 +2,7 @@
 import React, { forwardRef, useRef, useImperativeHandle, useState, useEffect } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/Menu/Menu.tsx
+++ b/packages/@smolitux/core/src/components/Menu/Menu.tsx
@@ -10,7 +10,7 @@ import React, {
 } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/Popover/Popover.tsx
+++ b/packages/@smolitux/core/src/components/Popover/Popover.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useRef, useEffect, useId } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/TextArea/TextArea.tsx
+++ b/packages/@smolitux/core/src/components/TextArea/TextArea.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, useCallback, useEffect, useRef, useState, useId } fr
 import { useFormControl } from '../FormControl/FormControl';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/@smolitux/core/src/components/TimePicker/TimePicker.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { useFormControl } from '../FormControl/FormControl';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/core/src/components/Toast/Toast.tsx
+++ b/packages/@smolitux/core/src/components/Toast/Toast.tsx
@@ -2,7 +2,7 @@
 import React, { forwardRef, useState, useEffect, useId } from 'react';
 
 // Versuche den Theme-Import, mit Fallback für Tests und Entwicklung
-let useTheme: () => { themeMode: string; colors?: Record<string, any> };
+let useTheme: () => { themeMode: string; colors?: Record<string, unknown> };
 try {
   useTheme = require('@smolitux/theme').useTheme;
 } catch (e) {

--- a/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
@@ -59,7 +59,7 @@ export interface ActivityObject {
   /** Aktualisierungsdatum des Objekts */
   updated?: Date;
   /** Zusätzliche Attribute des Objekts */
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ActivityActor {
@@ -78,7 +78,7 @@ export interface ActivityActor {
   /** URL des Akteurs */
   url?: string;
   /** Zusätzliche Attribute des Akteurs */
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ActivityStreamItem {
@@ -106,7 +106,7 @@ export interface ActivityStreamItem {
     logoUrl?: string;
   };
   /** Zusätzliche Attribute der Aktivität */
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ActivityStreamProps {
@@ -125,7 +125,7 @@ export interface ActivityStreamProps {
   /** Callback beim Aktualisieren der Aktivitäten */
   onRefresh?: () => Promise<void>;
   /** Callback beim Filtern der Aktivitäten */
-  onFilter?: (filters: Record<string, any>) => Promise<void>;
+  onFilter?: (filters: Record<string, unknown>) => Promise<void>;
   /** Zusätzliche CSS-Klassen */
   className?: string;
   /** Ist die Komponente im Ladezustand? */
@@ -135,7 +135,7 @@ export interface ActivityStreamProps {
   /** Filteroptionen anzeigen? */
   showFilters?: boolean;
   /** Standardfilter */
-  defaultFilters?: Record<string, any>;
+  defaultFilters?: Record<string, unknown>;
 }
 
 /**
@@ -158,7 +158,7 @@ export const ActivityStream: React.FC<ActivityStreamProps> = ({
 }) => {
   const [loadingMore, setLoadingMore] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [filters, setFilters] = useState<Record<string, any>>(defaultFilters);
+  const [filters, setFilters] = useState<Record<string, unknown>>(defaultFilters);
   const [showFilterPanel, setShowFilterPanel] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const streamRef = useRef<HTMLDivElement>(null);

--- a/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
+++ b/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
@@ -20,7 +20,7 @@ export const FederatedSearch: React.FC<FederatedSearchProps> = ({
   const [activePlatforms, setActivePlatforms] = useState<string[]>(
     defaultActivePlatforms || platforms.filter((p) => p.isActive).map((p) => p.id)
   );
-  const [filters, setFilters] = useState<Record<string, any>>(defaultFilters);
+  const [filters, setFilters] = useState<Record<string, unknown>>(defaultFilters);
   const [isSearching, setIsSearching] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -73,7 +73,7 @@ export const FederatedSearch: React.FC<FederatedSearchProps> = ({
   };
 
   // Filter ändern
-  const handleFilterChange = (key: string, value: any) => {
+  const handleFilterChange = (key: string, value: unknown) => {
     setFilters((prev) => ({
       ...prev,
       [key]: value,

--- a/packages/@smolitux/federation/src/types/index.ts
+++ b/packages/@smolitux/federation/src/types/index.ts
@@ -48,7 +48,7 @@ export interface FederatedPlatform {
   /** Maximale Textlänge */
   maxTextLength?: number;
   /** Zusätzliche Metadaten zur Plattform */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 // Search related types
@@ -83,7 +83,7 @@ export interface SearchResult {
   /** Relevanz des Suchergebnisses (0-100) */
   relevance?: number;
   /** Zusätzliche Metadaten zum Suchergebnis */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface FederatedSearchProps {
@@ -93,7 +93,7 @@ export interface FederatedSearchProps {
   onSearch: (
     query: string,
     platforms: string[],
-    filters: Record<string, any>
+    filters: Record<string, unknown>
   ) => Promise<SearchResult[]>;
   /** Callback beim Klicken auf ein Suchergebnis */
   onResultClick?: (result: SearchResult) => void;
@@ -106,5 +106,5 @@ export interface FederatedSearchProps {
   /** Standardmäßig aktive Plattformen */
   defaultActivePlatforms?: string[];
   /** Standardmäßige Suchfilter */
-  defaultFilters?: Record<string, any>;
+  defaultFilters?: Record<string, unknown>;
 }

--- a/packages/@smolitux/media/src/components/MediaCarousel/MediaCarousel.tsx
+++ b/packages/@smolitux/media/src/components/MediaCarousel/MediaCarousel.tsx
@@ -31,7 +31,7 @@ export interface MediaItem {
   /** Ist das Medienelement ein Premium-Inhalt? */
   isPremium?: boolean;
   /** Zusätzliche Metadaten zum Medienelement */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface MediaCarouselProps {


### PR DESCRIPTION
## Summary
- replace `Record<string, any>` with `Record<string, unknown>` across packages
- update ActivityStream and FederatedSearch to avoid `any`
- document session results in COMPONENT_STATUS and component-status docs

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test --workspace=@smolitux/core` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fd22ebd083248aea5e3903540821