### PR TITLE
Improve utils helper validation

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -47,3 +47,5 @@
 - Removed 'as any' casts in List, List.a11y, Zoom, Zoom.a11y, LanguageSwitcher.
 - Updated Dialog story typing.
 - Analyzer reports 126 validation issues.
+### Update 2025-06-08
+- Improved chunk helper input validation.

--- a/packages/@smolitux/utils/src/helpers/helpers.ts
+++ b/packages/@smolitux/utils/src/helpers/helpers.ts
@@ -99,6 +99,10 @@ export function sortBy<T>(arr: T[], key: (item: T) => any): T[] {
 }
 
 export function chunk<T>(arr: T[], size: number): T[][] {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error('size must be a positive integer');
+  }
+
   const result: T[][] = [];
   for (let i = 0; i < arr.length; i += size) {
     result.push(arr.slice(i, i + size));


### PR DESCRIPTION
## Summary
- validate input size in chunk helper for utils
- record update in COMPONENT_STATUS

## Testing
- `npm run lint --workspace=@smolitux/utils` *(fails: Cannot find module '../lib/cli')*
- `npm run test --workspace=@smolitux/utils` *(fails: jest not found)*
- `npm run build --workspace=@smolitux/utils` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460ad241388324a6bcf0efcc94ad17