### PR TITLE
Fix some any casts in core

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,6 +1,6 @@
 # Smolitux UI - Codex Progress
 
-**Started:** Sun Jun  8 21:46:31 UTC 2025
+**Started:** Sun Jun  8 21:56:14 UTC 2025
 **Strategy:** Work with existing codebase, no setup dependencies
 
 ## 🎯 Package Priority (from AGENTS.md):
@@ -43,6 +43,7 @@
 
 ---
 *Updated by Codex AI*
-
-### Update 2025-06-10
-Analyzer reports 180 components with 100% test and story coverage. 126 validation issues remain. Next session will focus on strict TypeScript cleanup in @smolitux/core.
+### Update 2025-06-11
+- Removed 'as any' casts in List, List.a11y, Zoom, Zoom.a11y, LanguageSwitcher.
+- Updated Dialog story typing.
+- Analyzer reports 126 validation issues.

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -285,3 +285,8 @@ Latest analyzer run shows **100%** test and story coverage across 180 components
 
 ### Update 2025-06-10 (Analyzer Results)
 Latest analyzer run shows **100%** test and story coverage across 180 components. **126 validation issues** remain, primarily TypeScript "any" usage and missing `data-testid` attributes. Continue strict typing cleanup and fix remaining accessibility IDs.
+### Update 2025-06-11 (Codex Session)
+- Removed several `as any` casts in core components (List, Zoom, LanguageSwitcher).
+- Updated Dialog stories to use typed motion presets.
+- Analyzer still reports 126 validation issues after fixes.
+- Next: Continue TypeScript strict cleanup.

--- a/packages/@smolitux/core/src/components/Dialog/stories/Dialog.stories.tsx
+++ b/packages/@smolitux/core/src/components/Dialog/stories/Dialog.stories.tsx
@@ -369,7 +369,9 @@ export const WithForm: Story = {
 export const WithAnimations: Story = {
   render: () => {
     const [isOpen, setIsOpen] = React.useState(false);
-    const [motionPreset, setMotionPreset] = React.useState<string>('scale');
+    const [motionPreset, setMotionPreset] = React.useState<
+      'fade' | 'scale' | 'slide-from-top' | 'slide-from-bottom' | 'slide-from-left' | 'slide-from-right'
+    >('scale');
 
     return (
       <>
@@ -428,7 +430,7 @@ export const WithAnimations: Story = {
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
           title={`Animation: ${motionPreset}`}
-          motionPreset={motionPreset as any}
+          motionPreset={motionPreset}
         >
           <div className="p-6">
             <p className="mb-4">Dieser Dialog verwendet die Animation "{motionPreset}".</p>

--- a/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.a11y.tsx
+++ b/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.a11y.tsx
@@ -229,10 +229,10 @@ export const LanguageSwitcherA11y: React.FC<LanguageSwitcherProps> = ({
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown as any);
+    document.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      document.removeEventListener('keydown', handleKeyDown as any);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen]);
 

--- a/packages/@smolitux/core/src/components/List/List.a11y.tsx
+++ b/packages/@smolitux/core/src/components/List/List.a11y.tsx
@@ -535,7 +535,7 @@ export const ListItemA11y = forwardRef<HTMLLIElement, ListItemProps>(
           className={classes}
           role="listitem"
           aria-describedby={descriptionId}
-          {...(rest as any)}
+          {...(rest as React.HTMLAttributes<HTMLDivElement>)}
         >
           {renderDescription()}
           {renderContent()}

--- a/packages/@smolitux/core/src/components/List/List.tsx
+++ b/packages/@smolitux/core/src/components/List/List.tsx
@@ -309,8 +309,9 @@ export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
 
     // Für description-Listen
     if (variant === 'description') {
+      const divProps = rest as React.HTMLAttributes<HTMLDivElement>;
       return (
-        <div ref={ref as React.Ref<HTMLDivElement>} className={classes} {...(rest as any)}>
+        <div ref={ref as React.Ref<HTMLDivElement>} className={classes} {...divProps}>
           {renderContent()}
         </div>
       );

--- a/packages/@smolitux/core/src/components/Zoom/Zoom.a11y.tsx
+++ b/packages/@smolitux/core/src/components/Zoom/Zoom.a11y.tsx
@@ -261,20 +261,20 @@ export const ZoomA11y = forwardRef(
     };
 
     // Funktion zum Behandeln des Refs
-    const handleRef = (instance: any) => {
+    const handleRef = (instance: HTMLElement | null) => {
       // Wenn ref eine Funktion ist, rufen wir sie mit der Instanz auf
       if (typeof ref === 'function') {
         ref(instance);
       }
       // Wenn ref ein Objekt ist, setzen wir seine current-Eigenschaft
       else if (ref) {
-        (ref as React.MutableRefObject<any>).current = instance;
+        (ref as React.MutableRefObject<HTMLElement | null>).current = instance;
       }
     };
 
     // Wenn das Kind ein einzelnes React-Element ist, klonen wir es und fügen unsere Props hinzu
     if (React.isValidElement(children)) {
-      return React.cloneElement(children, {
+      return React.cloneElement(children as React.ReactElement, {
         ref: handleRef,
         style: {
           ...zoomStyle,
@@ -285,8 +285,8 @@ export const ZoomA11y = forwardRef(
           : children.props.className,
         'data-state': state,
         ...filteredAriaAttributes,
-        // Wir müssen die restlichen Props explizit übergeben, um TypeScript-Fehler zu vermeiden
-      } as any);
+        ...rest,
+      });
     }
 
     // Ansonsten wrappen wir die Kinder in einem Element

--- a/packages/@smolitux/core/src/components/Zoom/Zoom.tsx
+++ b/packages/@smolitux/core/src/components/Zoom/Zoom.tsx
@@ -143,7 +143,7 @@ export const Zoom = forwardRef(function Zoom(
 
   // Wenn es ein einzelnes Kind ist, klonen wir es und fügen die Transition-Props hinzu
   if (React.isValidElement(children)) {
-    return React.cloneElement(children, {
+    return React.cloneElement(children as React.ReactElement, {
       ref: handleRef,
       style: {
         ...zoomStyle,
@@ -154,8 +154,8 @@ export const Zoom = forwardRef(function Zoom(
         ? `${className} ${children.props.className || ''}`
         : children.props.className,
       'data-state': state,
-      // Wir müssen die restlichen Props explizit übergeben, um TypeScript-Fehler zu vermeiden
-    } as any);
+      ...rest,
+    });
   }
 
   // Ansonsten wrappen wir die Kinder in einem Element


### PR DESCRIPTION
## Summary
- remove `as any` casts in core components
- type `motionPreset` in Dialog stories
- document validation progress

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684606b0214c8324ae81fa716c283b0d