### PR TITLE
Add Stack layout component

### DIFF
--- a/docs/wiki/development/component-status-layout.md
+++ b/docs/wiki/development/component-status-layout.md
@@ -10,5 +10,6 @@ This document tracks the current implementation and test status for the `@smolit
 | Header | ✅ | ❌ | ✅ | Needs A11y Tests |
 | Footer | ✅ | ❌ | ✅ | Needs A11y Tests |
 | Sidebar | ✅ | ✅ | ✅ | Ready |
+| Stack | ✅ | ❌ | ✅ | Pending |
 
-*Updated: 2025-06-12*
+*Updated: 2025-06-09*

--- a/packages/@smolitux/layout/src/components/Stack/Stack.stories.tsx
+++ b/packages/@smolitux/layout/src/components/Stack/Stack.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Stack } from './Stack';
+
+const meta: Meta<typeof Stack> = {
+  title: 'Layout/Stack',
+  component: Stack,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof Stack>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Stack {...args}>
+      <div className="bg-gray-200 p-2">Item 1</div>
+      <div className="bg-gray-200 p-2">Item 2</div>
+      <div className="bg-gray-200 p-2">Item 3</div>
+    </Stack>
+  ),
+  args: {
+    spacing: 2,
+    direction: 'vertical',
+  },
+};
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <Stack {...args}>
+      <div className="bg-gray-200 p-2">Item 1</div>
+      <div className="bg-gray-200 p-2">Item 2</div>
+      <div className="bg-gray-200 p-2">Item 3</div>
+    </Stack>
+  ),
+  args: {
+    spacing: 4,
+    direction: 'horizontal',
+  },
+};
+
+export const WithDivider: Story = {
+  render: (args) => (
+    <Stack {...args} divider={<span className="mx-1">|</span>}>
+      <span>One</span>
+      <span>Two</span>
+      <span>Three</span>
+    </Stack>
+  ),
+  args: {
+    direction: 'horizontal',
+    spacing: 2,
+  },
+};
+
+export const Responsive: Story = {
+  render: (args) => (
+    <Stack {...args}>
+      <div className="bg-gray-200 p-2">Item 1</div>
+      <div className="bg-gray-200 p-2">Item 2</div>
+      <div className="bg-gray-200 p-2">Item 3</div>
+    </Stack>
+  ),
+  args: {
+    direction: { sm: 'vertical', md: 'horizontal' },
+    spacing: { sm: 2, lg: 6 },
+  },
+};

--- a/packages/@smolitux/layout/src/components/Stack/Stack.test.tsx
+++ b/packages/@smolitux/layout/src/components/Stack/Stack.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Stack } from './Stack';
+
+describe('Stack', () => {
+  it('renders children', () => {
+    render(
+      <Stack data-testid="stack">
+        <span>One</span>
+        <span>Two</span>
+      </Stack>
+    );
+
+    expect(screen.getByTestId('stack')).toBeInTheDocument();
+    expect(screen.getByText('One')).toBeInTheDocument();
+    expect(screen.getByText('Two')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<Stack className="custom" data-testid="stack" />);
+    expect(screen.getByTestId('stack')).toHaveClass('custom');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Stack ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/packages/@smolitux/layout/src/components/Stack/Stack.tsx
+++ b/packages/@smolitux/layout/src/components/Stack/Stack.tsx
@@ -1,0 +1,68 @@
+import React, { forwardRef, Children, cloneElement } from 'react';
+import type { ResponsiveProp } from '../../types';
+
+export interface StackProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Anordnung der Elemente */
+  direction?: ResponsiveProp<'vertical' | 'horizontal'>;
+  /** Abstand zwischen den Elementen */
+  spacing?: ResponsiveProp<0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12>;
+  /** Trenn-Element zwischen den Kindern */
+  divider?: React.ReactElement;
+}
+
+const getClasses = <T extends string | number>(
+  prop: ResponsiveProp<T> | undefined,
+  prefix: string,
+  map?: Record<string, string>
+) => {
+  if (prop === undefined) return '';
+  const convert = (value: any) => (map ? map[value] || value : value);
+  if (typeof prop === 'object') {
+    return Object.entries(prop)
+      .map(([bp, val]) => `${bp}:${prefix}-${convert(val)}`)
+      .join(' ');
+  }
+  return `${prefix}-${convert(prop)}`;
+};
+
+export const Stack = forwardRef<HTMLDivElement, StackProps>(
+  (
+    {
+      direction = 'vertical',
+      spacing = 0,
+      divider,
+      className = '',
+      children,
+      ...rest
+    },
+    ref
+  ) => {
+    const directionClasses = getClasses(direction, 'flex', {
+      vertical: 'col',
+      horizontal: 'row',
+    });
+    const gapClasses = getClasses(spacing, 'gap');
+
+    const classes = ['flex', directionClasses, gapClasses, className]
+      .filter(Boolean)
+      .join(' ');
+
+    const content = divider
+      ? Children.toArray(children).flatMap((child, index, arr) =>
+          index < arr.length - 1
+            ? [child, cloneElement(divider, { key: `divider-${index}` })]
+            : [child]
+        )
+      : children;
+
+    return (
+      <div ref={ref} className={classes} {...rest}>
+        {content}
+      </div>
+    );
+  }
+);
+
+Stack.displayName = 'Stack';
+
+export default Stack;

--- a/packages/@smolitux/layout/src/index.ts
+++ b/packages/@smolitux/layout/src/index.ts
@@ -13,6 +13,7 @@ export {
   default as DashboardLayout,
   type DashboardLayoutProps,
 } from './components/DashboardLayout/DashboardLayout';
+export { default as Stack, type StackProps } from './components/Stack/Stack';
 export type {
   Breakpoint,
   ResponsiveProp,


### PR DESCRIPTION
## Summary
- implement new `Stack` component in @smolitux/layout for vertical or horizontal stacking
- add unit tests and Storybook stories
- export Stack in the layout package
- update layout component status documentation

## Testing
- `npm run lint --workspace=@smolitux/layout` *(fails: npm not found)*
- `npm run test --workspace=@smolitux/layout` *(fails: npm not found)*
- `npm run build --workspace=@smolitux/layout` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a339f7c083249227662a444e84ea