### PR TITLE
Add NFTGallery blockchain component

### DIFF
--- a/docs/wiki/development/component-status-blockchain.md
+++ b/docs/wiki/development/component-status-blockchain.md
@@ -11,5 +11,6 @@ This page tracks the implementation status for the `@smolitux/blockchain` packag
 | SmartContractInteraction | In progress |
 | TokenDistributionChart | In progress |
 | TokenEconomy | In progress |
+| NFTGallery | In progress |
 
-*Last updated: 2025-06-08*
+*Last updated: 2025-06-09*

--- a/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.stories.tsx
+++ b/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { NFTGallery, NFTItem } from './NFTGallery';
+
+const meta: Meta<typeof NFTGallery> = {
+  title: 'Components/NFTGallery',
+  component: NFTGallery,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const sampleNfts: NFTItem[] = [
+  {
+    tokenId: '1',
+    name: 'Eco NFT #1',
+    imageUrl: 'https://placekitten.com/200/200',
+    chainId: 1,
+  },
+  {
+    tokenId: '2',
+    name: 'Eco NFT #2',
+    imageUrl: 'https://placekitten.com/201/200',
+    chainId: 137,
+  },
+  {
+    tokenId: '3',
+    name: 'Eco NFT #3',
+    imageUrl: 'https://placekitten.com/202/200',
+    chainId: 1,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    nfts: sampleNfts,
+  },
+};
+
+export const Selectable: Story = {
+  args: {
+    nfts: sampleNfts,
+    onSelect: (nft) => alert(`Selected ${nft.tokenId}`),
+  },
+};

--- a/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.tsx
+++ b/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Card } from '@smolitux/core';
+
+export interface NFTItem {
+  tokenId: string;
+  name?: string;
+  imageUrl?: string;
+  description?: string;
+  chainId?: number;
+}
+
+export interface NFTGalleryProps {
+  /** NFTs to display */
+  nfts: NFTItem[];
+  /** Callback when NFT is selected */
+  onSelect?: (nft: NFTItem) => void;
+  /** Number of columns */
+  columns?: number;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * NFTGallery component to showcase NFTs in a grid layout
+ */
+export const NFTGallery: React.FC<NFTGalleryProps> = ({
+  nfts,
+  onSelect,
+  columns = 3,
+  className = '',
+}) => {
+  const handleClick = (nft: NFTItem) => {
+    if (onSelect) {
+      onSelect(nft);
+    }
+  };
+
+  return (
+    <div className={className} data-testid="nft-gallery">
+      <div
+        className="grid gap-4"
+        style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+      >
+        {nfts.map((nft) => (
+          <Card
+            key={nft.tokenId}
+            className="p-2 cursor-pointer hover:shadow-md transition-shadow"
+            onClick={() => handleClick(nft)}
+          >
+            {nft.imageUrl ? (
+              <img
+                src={nft.imageUrl}
+                alt={nft.name || `NFT ${nft.tokenId}`}
+                className="w-full h-48 object-cover rounded"
+              />
+            ) : (
+              <div className="w-full h-48 rounded bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-gray-500 dark:text-gray-400 text-sm">
+                No Image
+              </div>
+            )}
+            <div className="mt-2">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                {nft.name || `Token ${nft.tokenId}`}
+              </h4>
+              {nft.chainId && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">Chain ID: {nft.chainId}</p>
+              )}
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/@smolitux/blockchain/src/components/NFTGallery/__tests__/NFTGallery.a11y.test.tsx
+++ b/packages/@smolitux/blockchain/src/components/NFTGallery/__tests__/NFTGallery.a11y.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { NFTGallery, NFTItem } from '../NFTGallery';
+
+const nfts: NFTItem[] = [
+  { tokenId: '1', name: 'NFT 1', imageUrl: 'img1.png' },
+];
+
+describe('NFTGallery Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<NFTGallery nfts={nfts} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/blockchain/src/components/NFTGallery/__tests__/NFTGallery.test.tsx
+++ b/packages/@smolitux/blockchain/src/components/NFTGallery/__tests__/NFTGallery.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NFTGallery, NFTItem } from '../NFTGallery';
+
+describe('NFTGallery', () => {
+  const nfts: NFTItem[] = [
+    { tokenId: '1', name: 'NFT 1', imageUrl: 'img1.png', chainId: 1 },
+    { tokenId: '2', name: 'NFT 2', imageUrl: 'img2.png', chainId: 137 },
+  ];
+
+  it('renders a grid of NFTs', () => {
+    render(<NFTGallery nfts={nfts} />);
+
+    expect(screen.getByTestId('nft-gallery')).toBeInTheDocument();
+    expect(screen.getByAltText('NFT 1')).toBeInTheDocument();
+    expect(screen.getByAltText('NFT 2')).toBeInTheDocument();
+  });
+
+  it('handles selection', () => {
+    const onSelect = jest.fn();
+    render(<NFTGallery nfts={nfts} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByAltText('NFT 1'));
+    expect(onSelect).toHaveBeenCalledWith(nfts[0]);
+  });
+});

--- a/packages/@smolitux/blockchain/src/components/NFTGallery/index.ts
+++ b/packages/@smolitux/blockchain/src/components/NFTGallery/index.ts
@@ -1,0 +1,1 @@
+export * from './NFTGallery';

--- a/packages/@smolitux/blockchain/src/components/index.ts
+++ b/packages/@smolitux/blockchain/src/components/index.ts
@@ -6,3 +6,4 @@ export * from './TransactionHistory';
 // Export new components
 export * from './TokenEconomy';
 export * from './SmartContractInteraction';
+export * from './NFTGallery';

--- a/packages/@smolitux/blockchain/src/index.ts
+++ b/packages/@smolitux/blockchain/src/index.ts
@@ -11,4 +11,5 @@ export * from './components/TokenDistributionChart';
 // Export new Blockchain components
 export * from './components/TokenEconomy';
 export * from './components/SmartContractInteraction';
+export * from './components/NFTGallery';
 export * from './types';

--- a/packages/@smolitux/blockchain/src/types.ts
+++ b/packages/@smolitux/blockchain/src/types.ts
@@ -19,6 +19,19 @@ export interface TokenInfo {
   address: string;
 }
 
+export interface NFTItem {
+  /** Token ID */
+  tokenId: string;
+  /** NFT name */
+  name?: string;
+  /** Image URL */
+  imageUrl?: string;
+  /** Description */
+  description?: string;
+  /** Chain ID */
+  chainId?: number;
+}
+
 export type TransactionType = 'all' | 'send' | 'receive' | 'stake' | 'unstake' | 'reward' | 'fee';
 
 export interface Transaction {


### PR DESCRIPTION
## Summary
- implement `NFTGallery` with selection handling and grid layout
- export `NFTGallery` from package
- define new `NFTItem` type
- update blockchain component status doc

## Testing
- `bash scripts/smolitux-analyzer.sh --package=blockchain`
- `npx eslint packages/@smolitux/blockchain/src --ext .ts,.tsx -c .eslintrc.js` *(fails: config not supported)*
- `npm run test --workspace=@smolitux/blockchain` *(fails: jest not found)*
- `npm run build --workspace=@smolitux/blockchain` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a2f7cce0832487b897fccd9a41b0