### PR TITLE
Add DonutChart and Histogram components

### DIFF
--- a/docs/wiki/development/component-status-charts.md
+++ b/docs/wiki/development/component-status-charts.md
@@ -2,12 +2,16 @@
 
 This page tracks the completion status of the chart components in the `@smolitux/charts` package.
 
-| Component   | Status  | Notes |
-|-------------|--------|-------|
+| Component   | Status      | Notes                                                      |
+| ----------- | ----------- | ---------------------------------------------------------- |
 | LineChart   | ✅ Complete | Data interfaces, config types and event handlers available |
-| BarChart    | ✅ Complete | Includes responsive behaviour and interactive features |
-| PieChart    | ✅ Complete | Supports donut mode and click events |
-| AreaChart   | ✅ Complete | Stacked and filled modes supported |
-| RadarChart  | ✅ Complete | Tooltips and point click callbacks included |
+| BarChart    | ✅ Complete | Includes responsive behaviour and interactive features     |
+| PieChart    | ✅ Complete | Supports donut mode and click events                       |
+| AreaChart   | ✅ Complete | Stacked and filled modes supported                         |
+| RadarChart  | ✅ Complete | Tooltips and point click callbacks included                |
+| ScatterPlot | ✅ Complete | Zoomable and pannable scatter chart                        |
+| Heatmap     | ✅ Complete | Color scale grid with keyboard navigation                  |
+| DonutChart  | ✅ Complete | Wrapper around PieChart with donut mode                    |
+| Histogram   | ✅ Complete | Displays frequency distribution using bars                 |
 
 _Last updated: 2025-06-12_

--- a/packages/@smolitux/charts/src/components/DonutChart/DonutChart.stories.tsx
+++ b/packages/@smolitux/charts/src/components/DonutChart/DonutChart.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { DonutChart } from './DonutChart';
+
+const meta: Meta<typeof DonutChart> = {
+  title: 'Charts/DonutChart',
+  component: DonutChart,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    height: { control: { type: 'number' } },
+    width: { control: { type: 'text' } },
+    showLegend: { control: { type: 'boolean' } },
+    showValues: { control: { type: 'boolean' } },
+    legendPosition: {
+      control: { type: 'radio' },
+      options: ['top', 'right', 'bottom', 'left'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DonutChart>;
+
+const sampleData = [
+  { label: 'A', value: 40 },
+  { label: 'B', value: 60 },
+];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    height: 300,
+    width: 300,
+    title: 'Distribution',
+    showLegend: true,
+    showValues: true,
+  },
+};

--- a/packages/@smolitux/charts/src/components/DonutChart/DonutChart.tsx
+++ b/packages/@smolitux/charts/src/components/DonutChart/DonutChart.tsx
@@ -1,0 +1,15 @@
+import React, { forwardRef } from 'react';
+import PieChart, { type PieChartProps } from '../PieChart/PieChart';
+
+export interface DonutChartProps extends Omit<PieChartProps, 'donut'> {}
+
+/**
+ * DonutChart is a thin wrapper around PieChart with donut mode enabled by default.
+ */
+export const DonutChart = forwardRef<SVGSVGElement, DonutChartProps>(({ ...props }, ref) => (
+  <PieChart ref={ref} donut {...props} />
+));
+
+DonutChart.displayName = 'DonutChart';
+
+export default DonutChart;

--- a/packages/@smolitux/charts/src/components/DonutChart/__tests__/DonutChart.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/DonutChart/__tests__/DonutChart.a11y.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { DonutChart } from '../DonutChart';
+
+expect.extend(toHaveNoViolations);
+
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' }),
+}));
+
+describe('DonutChart Accessibility', () => {
+  const mockData = [
+    { label: 'A', value: 40 },
+    { label: 'B', value: 60 },
+  ];
+
+  test('should have no accessibility violations', async () => {
+    const { container } = render(
+      <DonutChart data={mockData} title="Distribution" aria-label="Donut chart" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/charts/src/components/DonutChart/__tests__/DonutChart.snapshot.test.tsx
+++ b/packages/@smolitux/charts/src/components/DonutChart/__tests__/DonutChart.snapshot.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DonutChart } from '../DonutChart';
+
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' }),
+}));
+
+describe('DonutChart Snapshots', () => {
+  const mockData = [
+    { label: 'A', value: 40 },
+    { label: 'B', value: 60 },
+  ];
+
+  it('renders default chart', () => {
+    const { asFragment } = render(<DonutChart data={mockData} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/charts/src/components/DonutChart/__tests__/DonutChart.test.tsx
+++ b/packages/@smolitux/charts/src/components/DonutChart/__tests__/DonutChart.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DonutChart } from '../DonutChart';
+
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' }),
+}));
+
+describe('DonutChart', () => {
+  const mockData = [
+    { label: 'A', value: 40 },
+    { label: 'B', value: 60 },
+  ];
+
+  test('renders donut chart with default props', () => {
+    render(<DonutChart data={mockData} />);
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  test('passes through width and height', () => {
+    render(<DonutChart data={mockData} width={300} height={300} />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '300');
+    expect(svg).toHaveAttribute('height', '300');
+  });
+
+  test('applies custom className', () => {
+    render(<DonutChart data={mockData} className="custom" />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveClass('custom');
+  });
+});

--- a/packages/@smolitux/charts/src/components/DonutChart/index.ts
+++ b/packages/@smolitux/charts/src/components/DonutChart/index.ts
@@ -1,0 +1,1 @@
+export { default, type DonutChartProps } from './DonutChart';

--- a/packages/@smolitux/charts/src/components/Histogram/Histogram.stories.tsx
+++ b/packages/@smolitux/charts/src/components/Histogram/Histogram.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { Histogram } from './Histogram';
+
+const meta: Meta<typeof Histogram> = {
+  title: 'Charts/Histogram',
+  component: Histogram,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    height: { control: { type: 'number' } },
+    width: { control: { type: 'text' } },
+    bins: { control: { type: 'number' } },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Histogram>;
+
+const sampleData = [12, 15, 16, 17, 18, 19, 18, 17, 20, 21, 22, 23];
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    bins: 5,
+    height: 300,
+    width: 600,
+    title: 'Sample Histogram',
+  },
+};

--- a/packages/@smolitux/charts/src/components/Histogram/Histogram.tsx
+++ b/packages/@smolitux/charts/src/components/Histogram/Histogram.tsx
@@ -1,0 +1,43 @@
+import React, { forwardRef, useMemo } from 'react';
+import BarChart, { type BarChartProps, type BarChartSeries } from '../BarChart/BarChart';
+
+export interface HistogramProps extends Omit<BarChartProps, 'data'> {
+  /** Numeric values to bin */
+  data: number[];
+  /** Number of bins */
+  bins?: number;
+}
+
+/**
+ * Histogram visualises frequency distribution of numeric data using BarChart.
+ */
+export const Histogram = forwardRef<SVGSVGElement, HistogramProps>(
+  ({ data, bins = 10, ...rest }, ref) => {
+    const barSeries = useMemo<BarChartSeries>(() => {
+      if (!data || data.length === 0) {
+        return { id: 'hist', name: 'Histogram', data: [] };
+      }
+      const min = Math.min(...data);
+      const max = Math.max(...data);
+      const step = (max - min) / bins;
+      const counts = new Array(bins).fill(0);
+      data.forEach((value) => {
+        const index = Math.min(Math.floor((value - min) / step), bins - 1);
+        counts[index]++;
+      });
+      const barData = counts.map((count, i) => {
+        const start = min + step * i;
+        const end = start + step;
+        const label = `${start.toFixed(1)}-${end.toFixed(1)}`;
+        return { label, value: count };
+      });
+      return { id: 'hist', name: 'Histogram', data: barData };
+    }, [data, bins]);
+
+    return <BarChart ref={ref} data={barSeries} {...rest} />;
+  }
+);
+
+Histogram.displayName = 'Histogram';
+
+export default Histogram;

--- a/packages/@smolitux/charts/src/components/Histogram/__tests__/Histogram.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/Histogram/__tests__/Histogram.a11y.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Histogram } from '../Histogram';
+
+expect.extend(toHaveNoViolations);
+
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' }),
+}));
+
+describe('Histogram Accessibility', () => {
+  const values = [1, 2, 2, 3, 4, 5, 5];
+
+  test('should have no accessibility violations', async () => {
+    const { container } = render(
+      <Histogram data={values} bins={4} aria-label="Histogram" title="Values" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/charts/src/components/Histogram/__tests__/Histogram.snapshot.test.tsx
+++ b/packages/@smolitux/charts/src/components/Histogram/__tests__/Histogram.snapshot.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Histogram } from '../Histogram';
+
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' }),
+}));
+
+describe('Histogram Snapshots', () => {
+  const values = [1, 2, 2, 3, 4, 5, 5];
+
+  it('renders default chart', () => {
+    const { asFragment } = render(<Histogram data={values} bins={4} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/charts/src/components/Histogram/__tests__/Histogram.test.tsx
+++ b/packages/@smolitux/charts/src/components/Histogram/__tests__/Histogram.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Histogram } from '../Histogram';
+
+jest.mock('@smolitux/theme', () => ({
+  useTheme: () => ({ themeMode: 'light' }),
+}));
+
+describe('Histogram', () => {
+  const values = [1, 2, 2, 3, 4, 5, 5];
+
+  test('renders histogram', () => {
+    const { container } = render(<Histogram data={values} bins={4} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/charts/src/components/Histogram/index.ts
+++ b/packages/@smolitux/charts/src/components/Histogram/index.ts
@@ -1,0 +1,1 @@
+export { default, type HistogramProps } from './Histogram';

--- a/packages/@smolitux/charts/src/index.ts
+++ b/packages/@smolitux/charts/src/index.ts
@@ -41,3 +41,5 @@ export {
   type RadarChartSeries,
   type RadarChartDataPoint,
 } from './components/RadarChart/RadarChart';
+export { default as DonutChart, type DonutChartProps } from './components/DonutChart/DonutChart';
+export { default as Histogram, type HistogramProps } from './components/Histogram/Histogram';


### PR DESCRIPTION
## Summary
- add `DonutChart` wrapper component for Pie charts
- implement `Histogram` component using `BarChart`
- update chart exports
- document new chart components in the status page

## Testing
- `npx eslint "packages/**/*.{ts,tsx}"` *(fails: context.getSource is not a function)*
- `npm run test` *(fails to run due to missing modules in other packages)*
- `npm run build` *(fails due to TypeScript errors in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6846a3145e088324846c13352156e8e8