### PR TITLE
Add PlatformNotice test coverage

### DIFF
--- a/docs/wiki/development/component-status-resonance.md
+++ b/docs/wiki/development/component-status-resonance.md
@@ -23,5 +23,6 @@ This page tracks the implementation and test status of the platform specific com
 | Profile | ProfileHeader | ✅ | ✅ | ✅ | Ready |
 | Profile | ProfileWallet | ✅ | ✅ | ✅ | Ready |
 | Platform | PlatformIntegration | ✅ | ✅ | ✅ | Ready |
+| Platform | PlatformNotice | ✅ | ✅ | ✅ | Ready |
 
-> Last updated: 2025-06-08
+> Last updated: 2025-06-09

--- a/packages/@smolitux/resonance/src/components/platform/PlatformNotice.test.tsx
+++ b/packages/@smolitux/resonance/src/components/platform/PlatformNotice.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { PlatformNotice } from './PlatformNotice';
+import { PlatformInfo } from '../../platform/types';
+
+expect.extend(toHaveNoViolations);
+
+const unsupported: PlatformInfo = {
+  name: 'Unknown',
+  supported: false,
+  message: 'Unsupported platform',
+};
+
+const supported: PlatformInfo = {
+  name: 'Eco',
+  supported: true,
+};
+
+describe('PlatformNotice', () => {
+  it('renders message when platform not supported', () => {
+    render(<PlatformNotice platform={unsupported} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Unsupported platform');
+  });
+
+  it('renders nothing when platform supported', () => {
+    const { container } = render(<PlatformNotice platform={supported} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<PlatformNotice platform={unsupported} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Summary
- add missing test for `PlatformNotice`
- update Resonance component status docs

## Testing
- `npm run lint` *(fails: ESLint config issue)*
- `npm test` *(fails: missing modules and TS errors)*
- `npm run build --workspace=@smolitux/resonance` *(fails: could not resolve @smolitux/core)*

------
https://chatgpt.com/codex/tasks/task_e_6846a34ddfc48324beccd72a87f1e30c