### PR TITLE
feat(charts): add ChartAxis and ChartLegend components

### DIFF
--- a/docs/wiki/accessibility/components/chartaxis.md
+++ b/docs/wiki/accessibility/components/chartaxis.md
@@ -1,0 +1,5 @@
+# ChartAxis Barrierefreiheit
+
+- Beschriftungen werden als `<text>`-Elemente ausgegeben und sind damit von Screenreadern erfassbar.
+- Kontrastreiche Farben sollten für Texte und Linien gewählt werden.
+- Achsenlabels können mit `aria-label` am übergeordneten `<svg>`-Element ergänzt werden.

--- a/docs/wiki/accessibility/components/chartlegend.md
+++ b/docs/wiki/accessibility/components/chartlegend.md
@@ -1,0 +1,5 @@
+# ChartLegend Barrierefreiheit
+
+- Legendentexte sind als `<text>`-Elemente vorhanden und somit zugänglich.
+- Farbmarkierungen sollten ausreichenden Kontrast zum Hintergrund haben.
+- Bei horizontaler Ausrichtung genug Abstand für Tastaturfokus einplanen.

--- a/docs/wiki/components/charts/README.md
+++ b/docs/wiki/components/charts/README.md
@@ -1,0 +1,6 @@
+# Charts Komponenten
+
+- [BarChart](bar-chart.md)
+- [LineChart](line-chart.md)
+- [ChartAxis](chart-axis.md)
+- [ChartLegend](chart-legend.md)

--- a/docs/wiki/components/charts/chart-axis.md
+++ b/docs/wiki/components/charts/chart-axis.md
@@ -1,0 +1,32 @@
+# ChartAxis
+
+Die **ChartAxis**-Komponente stellt eine wiederverwendbare SVG-Achse für Diagramme bereit. Sie kann horizontal oder vertikal ausgerichtet werden und unterstützt Ticks sowie ein optionales Achsenlabel.
+
+## Import
+```jsx
+import { ChartAxis } from '@smolitux/charts';
+```
+
+## Verwendung
+```jsx
+<svg width={200} height={60}>
+  <ChartAxis
+    length={180}
+    ticks={[{ value: 0, position: 0 }, { value: 100, position: 1 }]}
+    orientation="horizontal"
+    axisLabel="X-Axis"
+  />
+</svg>
+```
+
+## Props
+| Prop | Typ | Beschreibung |
+|------|-----|--------------|
+| `length` | `number` | Länge der Achse |
+| `orientation` | `'horizontal' \| 'vertical'` | Ausrichtung der Achse |
+| `ticks` | `ChartAxisTick[]` | Tick-Werte und Positionen |
+| `axisLabel` | `string` | Beschriftung der Achse |
+| `className` | `string` | Zusätzliche CSS-Klasse |
+
+## Barrierefreiheit
+Die Achse verwendet ein `svg`-Element mit semantischen `<line>`- und `<text>`-Elementen. Alle Texte sind per Screenreader erfassbar.

--- a/docs/wiki/components/charts/chart-legend.md
+++ b/docs/wiki/components/charts/chart-legend.md
@@ -1,0 +1,30 @@
+# ChartLegend
+
+Die **ChartLegend**-Komponente zeigt eine einfache Legende für Diagramme an. Die Einträge können horizontal oder vertikal angeordnet werden.
+
+## Import
+```jsx
+import { ChartLegend } from '@smolitux/charts';
+```
+
+## Verwendung
+```jsx
+<svg width={200} height={80}>
+  <ChartLegend
+    items={[{ label: 'A', color: '#ff0000' }, { label: 'B', color: '#00ff00' }]}
+    direction="horizontal"
+  />
+</svg>
+```
+
+## Props
+| Prop | Typ | Beschreibung |
+|------|-----|--------------|
+| `items` | `LegendItem[]` | Einträge der Legende |
+| `direction` | `'horizontal' \| 'vertical'` | Ausrichtung der Einträge |
+| `itemSpacing` | `number` | Abstand zwischen den Einträgen |
+| `markerSize` | `number` | Größe der Farbmarkierung |
+| `className` | `string` | Zusätzliche CSS-Klasse |
+
+## Barrierefreiheit
+Alle Texte der Legende sind innerhalb des SVG lesbar und können von Screenreadern erfasst werden.

--- a/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.stories.tsx
+++ b/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { ChartAxis } from './ChartAxis';
+
+const meta: Meta<typeof ChartAxis> = {
+  title: 'Charts/ChartAxis',
+  component: ChartAxis,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: { control: { type: 'radio' }, options: ['horizontal', 'vertical'] },
+    length: { control: { type: 'number' } },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChartAxis>;
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <svg width={200} height={60} viewBox="0 0 200 60">
+      <ChartAxis {...args} />
+    </svg>
+  ),
+  args: {
+    length: 180,
+    ticks: [
+      { value: 0, position: 0 },
+      { value: 50, position: 0.5 },
+      { value: 100, position: 1 },
+    ],
+    orientation: 'horizontal',
+    axisLabel: 'X-Axis',
+  },
+};
+
+export const Vertical: Story = {
+  render: (args) => (
+    <svg width={80} height={200} viewBox="0 0 80 200">
+      <ChartAxis {...args} />
+    </svg>
+  ),
+  args: {
+    length: 180,
+    orientation: 'vertical',
+    ticks: [
+      { value: 0, position: 0 },
+      { value: 50, position: 0.5 },
+      { value: 100, position: 1 },
+    ],
+    axisLabel: 'Y-Axis',
+  },
+};

--- a/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.tsx
@@ -1,0 +1,86 @@
+import React, { forwardRef } from 'react';
+
+export interface ChartAxisTick {
+  /** Wert des Ticks */
+  value: string | number;
+  /** Position relativ (0-1) */
+  position: number;
+  /** Optionales Label */
+  label?: string;
+}
+
+export interface ChartAxisProps extends React.SVGAttributes<SVGGElement> {
+  /** Orientierung der Achse */
+  orientation?: 'horizontal' | 'vertical';
+  /** Gesamtlänge der Achse */
+  length: number;
+  /** Ticks für die Achse */
+  ticks?: ChartAxisTick[];
+  /** Achsenlabel */
+  axisLabel?: string;
+  /** Abstand der Ticks */
+  tickSize?: number;
+}
+
+/**
+ * Universelle Achsen-Komponente für SVG-Charts
+ */
+export const ChartAxis = forwardRef<SVGGElement, ChartAxisProps>(
+  (
+    {
+      orientation = 'horizontal',
+      length,
+      ticks = [],
+      axisLabel,
+      tickSize = 6,
+      className = '',
+      ...rest
+    },
+    ref,
+  ) => {
+    const isHorizontal = orientation === 'horizontal';
+    const axisLine = isHorizontal
+      ? { x1: 0, y1: 0, x2: length, y2: 0 }
+      : { x1: 0, y1: 0, x2: 0, y2: length };
+
+    return (
+      <g ref={ref} className={`smolitux-chart-axis ${className}`.trim()} {...rest} data-testid="chart-axis">
+        <line {...axisLine} stroke="currentColor" />
+        {ticks.map((tick) => {
+          const pos = tick.position * length;
+          const tickProps = isHorizontal
+            ? { x1: pos, y1: 0, x2: pos, y2: tickSize }
+            : { x1: 0, y1: pos, x2: -tickSize, y2: pos };
+          const textProps = isHorizontal
+            ? { x: pos, y: tickSize + 12, textAnchor: 'middle' as const }
+            : { x: -tickSize - 2, y: pos, textAnchor: 'end' as const, dominantBaseline: 'middle' as const };
+          return (
+            <g key={tick.value} className="tick">
+              <line {...tickProps} stroke="currentColor" />
+              <text {...textProps} fontSize="12" fill="currentColor">
+                {tick.label ?? tick.value}
+              </text>
+            </g>
+          );
+        })}
+        {axisLabel && (
+          <text
+            x={isHorizontal ? length / 2 : -tickSize - 20}
+            y={isHorizontal ? tickSize + 28 : length / 2}
+            textAnchor="middle"
+            transform={isHorizontal ? undefined : `rotate(-90, ${-tickSize - 20}, ${length / 2})`}
+            fontSize="12"
+            fontWeight="bold"
+            fill="currentColor"
+          >
+            {axisLabel}
+          </text>
+        )}
+      </g>
+    );
+  },
+);
+
+ChartAxis.displayName = 'ChartAxis';
+
+export default ChartAxis;

--- a/packages/@smolitux/charts/src/components/ChartAxis/__tests__/ChartAxis.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/ChartAxis/__tests__/ChartAxis.a11y.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { ChartAxis } from '../ChartAxis';
+
+expect.extend(toHaveNoViolations);
+
+describe('ChartAxis Accessibility', () => {
+  it('has no violations', async () => {
+    const { container } = render(
+      <svg>
+        <ChartAxis length={100} ticks={[{ value: 0, position: 0 }]} />
+      </svg>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/charts/src/components/ChartAxis/__tests__/ChartAxis.snapshot.test.tsx
+++ b/packages/@smolitux/charts/src/components/ChartAxis/__tests__/ChartAxis.snapshot.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ChartAxis } from '../ChartAxis';
+
+describe('ChartAxis Snapshot', () => {
+  it('matches snapshot', () => {
+    const { asFragment } = render(
+      <svg>
+        <ChartAxis length={100} ticks={[{ value: 0, position: 0 }]} />
+      </svg>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/charts/src/components/ChartAxis/__tests__/ChartAxis.test.tsx
+++ b/packages/@smolitux/charts/src/components/ChartAxis/__tests__/ChartAxis.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChartAxis } from '../ChartAxis';
+
+describe('ChartAxis', () => {
+  it('renders axis line', () => {
+    render(
+      <svg>
+        <ChartAxis length={100} />
+      </svg>,
+    );
+    expect(screen.getByTestId('chart-axis')).toBeInTheDocument();
+  });
+
+  it('renders ticks', () => {
+    const ticks = [
+      { value: 0, position: 0 },
+      { value: 10, position: 1 },
+    ];
+    render(
+      <svg>
+        <ChartAxis length={100} ticks={ticks} />
+      </svg>,
+    );
+    expect(screen.getAllByText('0')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('10')[0]).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/charts/src/components/ChartAxis/index.ts
+++ b/packages/@smolitux/charts/src/components/ChartAxis/index.ts
@@ -1,0 +1,1 @@
+export { default, type ChartAxisProps, type ChartAxisTick } from './ChartAxis';

--- a/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.stories.tsx
+++ b/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { ChartLegend } from './ChartLegend';
+
+const meta: Meta<typeof ChartLegend> = {
+  title: 'Charts/ChartLegend',
+  component: ChartLegend,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    direction: { control: { type: 'radio' }, options: ['horizontal', 'vertical'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChartLegend>;
+
+const legendItems = [
+  { label: 'Series A', color: '#ff0000' },
+  { label: 'Series B', color: '#00ff00' },
+];
+
+export const Vertical: Story = {
+  render: (args) => (
+    <svg width={200} height={80} viewBox="0 0 200 80">
+      <ChartLegend {...args} />
+    </svg>
+  ),
+  args: {
+    items: legendItems,
+    direction: 'vertical',
+  },
+};
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <svg width={200} height={40} viewBox="0 0 200 40">
+      <ChartLegend {...args} />
+    </svg>
+  ),
+  args: {
+    items: legendItems,
+    direction: 'horizontal',
+  },
+};

--- a/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.tsx
@@ -1,0 +1,59 @@
+import React, { forwardRef } from 'react';
+
+export interface LegendItem {
+  /** Beschriftung des Eintrags */
+  label: string;
+  /** Farbe des Eintrags */
+  color: string;
+}
+
+export interface ChartLegendProps extends React.SVGAttributes<SVGGElement> {
+  /** Einträge der Legende */
+  items: LegendItem[];
+  /** Ausrichtung der Einträge */
+  direction?: 'horizontal' | 'vertical';
+  /** Abstand zwischen den Einträgen */
+  itemSpacing?: number;
+  /** Größe der Farbmarkierung */
+  markerSize?: number;
+}
+
+/**
+ * Wiederverwendbare SVG-Legende
+ */
+export const ChartLegend = forwardRef<SVGGElement, ChartLegendProps>(
+  (
+    {
+      items,
+      direction = 'vertical',
+      itemSpacing = 20,
+      markerSize = 12,
+      className = '',
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <g ref={ref} className={`smolitux-chart-legend ${className}`.trim()} {...rest} data-testid="chart-legend">
+        {items.map((item, index) => {
+          const translate =
+            direction === 'vertical'
+              ? `translate(0, ${index * itemSpacing})`
+              : `translate(${index * (markerSize * 4)}, 0)`;
+          return (
+            <g key={item.label} transform={translate} className="legend-item">
+              <rect width={markerSize} height={markerSize} fill={item.color} rx={2} />
+              <text x={markerSize + 4} y={markerSize / 2} dominantBaseline="middle" fontSize="12" fill="currentColor">
+                {item.label}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+    );
+  },
+);
+
+ChartLegend.displayName = 'ChartLegend';
+
+export default ChartLegend;

--- a/packages/@smolitux/charts/src/components/ChartLegend/__tests__/ChartLegend.a11y.test.tsx
+++ b/packages/@smolitux/charts/src/components/ChartLegend/__tests__/ChartLegend.a11y.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { ChartLegend } from '../ChartLegend';
+
+expect.extend(toHaveNoViolations);
+
+describe('ChartLegend Accessibility', () => {
+  it('has no violations', async () => {
+    const items = [{ label: 'A', color: '#ff0000' }];
+    const { container } = render(
+      <svg>
+        <ChartLegend items={items} />
+      </svg>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/charts/src/components/ChartLegend/__tests__/ChartLegend.snapshot.test.tsx
+++ b/packages/@smolitux/charts/src/components/ChartLegend/__tests__/ChartLegend.snapshot.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ChartLegend } from '../ChartLegend';
+
+describe('ChartLegend Snapshot', () => {
+  it('matches snapshot', () => {
+    const items = [{ label: 'A', color: '#ff0000' }];
+    const { asFragment } = render(
+      <svg>
+        <ChartLegend items={items} />
+      </svg>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/@smolitux/charts/src/components/ChartLegend/__tests__/ChartLegend.test.tsx
+++ b/packages/@smolitux/charts/src/components/ChartLegend/__tests__/ChartLegend.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChartLegend } from '../ChartLegend';
+
+describe('ChartLegend', () => {
+  const items = [
+    { label: 'A', color: '#ff0000' },
+    { label: 'B', color: '#00ff00' },
+  ];
+
+  it('renders legend items', () => {
+    render(
+      <svg>
+        <ChartLegend items={items} />
+      </svg>,
+    );
+    expect(screen.getByTestId('chart-legend')).toBeInTheDocument();
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+});

--- a/packages/@smolitux/charts/src/components/ChartLegend/index.ts
+++ b/packages/@smolitux/charts/src/components/ChartLegend/index.ts
@@ -1,0 +1,1 @@
+export { default, type ChartLegendProps, type LegendItem } from './ChartLegend';

--- a/packages/@smolitux/charts/src/index.ts
+++ b/packages/@smolitux/charts/src/index.ts
@@ -43,3 +43,5 @@ export {
 } from './components/RadarChart/RadarChart';
 export { default as DonutChart, type DonutChartProps } from './components/DonutChart/DonutChart';
 export { default as Histogram, type HistogramProps } from './components/Histogram/Histogram';
+export { default as ChartAxis, type ChartAxisProps, type ChartAxisTick } from './components/ChartAxis/ChartAxis';
+export { default as ChartLegend, type ChartLegendProps, type LegendItem } from './components/ChartLegend/ChartLegend';

--- a/packages/@smolitux/charts/tsconfig.json
+++ b/packages/@smolitux/charts/tsconfig.json
@@ -2,8 +2,22 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "paths": {
+      "@smolitux/theme": ["../../theme/src"],
+      "@smolitux/utils": ["../../utils/src"],
+      "@smolitux/core": ["../../core/src"]
+    }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.old.tsx",
+    "**/*.old.*.tsx",
+    "**/*.stories.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- add reusable ChartAxis and ChartLegend components
- provide tests and stories
- document new charts helpers
- update charts package exports and tsconfig

## Testing
- `npm run lint --workspace=@smolitux/charts` *(fails: Cannot find module '../lib/cli')*
- `npm run test --workspace=@smolitux/charts` *(fails: Jest configuration error)*
- `npm run build --workspace=@smolitux/charts` *(fails: TS6059 path issues)*

------
https://chatgpt.com/codex/tasks/task_e_6846aa8e4c848324bf7441a211832911