### PR TITLE
Add ProtocolHandler component

### DIFF
--- a/docs/wiki/development/component-status-federation.md
+++ b/docs/wiki/development/component-status-federation.md
@@ -11,6 +11,7 @@ This page tracks the progress and quality of the **federation** package. Compone
 | FederatedSearch | ✅ | ❌ | ❌ | Needs A11y Tests |
 | FederationStatus | ✅ | ❌ | ❌ | Needs A11y Tests |
 | PlatformSelector | ✅ | ❌ | ❌ | Needs A11y Tests |
+| ProtocolHandler | ✅ | ❌ | ❌ | Needs A11y Tests |
 
 ## Next Steps
 
@@ -20,4 +21,4 @@ This page tracks the progress and quality of the **federation** package. Compone
 4. Ensure all components export strict TypeScript types with no `any` usage.
 5. Add accessibility tests for interactive elements.
 
-_Last updated: 2025-06-08 by Codex_
+_Last updated: 2025-06-09 by Codex_

--- a/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.stories.tsx
+++ b/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProtocolHandler } from './ProtocolHandler';
+import { SupportedProtocol } from '../../types';
+
+const meta: Meta<typeof ProtocolHandler> = {
+  title: 'Federation/ProtocolHandler',
+  component: ProtocolHandler,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Handles connections to federation protocols like ActivityPub or Matrix.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof ProtocolHandler>;
+
+const protocols: SupportedProtocol[] = [
+  {
+    name: 'ActivityPub',
+    version: '1.0',
+    capabilities: ['messages', 'search'],
+    endpoints: [{ path: 'wss://example.com/ap', method: 'GET' }],
+    authentication: ['none'],
+  },
+  {
+    name: 'Matrix',
+    version: '1.7',
+    capabilities: ['messages', 'presence'],
+    endpoints: [{ path: 'wss://example.com/matrix', method: 'GET' }],
+    authentication: ['token'],
+  },
+];
+
+export const Default: Story = {
+  args: {
+    protocols,
+  },
+};

--- a/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.test.tsx
+++ b/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { ProtocolHandler } from './ProtocolHandler';
+import { SupportedProtocol } from '../../types';
+
+const protocols: SupportedProtocol[] = [
+  {
+    name: 'ActivityPub',
+    version: '1.0',
+    capabilities: ['messages'],
+    endpoints: [{ path: 'ws://example.com/ap', method: 'GET' }],
+    authentication: ['none'],
+  },
+];
+
+describe('ProtocolHandler', () => {
+  it('renders protocol list', () => {
+    render(<ProtocolHandler protocols={protocols} />);
+    expect(screen.getByText('ActivityPub')).toBeInTheDocument();
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = render(<ProtocolHandler protocols={protocols} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('reconnect button calls connect', async () => {
+    const user = userEvent.setup();
+    render(<ProtocolHandler protocols={protocols} />);
+    await user.click(screen.getByRole('button', { name: /Reconnect/i }));
+    expect(screen.getByTestId('protocol-handler')).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
+++ b/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Button } from '@smolitux/core';
+import {
+  ProtocolHandlerProps,
+  ProtocolConnection,
+  SupportedProtocol,
+  ProtocolMessage,
+} from '../../types';
+
+interface ConnectionState {
+  status: ProtocolConnection['status'];
+  socket?: WebSocket;
+}
+
+export const ProtocolHandler: React.FC<ProtocolHandlerProps> = ({
+  protocols,
+  onMessage,
+  onConnection,
+  errorHandling = { retries: 3, retryDelay: 1000 },
+  authentication,
+  className,
+}) => {
+  const [connections, setConnections] = useState<Record<string, ConnectionState>>(
+    {}
+  );
+
+  useEffect(() => {
+    protocols.forEach((protocol) => {
+      connect(protocol);
+    });
+
+    return () => {
+      Object.values(connections).forEach((conn) => conn.socket?.close());
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [protocols]);
+
+  const connect = (protocol: SupportedProtocol) => {
+    const endpoint = protocol.endpoints.find((e) => e.method === 'GET');
+    if (!endpoint) return;
+
+    updateConnection(protocol.name, { status: 'connecting' });
+    const socket = new WebSocket(endpoint.path);
+
+    socket.onopen = () => {
+      updateConnection(protocol.name, { status: 'connected', socket });
+      onConnection?.({ protocol: protocol.name, status: 'connected' });
+    };
+
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        onMessage?.({ protocol: protocol.name, content: data });
+      } catch {
+        onMessage?.({ protocol: protocol.name, content: { raw: event.data } });
+      }
+    };
+
+    socket.onerror = () => {
+      updateConnection(protocol.name, { status: 'error' });
+      onConnection?.({ protocol: protocol.name, status: 'error' });
+      retry(protocol, 1);
+    };
+
+    socket.onclose = () => {
+      updateConnection(protocol.name, { status: 'disconnected' });
+      onConnection?.({ protocol: protocol.name, status: 'disconnected' });
+    };
+  };
+
+  const retry = (protocol: SupportedProtocol, attempt: number) => {
+    if (attempt > (errorHandling.retries || 0)) return;
+    setTimeout(() => connect(protocol), errorHandling.retryDelay || 1000);
+  };
+
+  const updateConnection = (
+    name: SupportedProtocol['name'],
+    state: Partial<ConnectionState>
+  ) => {
+    setConnections((prev) => ({
+      ...prev,
+      [name]: { ...prev[name], ...state },
+    }));
+  };
+
+  return (
+    <Card className={className} data-testid="protocol-handler">
+      <h3 className="font-semibold mb-2">Protocol Connections</h3>
+      <ul className="space-y-1">
+        {protocols.map((p) => (
+          <li key={p.name} className="flex items-center justify-between">
+            <span>{p.name}</span>
+            <span>{connections[p.name]?.status || 'disconnected'}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 text-right">
+        <Button
+          size="sm"
+          onClick={() =>
+            protocols.forEach((protocol) => connect(protocol))
+          }
+        >
+          Reconnect
+        </Button>
+      </div>
+    </Card>
+  );
+};
+
+export default ProtocolHandler;

--- a/packages/@smolitux/federation/src/components/ProtocolHandler/index.ts
+++ b/packages/@smolitux/federation/src/components/ProtocolHandler/index.ts
@@ -1,0 +1,1 @@
+export * from './ProtocolHandler';

--- a/packages/@smolitux/federation/src/index.ts
+++ b/packages/@smolitux/federation/src/index.ts
@@ -9,3 +9,4 @@ export { PlatformSelector } from './components/PlatformSelector';
 export { ActivityStream } from './components/ActivityStream';
 export { FederationStatus } from './components/FederationStatus';
 export { CrossPlatformShare } from './components/CrossPlatformShare';
+export { ProtocolHandler } from './components/ProtocolHandler';

--- a/packages/@smolitux/federation/src/types/index.ts
+++ b/packages/@smolitux/federation/src/types/index.ts
@@ -108,3 +108,50 @@ export interface FederatedSearchProps {
   /** Standardmäßige Suchfilter */
   defaultFilters?: Record<string, unknown>;
 }
+
+export type ProtocolCapability = 'messages' | 'presence' | 'search' | 'media';
+
+export interface ProtocolEndpoint {
+  path: string;
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+}
+
+export type AuthMethod = 'none' | 'token' | 'basic' | 'oauth2';
+
+export interface SupportedProtocol {
+  name: 'ActivityPub' | 'ATProtocol' | 'Matrix' | 'Nostr' | 'RSS';
+  version: string;
+  capabilities: ProtocolCapability[];
+  endpoints: ProtocolEndpoint[];
+  authentication: AuthMethod[];
+}
+
+export interface ProtocolMessage {
+  protocol: SupportedProtocol['name'];
+  content: Record<string, unknown>;
+}
+
+export interface ProtocolConnection {
+  protocol: SupportedProtocol['name'];
+  status: 'connected' | 'connecting' | 'disconnected' | 'error';
+}
+
+export interface ProtocolErrorHandling {
+  retries?: number;
+  retryDelay?: number;
+}
+
+export interface ProtocolAuth {
+  token?: string;
+  username?: string;
+  password?: string;
+}
+
+export interface ProtocolHandlerProps {
+  protocols: SupportedProtocol[];
+  onMessage?: (message: ProtocolMessage) => void;
+  onConnection?: (connection: ProtocolConnection) => void;
+  errorHandling?: ProtocolErrorHandling;
+  authentication?: ProtocolAuth;
+  className?: string;
+}


### PR DESCRIPTION
## Summary
- add ProtocolHandler federation component
- define protocol handler types
- export new component and update federation status docs

## Testing
- `npm run lint --workspace=@smolitux/federation` *(fails: ESLint couldn't find config)*
- `npm run test --workspace=@smolitux/federation` *(fails: jest not found)*
- `npm run build --workspace=@smolitux/federation` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a5e4f9d48324bb31ea56c72e7968