### PR TITLE
Add render and helpers to testing package

### DIFF
--- a/packages/@smolitux/testing/__tests__/generators.test.ts
+++ b/packages/@smolitux/testing/__tests__/generators.test.ts
@@ -1,0 +1,10 @@
+import { generateId } from '../src/generators';
+
+describe('generateId', () => {
+  it('generates incremental ids', () => {
+    const a = generateId('test');
+    const b = generateId('test');
+    expect(a).toBe('test-1');
+    expect(b).toBe('test-2');
+  });
+});

--- a/packages/@smolitux/testing/__tests__/helpers.test.ts
+++ b/packages/@smolitux/testing/__tests__/helpers.test.ts
@@ -1,0 +1,13 @@
+import { render, userEvent } from '../src/helpers';
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { MockButton } from '../src/mocks';
+
+describe('helpers exports', () => {
+  it('re-exports utilities', async () => {
+    const handleClick = jest.fn();
+    render(<MockButton onClick={handleClick}>Ok</MockButton>);
+    await userEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/packages/@smolitux/testing/__tests__/mocks.test.tsx
+++ b/packages/@smolitux/testing/__tests__/mocks.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MockButton, MockInput } from '../src/mocks';
+
+describe('mock components', () => {
+  it('renders MockButton', () => {
+    render(<MockButton>Click</MockButton>);
+    expect(screen.getByTestId('mock-button')).toHaveTextContent('Click');
+  });
+
+  it('renders MockInput', () => {
+    render(<MockInput placeholder="test" />);
+    expect(screen.getByPlaceholderText('test')).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/testing/__tests__/providers.test.tsx
+++ b/packages/@smolitux/testing/__tests__/providers.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Providers from '../src/providers';
+import { MockButton } from '../src/mocks';
+
+describe('Providers wrapper', () => {
+  it('wraps children', () => {
+    render(
+      <Providers>
+        <MockButton>Text</MockButton>
+      </Providers>
+    );
+    expect(screen.getByTestId('mock-button')).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/testing/__tests__/render.test.tsx
+++ b/packages/@smolitux/testing/__tests__/render.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import render from '../src/render';
+import { MockButton } from '../src/mocks';
+
+describe('render utility', () => {
+  it('renders component with ThemeProvider', () => {
+    render(<MockButton>Ok</MockButton>);
+    expect(screen.getByTestId('mock-button')).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/testing/__tests__/setup.test.ts
+++ b/packages/@smolitux/testing/__tests__/setup.test.ts
@@ -1,0 +1,7 @@
+import '../src/setup';
+
+describe('setup', () => {
+  it('loads jest-dom', () => {
+    expect(expect.extend).toBeTruthy();
+  });
+});

--- a/packages/@smolitux/testing/__tests__/user-events.test.tsx
+++ b/packages/@smolitux/testing/__tests__/user-events.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { userEvent } from '../src/user-events';
+import render from '../src/render';
+import { MockButton } from '../src/mocks';
+
+describe('user-events', () => {
+  it('clicks through userEvent', async () => {
+    const handleClick = jest.fn();
+    render(<MockButton onClick={handleClick}>Press</MockButton>);
+    await userEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@smolitux/testing/src/generators.ts
+++ b/packages/@smolitux/testing/src/generators.ts
@@ -1,0 +1,4 @@
+export const generateId = (() => {
+  let count = 0;
+  return (prefix = 'id') => `${prefix}-${++count}`;
+})();

--- a/packages/@smolitux/testing/src/helpers.ts
+++ b/packages/@smolitux/testing/src/helpers.ts
@@ -1,0 +1,3 @@
+export * from './a11y';
+export { render } from './render';
+export { userEvent } from './user-events';

--- a/packages/@smolitux/testing/src/index.ts
+++ b/packages/@smolitux/testing/src/index.ts
@@ -7,14 +7,36 @@
 import a11y, { A11yTestOptions, A11yTestResult } from './a11y';
 import { registerA11yMatchers, a11yMatchers } from './a11y/matchers';
 import { customMatchers } from './customMatchers';
+import render from './render';
+import * as mocks from './mocks';
+import * as helpers from './helpers';
+import * as generators from './generators';
+import userEvent from './user-events';
 
 // Register custom Jest matchers on import
 expect.extend(customMatchers);
 
-export { a11y, A11yTestOptions, A11yTestResult, registerA11yMatchers, a11yMatchers, customMatchers };
+export {
+  a11y,
+  A11yTestOptions,
+  A11yTestResult,
+  registerA11yMatchers,
+  a11yMatchers,
+  customMatchers,
+  render,
+  mocks,
+  helpers,
+  generators,
+  userEvent,
+};
 
 export default {
   a11y,
   registerA11yMatchers,
   a11yMatchers,
+  render,
+  mocks,
+  helpers,
+  generators,
+  userEvent,
 };

--- a/packages/@smolitux/testing/src/mocks/apis.ts
+++ b/packages/@smolitux/testing/src/mocks/apis.ts
@@ -1,0 +1,7 @@
+export const mockFetch = jest.fn(() => Promise.resolve({ json: () => ({}) }));
+
+export const mockStorage = {
+  getItem: jest.fn(() => null),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+};

--- a/packages/@smolitux/testing/src/mocks/components.tsx
+++ b/packages/@smolitux/testing/src/mocks/components.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const MockButton = ({ children }: { children?: React.ReactNode }) => (
+  <button data-testid="mock-button">{children}</button>
+);
+
+export const MockInput = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+  <input data-testid="mock-input" {...props} />
+);

--- a/packages/@smolitux/testing/src/mocks/data.ts
+++ b/packages/@smolitux/testing/src/mocks/data.ts
@@ -1,0 +1,9 @@
+export const mockUser = {
+  id: 1,
+  name: 'Test User',
+};
+
+export const mockPosts = [
+  { id: 1, title: 'Hello World' },
+  { id: 2, title: 'Another Post' },
+];

--- a/packages/@smolitux/testing/src/mocks/index.ts
+++ b/packages/@smolitux/testing/src/mocks/index.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * from './data';
+export * from './apis';

--- a/packages/@smolitux/testing/src/providers.tsx
+++ b/packages/@smolitux/testing/src/providers.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react';
+import { ThemeProvider, ThemeOptions, defaultTheme } from '@smolitux/theme';
+
+export interface ProvidersProps {
+  children: ReactNode;
+  theme?: ThemeOptions;
+}
+
+/**
+ * Default test providers wrapper used by render utility.
+ */
+export const Providers: React.FC<ProvidersProps> = ({ children, theme = defaultTheme }) => (
+  <ThemeProvider value={theme}>{children}</ThemeProvider>
+);
+
+export default Providers;

--- a/packages/@smolitux/testing/src/render.tsx
+++ b/packages/@smolitux/testing/src/render.tsx
@@ -1,0 +1,22 @@
+import React, { ReactElement, ReactNode } from 'react';
+import { render as rtlRender, RenderOptions, RenderResult } from '@testing-library/react';
+import { ThemeProvider, defaultTheme, ThemeOptions } from '@smolitux/theme';
+
+export interface ProvidersOptions extends RenderOptions {
+  theme?: ThemeOptions;
+}
+
+/**
+ * Render a component wrapped with ThemeProvider and other test providers.
+ */
+export function render(ui: ReactElement, options: ProvidersOptions = {}): RenderResult {
+  const { theme = defaultTheme, ...rest } = options;
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <ThemeProvider value={theme}>{children}</ThemeProvider>
+  );
+
+  return rtlRender(ui, { wrapper: Wrapper, ...rest });
+}
+
+export default render;

--- a/packages/@smolitux/testing/src/setup.ts
+++ b/packages/@smolitux/testing/src/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/@smolitux/testing/src/user-events.ts
+++ b/packages/@smolitux/testing/src/user-events.ts
@@ -1,0 +1,4 @@
+import userEvent from '@testing-library/user-event';
+
+export { userEvent };
+export default userEvent;


### PR DESCRIPTION
## Summary
- add render utility wrapping ThemeProvider
- expose user-events, providers, and helpers
- add simple generator function
- add mock components, data, and apis
- create tests for new utilities

## Testing
- `npm run lint --workspace=@smolitux/testing` *(fails: ESLint couldn't find config)*
- `npm test --workspace=@smolitux/testing --silent` *(fails: jest not found)*
- `npm run build --workspace=@smolitux/testing` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a358d0e883248810c7248db45682