### PR TITLE
feat(voice-control): add VoiceRecognition component

### DIFF
--- a/docs/wiki/development/component-status-voice-control.md
+++ b/docs/wiki/development/component-status-voice-control.md
@@ -5,6 +5,7 @@
 | VoiceControlProvider | ✅ | ✅ | ✅ | Ready |
 | withVoiceControl | ✅ | ✅ | ✅ | Ready |
 | SpeechSynthesizer | ✅ | ✅ | ✅ | Ready |
+| VoiceRecognition | ✅ | ✅ | ✅ | Ready |
 | FeedbackManager | ✅ | – | – | Ready |
 | VoiceControlManager | ✅ | – | – | Ready |
 | WebSpeechRecognitionEngine | ✅ | – | – | Ready |

--- a/packages/@smolitux/voice-control/src/components/VoiceRecognition/VoiceRecognition.stories.tsx
+++ b/packages/@smolitux/voice-control/src/components/VoiceRecognition/VoiceRecognition.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { VoiceRecognition } from './VoiceRecognition';
+
+const meta: Meta<typeof VoiceRecognition> = {
+  title: 'Voice Control/VoiceRecognition',
+  component: VoiceRecognition,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+
+export const Default: StoryObj<typeof VoiceRecognition> = {
+  args: {},
+};

--- a/packages/@smolitux/voice-control/src/components/VoiceRecognition/VoiceRecognition.test.tsx
+++ b/packages/@smolitux/voice-control/src/components/VoiceRecognition/VoiceRecognition.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { VoiceRecognition } from './VoiceRecognition';
+
+expect.extend(toHaveNoViolations);
+
+declare global {
+  interface Window {
+    SpeechRecognition: any;
+    webkitSpeechRecognition: any;
+  }
+}
+
+describe('VoiceRecognition', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders unsupported message if API missing', () => {
+    delete (window as any).SpeechRecognition;
+    delete (window as any).webkitSpeechRecognition;
+    const { getByRole } = render(<VoiceRecognition />);
+    expect(getByRole('status')).toHaveTextContent('Speech recognition not supported');
+  });
+
+  it('starts and stops recognition', () => {
+    const start = jest.fn();
+    const stop = jest.fn();
+    const Mock = jest.fn().mockImplementation(() => ({ start, stop }));
+    window.SpeechRecognition = Mock;
+    const { getByRole } = render(<VoiceRecognition />);
+    const btn = getByRole('button');
+    fireEvent.click(btn);
+    expect(start).toHaveBeenCalled();
+    fireEvent.click(btn);
+    expect(stop).toHaveBeenCalled();
+  });
+
+  it('has no a11y violations', async () => {
+    window.SpeechRecognition = jest.fn().mockImplementation(() => ({ start: jest.fn(), stop: jest.fn() }));
+    const { container } = render(<VoiceRecognition />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/voice-control/src/components/VoiceRecognition/VoiceRecognition.tsx
+++ b/packages/@smolitux/voice-control/src/components/VoiceRecognition/VoiceRecognition.tsx
@@ -1,0 +1,90 @@
+import React, { forwardRef, useEffect, useState, useRef } from 'react';
+
+export interface VoiceRecognitionProps {
+  language?: string;
+  onResult?: (transcript: string, isFinal: boolean) => void;
+  autoStart?: boolean;
+  className?: string;
+}
+
+declare global {
+  interface Window {
+    webkitSpeechRecognition: typeof SpeechRecognition;
+  }
+}
+
+export const VoiceRecognition = forwardRef<HTMLDivElement, VoiceRecognitionProps>(
+  (
+    { language = 'en-US', onResult, autoStart = false, className },
+    ref
+  ) => {
+    const [supported, setSupported] = useState<boolean>(false);
+    const [listening, setListening] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
+    const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+    useEffect(() => {
+      const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SR) {
+        setSupported(false);
+        setError('Speech recognition not supported');
+        return;
+      }
+      setSupported(true);
+      const recognition = new SR();
+      recognition.lang = language;
+      recognition.interimResults = true;
+
+      recognition.onstart = () => setListening(true);
+      recognition.onend = () => setListening(false);
+      recognition.onerror = (e) => {
+        setError(e.error);
+        setListening(false);
+      };
+      recognition.onresult = (e) => {
+        const last = e.results[e.results.length - 1];
+        const transcript = last[0].transcript;
+        onResult?.(transcript, last.isFinal);
+      };
+
+      recognitionRef.current = recognition;
+      if (autoStart) recognition.start();
+
+      return () => {
+        recognition.stop();
+      };
+    }, [language, autoStart, onResult]);
+
+    const toggle = () => {
+      const r = recognitionRef.current;
+      if (!r) return;
+      try {
+        if (listening) r.stop();
+        else r.start();
+      } catch (e) {
+        // ignore start errors when already started
+      }
+    };
+
+    if (!supported) {
+      return (
+        <div ref={ref} className={className} role="status">
+          {error || 'Speech recognition not supported'}
+        </div>
+      );
+    }
+
+    return (
+      <div ref={ref} className={className}>
+        <button type="button" onClick={toggle} disabled={!!error}>
+          {listening ? 'Stop' : 'Start'}
+        </button>
+        {error && <div role="alert">{error}</div>}
+      </div>
+    );
+  }
+);
+
+VoiceRecognition.displayName = 'VoiceRecognition';
+
+export default VoiceRecognition;

--- a/packages/@smolitux/voice-control/src/components/VoiceRecognition/index.ts
+++ b/packages/@smolitux/voice-control/src/components/VoiceRecognition/index.ts
@@ -1,0 +1,2 @@
+export { VoiceRecognition } from './VoiceRecognition';
+export type { VoiceRecognitionProps } from './VoiceRecognition';

--- a/packages/@smolitux/voice-control/src/index.ts
+++ b/packages/@smolitux/voice-control/src/index.ts
@@ -17,3 +17,5 @@ export type {
   FeedbackType,
   RecognizerParams,
 } from './types';
+export { VoiceRecognition } from './components/VoiceRecognition';
+export type { VoiceRecognitionProps } from './components/VoiceRecognition';


### PR DESCRIPTION
## Summary
- add `VoiceRecognition` component under `@smolitux/voice-control`
- export new component from package index
- document component in wiki component status

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin)*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a3731b24832492485858bfbfc2f1