### PR TITLE
Automated component annotation

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -46,3 +46,5 @@
 
 ### Update 2025-06-13
 - Added automated annotation script for TODO/FIXME comments.
+
+### Update 2025-06-09 - Automated TODO/FIXME scan executed.

--- a/docs/wiki/development/component-fixme.md
+++ b/docs/wiki/development/component-fixme.md
@@ -4,3 +4,19 @@ Diese Datei sammelt automatisch erkannte FIXMEs in den Komponenten.
 
 ### Update 2025-06-13
 - Initial file created with automated annotator script `scripts/annotate-components.js`.
+
+### Update 2025-06-09 - Automated annotations
+## @smolitux/core
+
+| Komponente | FIXMEs |
+|------------|-------|
+| Dropdown | Props nicht typisiert |
+| Flex | Props nicht typisiert |
+| Menu | Props nicht typisiert |
+
+## @smolitux/layout
+
+| Komponente | FIXMEs |
+|------------|-------|
+| Grid | Props nicht typisiert |
+

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -303,3 +303,5 @@ See also [Resonance Component Status](./component-status-resonance.md) for packa
 
 ### Update 2025-06-13
 - Added automated annotation script for TODO/FIXME comments.
+
+### Update 2025-06-09 - Automated TODO/FIXME scan executed.

--- a/docs/wiki/development/component-todo.md
+++ b/docs/wiki/development/component-todo.md
@@ -162,3 +162,125 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 ### Update 2025-06-13
 - Added automate TODO/FIXME annotator script `scripts/annotate-components.js`.
 
+
+### Update 2025-06-09 - Automated annotations
+## @smolitux/ai
+
+| Komponente | TODOs |
+|------------|-------|
+| ContentAnalytics | forwardRef hinzufügen |
+| ContentModerator | forwardRef hinzufügen |
+| EngagementScore | forwardRef hinzufügen |
+| FakeNewsDetector | forwardRef hinzufügen |
+| RecommendationCarousel | forwardRef hinzufügen |
+| SentimentDisplay | forwardRef hinzufügen |
+| TrendingTopics | forwardRef hinzufügen |
+| TrollFilter | forwardRef hinzufügen |
+
+## @smolitux/blockchain
+
+| Komponente | TODOs |
+|------------|-------|
+| NFTGallery | forwardRef hinzufügen, Tests fehlen |
+| SmartContractInteraction | forwardRef hinzufügen, Tests fehlen |
+| StakingInterface | forwardRef hinzufügen, Tests fehlen |
+| TokenDisplay | forwardRef hinzufügen, Tests fehlen |
+| TokenDistributionChart | forwardRef hinzufügen, Tests fehlen |
+| TokenEconomy | forwardRef hinzufügen, Tests fehlen |
+| TransactionHistory | forwardRef hinzufügen, Tests fehlen |
+| WalletConnect | forwardRef hinzufügen, Tests fehlen |
+
+## @smolitux/charts
+
+| Komponente | TODOs |
+|------------|-------|
+| ChartAxis | Tests fehlen |
+| ChartLegend | Tests fehlen |
+| DonutChart | Tests fehlen |
+| Histogram | Tests fehlen |
+
+## @smolitux/community
+
+| Komponente | TODOs |
+|------------|-------|
+| ActivityFeed | forwardRef hinzufügen |
+| CommentSection | forwardRef hinzufügen |
+| FollowButton | forwardRef hinzufügen |
+| NotificationCenter | forwardRef hinzufügen |
+| UserProfile | forwardRef hinzufügen |
+
+## @smolitux/core
+
+| Komponente | TODOs |
+|------------|-------|
+| Accordion | forwardRef hinzufügen |
+| Alert | forwardRef hinzufügen |
+| Avatar | forwardRef hinzufügen |
+| Badge | forwardRef hinzufügen |
+| Collapse | forwardRef hinzufügen |
+| ColorPicker | forwardRef hinzufügen |
+| Dialog | forwardRef hinzufügen |
+| Drawer | forwardRef hinzufügen |
+| Form | forwardRef hinzufügen |
+| FormField | forwardRef hinzufügen |
+| LanguageSwitcher | forwardRef hinzufügen |
+| Menu | forwardRef hinzufügen |
+| Modal | forwardRef hinzufügen |
+| Popover | forwardRef hinzufügen |
+| RadioGroup | forwardRef hinzufügen |
+| Select | forwardRef hinzufügen |
+| Slide | forwardRef hinzufügen |
+| Stepper | forwardRef hinzufügen |
+| TabView | forwardRef hinzufügen |
+| Table | forwardRef hinzufügen |
+| Tabs | forwardRef hinzufügen |
+| Textarea | forwardRef hinzufügen |
+| Toast | forwardRef hinzufügen |
+| Tooltip | forwardRef hinzufügen |
+| voice | forwardRef hinzufügen |
+
+## @smolitux/federation
+
+| Komponente | TODOs |
+|------------|-------|
+| ActivityStream | forwardRef hinzufügen |
+| CrossPlatformShare | forwardRef hinzufügen |
+| FederatedSearch | forwardRef hinzufügen |
+| FederationStatus | forwardRef hinzufügen |
+| PlatformSelector | forwardRef hinzufügen |
+| ProtocolHandler | forwardRef hinzufügen |
+
+## @smolitux/layout
+
+| Komponente | TODOs |
+|------------|-------|
+| DashboardLayout | forwardRef hinzufügen |
+
+## @smolitux/media
+
+| Komponente | TODOs |
+|------------|-------|
+| AudioPlayer | forwardRef hinzufügen |
+| ImageGallery | forwardRef hinzufügen |
+| MediaCarousel | forwardRef hinzufügen |
+| MediaGrid | forwardRef hinzufügen |
+| MediaUploader | forwardRef hinzufügen |
+| VideoPlayer | forwardRef hinzufügen |
+
+## @smolitux/resonance
+
+| Komponente | TODOs |
+|------------|-------|
+| feed | forwardRef hinzufügen |
+| governance | forwardRef hinzufügen |
+| monetization | forwardRef hinzufügen |
+| platform | forwardRef hinzufügen |
+| post | forwardRef hinzufügen |
+| profile | forwardRef hinzufügen |
+
+## @smolitux/utils
+
+| Komponente | TODOs |
+|------------|-------|
+| patterns | forwardRef hinzufügen |
+

--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -20,3 +20,5 @@
 
 ### Update 2025-06-13
 - Added annotation script entry in docs.
+
+### Update 2025-06-09 - Automated TODO/FIXME scan executed.

--- a/packages/@smolitux/ai/src/components/ContentAnalytics/ContentAnalytics.tsx
+++ b/packages/@smolitux/ai/src/components/ContentAnalytics/ContentAnalytics.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 

--- a/packages/@smolitux/ai/src/components/ContentModerator/ContentModerator.tsx
+++ b/packages/@smolitux/ai/src/components/ContentModerator/ContentModerator.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/ai/src/components/EngagementScore/EngagementScore.tsx
+++ b/packages/@smolitux/ai/src/components/EngagementScore/EngagementScore.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, ProgressBar, Tooltip } from '@smolitux/core';
 

--- a/packages/@smolitux/ai/src/components/FakeNewsDetector/FakeNewsDetector.tsx
+++ b/packages/@smolitux/ai/src/components/FakeNewsDetector/FakeNewsDetector.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, Tooltip, ProgressBar } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/ai/src/components/RecommendationCarousel/RecommendationCarousel.tsx
+++ b/packages/@smolitux/ai/src/components/RecommendationCarousel/RecommendationCarousel.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 
 export interface RecommendationItem {

--- a/packages/@smolitux/ai/src/components/SentimentDisplay/SentimentDisplay.tsx
+++ b/packages/@smolitux/ai/src/components/SentimentDisplay/SentimentDisplay.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { useResponseCache } from '../../utils/useResponseCache';
 import { Card, Button, ProgressBar } from '@smolitux/core';

--- a/packages/@smolitux/ai/src/components/TrendingTopics/TrendingTopics.tsx
+++ b/packages/@smolitux/ai/src/components/TrendingTopics/TrendingTopics.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 

--- a/packages/@smolitux/ai/src/components/TrollFilter/TrollFilter.tsx
+++ b/packages/@smolitux/ai/src/components/TrollFilter/TrollFilter.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button, ProgressBar } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.tsx
+++ b/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card } from '@smolitux/core';
 

--- a/packages/@smolitux/blockchain/src/components/SmartContractInteraction/SmartContractInteraction.tsx
+++ b/packages/@smolitux/blockchain/src/components/SmartContractInteraction/SmartContractInteraction.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/blockchain/src/components/StakingInterface/StakingInterface.tsx
+++ b/packages/@smolitux/blockchain/src/components/StakingInterface/StakingInterface.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, Input, ProgressBar } from '@smolitux/core';
 

--- a/packages/@smolitux/blockchain/src/components/TokenDisplay/TokenDisplay.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenDisplay/TokenDisplay.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card } from '@smolitux/core';
 import { TokenInfo } from '../types';

--- a/packages/@smolitux/blockchain/src/components/TokenDistributionChart/TokenDistributionChart.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenDistributionChart/TokenDistributionChart.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 import { Card } from '@smolitux/core';
 

--- a/packages/@smolitux/blockchain/src/components/TokenEconomy/TokenEconomy.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenEconomy/TokenEconomy.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/blockchain/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/@smolitux/blockchain/src/components/TransactionHistory/TransactionHistory.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 import { TransactionType, Transaction } from '../types';

--- a/packages/@smolitux/blockchain/src/components/WalletConnect/WalletConnect.tsx
+++ b/packages/@smolitux/blockchain/src/components/WalletConnect/WalletConnect.tsx
@@ -1,3 +1,5 @@
+// TODO: Tests fehlen
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Button, Card } from '@smolitux/core';
 import { EthereumProvider } from '../types';

--- a/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.tsx
@@ -1,3 +1,4 @@
+// TODO: Tests fehlen
 import React, { forwardRef } from 'react';
 
 export interface ChartAxisTick {

--- a/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.tsx
@@ -1,3 +1,4 @@
+// TODO: Tests fehlen
 import React, { forwardRef } from 'react';
 
 export interface LegendItem {

--- a/packages/@smolitux/charts/src/components/DonutChart/DonutChart.tsx
+++ b/packages/@smolitux/charts/src/components/DonutChart/DonutChart.tsx
@@ -1,3 +1,4 @@
+// TODO: Tests fehlen
 import React, { forwardRef } from 'react';
 import PieChart, { type PieChartProps } from '../PieChart/PieChart';
 

--- a/packages/@smolitux/charts/src/components/Histogram/Histogram.tsx
+++ b/packages/@smolitux/charts/src/components/Histogram/Histogram.tsx
@@ -1,3 +1,4 @@
+// TODO: Tests fehlen
 import React, { forwardRef, useMemo } from 'react';
 import BarChart, { type BarChartProps, type BarChartSeries } from '../BarChart/BarChart';
 

--- a/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 

--- a/packages/@smolitux/community/src/components/CommentSection/CommentSection.tsx
+++ b/packages/@smolitux/community/src/components/CommentSection/CommentSection.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, ChangeEvent } from 'react';
 import { Button, Input } from '@smolitux/core';
 

--- a/packages/@smolitux/community/src/components/FollowButton/FollowButton.tsx
+++ b/packages/@smolitux/community/src/components/FollowButton/FollowButton.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Button } from '@smolitux/core';
 

--- a/packages/@smolitux/community/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/packages/@smolitux/community/src/components/NotificationCenter/NotificationCenter.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@smolitux/core';
 

--- a/packages/@smolitux/community/src/components/UserProfile/UserProfile.tsx
+++ b/packages/@smolitux/community/src/components/UserProfile/UserProfile.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 

--- a/packages/@smolitux/core/src/components/Accordion/Accordion.tsx
+++ b/packages/@smolitux/core/src/components/Accordion/Accordion.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Accordion/Accordion.tsx
 import React, { useState, createContext, useContext } from 'react';
 

--- a/packages/@smolitux/core/src/components/Accordion/AccordionItem.tsx
+++ b/packages/@smolitux/core/src/components/Accordion/AccordionItem.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Accordion/AccordionItem.tsx
 import React, { useRef, useState, useEffect } from 'react';
 import { useAccordionContext } from './Accordion';

--- a/packages/@smolitux/core/src/components/Alert/Alert.tsx
+++ b/packages/@smolitux/core/src/components/Alert/Alert.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useRef, useEffect, useState } from 'react';
 import './animations.css';
 

--- a/packages/@smolitux/core/src/components/Avatar/Avatar.tsx
+++ b/packages/@smolitux/core/src/components/Avatar/Avatar.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Avatar/Avatar.tsx
 import React, { useState } from 'react';
 

--- a/packages/@smolitux/core/src/components/Badge/Badge.tsx
+++ b/packages/@smolitux/core/src/components/Badge/Badge.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 
 export type BadgeVariant = 'default' | 'primary' | 'success' | 'warning' | 'error' | 'info';

--- a/packages/@smolitux/core/src/components/Collapse/Collapse.tsx
+++ b/packages/@smolitux/core/src/components/Collapse/Collapse.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useRef, useEffect, useState } from 'react';
 import { useTransition } from '../../animations/useTransition';
 import { TransitionPresetName, TransitionPreset } from '../../animations/transitions';

--- a/packages/@smolitux/core/src/components/ColorPicker/ColorPicker.original.tsx
+++ b/packages/@smolitux/core/src/components/ColorPicker/ColorPicker.original.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 
 export interface ColorPickerProps {

--- a/packages/@smolitux/core/src/components/Dialog/Dialog.original.tsx
+++ b/packages/@smolitux/core/src/components/Dialog/Dialog.original.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Dialog/Dialog.tsx
 import React, { useEffect, useRef } from 'react';
 import { Button } from '../Button/Button';

--- a/packages/@smolitux/core/src/components/Dialog/Dialog.tsx
+++ b/packages/@smolitux/core/src/components/Dialog/Dialog.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Dialog/Dialog.improved.tsx
 import React, { useEffect, useRef, useCallback } from 'react';
 

--- a/packages/@smolitux/core/src/components/Drawer/Drawer.original.tsx
+++ b/packages/@smolitux/core/src/components/Drawer/Drawer.original.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Drawer/Drawer.tsx
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 

--- a/packages/@smolitux/core/src/components/Drawer/Drawer.tsx
+++ b/packages/@smolitux/core/src/components/Drawer/Drawer.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Drawer/Drawer.improved.tsx
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 

--- a/packages/@smolitux/core/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/@smolitux/core/src/components/Dropdown/DropdownItem.tsx
@@ -1,3 +1,4 @@
+// FIXME: Props nicht typisiert
 // packages/@smolitux/core/src/components/Dropdown/DropdownItem.tsx
 import React, { useRef, useEffect } from 'react';
 import { useDropdownContext } from './Dropdown';

--- a/packages/@smolitux/core/src/components/Flex/Flex.tsx
+++ b/packages/@smolitux/core/src/components/Flex/Flex.tsx
@@ -1,3 +1,4 @@
+// FIXME: Props nicht typisiert
 import React, { forwardRef } from 'react';
 
 export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';

--- a/packages/@smolitux/core/src/components/Form/Form.tsx
+++ b/packages/@smolitux/core/src/components/Form/Form.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Form as ValidationForm, FormProps as ValidationFormProps } from '../../validation/Form';
 

--- a/packages/@smolitux/core/src/components/FormField/FormField.tsx
+++ b/packages/@smolitux/core/src/components/FormField/FormField.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import {
   FormField as ValidationFormField,

--- a/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.original.tsx
+++ b/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.original.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { useI18n } from '../../i18n/I18nProvider';
 import { LOCALE_NAMES, LOCALE_CODES, LOCALE_DIRECTIONS } from '../../i18n/constants';

--- a/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.improved.tsx
 import React, { useState, useEffect } from 'react';
 

--- a/packages/@smolitux/core/src/components/Menu/MenuDropdown.tsx
+++ b/packages/@smolitux/core/src/components/Menu/MenuDropdown.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Menu/MenuDropdown.tsx
 import React, { useState, useRef, useEffect } from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/@smolitux/core/src/components/Menu/MenuItem.original.tsx
+++ b/packages/@smolitux/core/src/components/Menu/MenuItem.original.tsx
@@ -1,3 +1,4 @@
+// FIXME: Props nicht typisiert
 // packages/@smolitux/core/src/components/Menu/MenuItem.tsx
 import React, { useState, useEffect } from 'react';
 import { useMenuContext } from './Menu';

--- a/packages/@smolitux/core/src/components/Menu/MenuItem.tsx
+++ b/packages/@smolitux/core/src/components/Menu/MenuItem.tsx
@@ -1,3 +1,4 @@
+// FIXME: Props nicht typisiert
 // packages/@smolitux/core/src/components/Menu/MenuItem.improved.tsx
 import React, { useState, useEffect, useRef, useId } from 'react';
 import { useMenuContext } from './Menu';

--- a/packages/@smolitux/core/src/components/Modal/Modal.tsx
+++ b/packages/@smolitux/core/src/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 import './animations.css';

--- a/packages/@smolitux/core/src/components/Popover/Popover.original.tsx
+++ b/packages/@smolitux/core/src/components/Popover/Popover.original.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Popover/Popover.tsx
 import React, { useState, useRef, useEffect } from 'react';
 

--- a/packages/@smolitux/core/src/components/Popover/Popover.tsx
+++ b/packages/@smolitux/core/src/components/Popover/Popover.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Popover/Popover.improved.tsx
 import React, { useState, useRef, useEffect, useId } from 'react';
 

--- a/packages/@smolitux/core/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/@smolitux/core/src/components/RadioGroup/RadioGroup.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { createContext } from 'react';
 import Radio from '../Radio/Radio';
 

--- a/packages/@smolitux/core/src/components/Select/Option.tsx
+++ b/packages/@smolitux/core/src/components/Select/Option.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 
 export interface OptionProps extends React.OptionHTMLAttributes<HTMLOptionElement> {

--- a/packages/@smolitux/core/src/components/Slide/Slide.tsx
+++ b/packages/@smolitux/core/src/components/Slide/Slide.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useRef } from 'react';
 import { useTransition } from '../../animations/useTransition';
 import { TransitionPresetName, TransitionPreset } from '../../animations/transitions';

--- a/packages/@smolitux/core/src/components/Stepper/Stepper.tsx
+++ b/packages/@smolitux/core/src/components/Stepper/Stepper.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Stepper/Stepper.tsx
 import React, { createContext, useContext, useMemo } from 'react';
 import './Stepper.css';

--- a/packages/@smolitux/core/src/components/TabView/TabView.fixed.tsx
+++ b/packages/@smolitux/core/src/components/TabView/TabView.fixed.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 
 export interface TabItem {

--- a/packages/@smolitux/core/src/components/TabView/TabView.tsx
+++ b/packages/@smolitux/core/src/components/TabView/TabView.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef, createContext, useContext } from 'react';
 import './TabView.css';
 

--- a/packages/@smolitux/core/src/components/Table/Table.tsx
+++ b/packages/@smolitux/core/src/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useMemo } from 'react';
 
 export type SortDirection = 'asc' | 'desc' | null;

--- a/packages/@smolitux/core/src/components/Tabs/Tabs.tsx
+++ b/packages/@smolitux/core/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Tabs/Tabs.tsx
 import React, { useState, useEffect, useRef, createContext, useContext, useMemo } from 'react';
 import './Tabs.css';

--- a/packages/@smolitux/core/src/components/Textarea/Textarea.tsx
+++ b/packages/@smolitux/core/src/components/Textarea/Textarea.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Textarea/Textarea.tsx
 // Diese Datei dient als Kompatibilitätsschicht für die TextArea-Komponente
 // und leitet alle Aufrufe an die TextArea-Komponente weiter.

--- a/packages/@smolitux/core/src/components/Toast/ToastProvider.original.tsx
+++ b/packages/@smolitux/core/src/components/Toast/ToastProvider.original.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Toast/ToastProvider.tsx
 import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
 import { Toast, ToastProps, ToastType } from './Toast';

--- a/packages/@smolitux/core/src/components/Toast/ToastProvider.tsx
+++ b/packages/@smolitux/core/src/components/Toast/ToastProvider.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/core/src/components/Toast/ToastProvider.improved.tsx
 import React, { createContext, useContext, useState, useCallback, ReactNode, useId } from 'react';
 import { Toast, ToastProps, ToastType } from './Toast';

--- a/packages/@smolitux/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/@smolitux/core/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useRef, useEffect } from 'react';
 import './Tooltip.css';
 

--- a/packages/@smolitux/core/src/components/voice/VoiceButton.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceButton.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Button, ButtonProps } from '../Button';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceCard.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceCard.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, CardProps } from '../Card';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceInput.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceInput.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Input, InputProps } from '../Input';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceModal.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceModal.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Modal, ModalProps } from '../Modal';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceSelect.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceSelect.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Select, SelectProps } from '../Select';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 import { Card, Button, Input } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/CrossPlatformShare/CrossPlatformShare.tsx
+++ b/packages/@smolitux/federation/src/components/CrossPlatformShare/CrossPlatformShare.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Checkbox, Tooltip, Alert } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
+++ b/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 import { Input, Button, Card } from '@smolitux/core';
 import { SearchResult, FederatedSearchProps } from '../../types';

--- a/packages/@smolitux/federation/src/components/FederationStatus/FederationStatus.tsx
+++ b/packages/@smolitux/federation/src/components/FederationStatus/FederationStatus.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, ProgressBar } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/PlatformSelector/PlatformSelector.tsx
+++ b/packages/@smolitux/federation/src/components/PlatformSelector/PlatformSelector.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Input } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
+++ b/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useEffect, useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 import {

--- a/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
+++ b/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 // packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
 import React, { useState, useEffect } from 'react';
 import Header, { HeaderProps } from '../Header/Header';

--- a/packages/@smolitux/layout/src/components/Grid/Grid.tsx
+++ b/packages/@smolitux/layout/src/components/Grid/Grid.tsx
@@ -1,3 +1,4 @@
+// FIXME: Props nicht typisiert
 import React, { forwardRef } from 'react';
 import type {
   GridBreakpoint,

--- a/packages/@smolitux/media/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/packages/@smolitux/media/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useRef, useEffect } from 'react';
 import type { MediaSrc } from '../../types';
 

--- a/packages/@smolitux/media/src/components/ImageGallery/ImageGallery.tsx
+++ b/packages/@smolitux/media/src/components/ImageGallery/ImageGallery.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { GalleryConfig } from '../../types';
 

--- a/packages/@smolitux/media/src/components/MediaCarousel/MediaCarousel.tsx
+++ b/packages/@smolitux/media/src/components/MediaCarousel/MediaCarousel.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 import { Card, Button } from '@smolitux/core';
 

--- a/packages/@smolitux/media/src/components/MediaGrid/MediaGrid.tsx
+++ b/packages/@smolitux/media/src/components/MediaGrid/MediaGrid.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Card } from '@smolitux/core';
 

--- a/packages/@smolitux/media/src/components/MediaUploader/MediaUploader.tsx
+++ b/packages/@smolitux/media/src/components/MediaUploader/MediaUploader.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useRef, useCallback } from 'react';
 import { Button } from '@smolitux/core';
 import { ProgressBar } from '@smolitux/core';

--- a/packages/@smolitux/media/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/@smolitux/media/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useRef, useEffect } from 'react';
 import type { MediaSrc } from '../../types';
 

--- a/packages/@smolitux/resonance/src/components/feed/FeedFilter.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedFilter.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Flex } from '../primitives';
 import { TabView } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/feed/FeedSidebar.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedSidebar.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Card, Button } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/feed/FeedView.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedView.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useEffect, useRef, useState } from 'react';
 import { Box, Flex } from '../primitives';
 import { Button } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/governance/GovernanceDashboard.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/GovernanceDashboard.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/governance/ProposalView.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/ProposalView.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/governance/VotingSystem.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/VotingSystem.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button, ProgressBar } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/monetization/CreatorDashboard.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/CreatorDashboard.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/monetization/RevenueModel.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/RevenueModel.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/monetization/RewardSystem.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/RewardSystem.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/platform/PlatformIntegration.tsx
+++ b/packages/@smolitux/resonance/src/components/platform/PlatformIntegration.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/platform/PlatformNotice.tsx
+++ b/packages/@smolitux/resonance/src/components/platform/PlatformNotice.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Box, Text } from '../primitives';
 import { PlatformInfo } from '../../platform/types';

--- a/packages/@smolitux/resonance/src/components/post/PostCreator.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostCreator.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useRef } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/post/PostInteractions.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostInteractions.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Button, Tooltip } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/post/PostMetrics.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostMetrics.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/post/PostView.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostView.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Card, Button } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileContent.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileContent.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Card, TabView } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileEditor.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileEditor.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Box, Flex } from '../primitives';
 import { Button, Input, TextArea } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileHeader.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileHeader.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Button } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileWallet.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileWallet.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Card, Button } from '@smolitux/core';

--- a/packages/@smolitux/utils/src/components/patterns/Button.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/Button.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React from 'react';
 
 export interface ButtonProps {

--- a/packages/@smolitux/utils/src/components/patterns/TabView.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/TabView.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Box } from '../primitives/Box';
 import { Flex } from '../primitives/Flex';

--- a/packages/@smolitux/utils/src/components/patterns/Tooltip.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/Tooltip.tsx
@@ -1,3 +1,4 @@
+// TODO: forwardRef hinzufügen
 import React, { useState, useRef, useEffect } from 'react';
 import { Box } from '../primitives/Box';
 

--- a/scripts/annotate-components.js
+++ b/scripts/annotate-components.js
@@ -4,44 +4,138 @@ const path = require('path');
 const baseDir = path.join(__dirname, '..');
 const packagesDir = path.join(baseDir, 'packages', '@smolitux');
 
-/** Simple heuristic to annotate TODOs and FIXMEs in component files */
-function scanFile(filePath) {
+const todoMap = {}; // {pkg: {component: Set<string>}}
+const fixmeMap = {}; // same structure
+
+function add(map, pkg, comp, msg) {
+  if (!map[pkg]) map[pkg] = {};
+  if (!map[pkg][comp]) map[pkg][comp] = new Set();
+  map[pkg][comp].add(msg);
+}
+
+function annotateFile(filePath, pkg, comp) {
   const text = fs.readFileSync(filePath, 'utf8');
   const lines = text.split(/\r?\n/);
   let added = false;
 
-  // Detect untyped props (props: any or (props) => )
-  const componentRegex = /(function|const)\s+([A-Z][A-Za-z0-9_]*)\s*(=\s*\(|\()/;
-  const propsAnyRegex = /\(.*props?:?\s*any\s*\)/;
-  const propsUntypedRegex = /\(\s*props\s*\)/;
-  if ((propsAnyRegex.test(text) || propsUntypedRegex.test(text)) && !lines[0].includes('// FIXME')) {
+  // skip if file already annotated
+  if (lines[0] && lines[0].startsWith('// TODO') || lines[0].startsWith('// FIXME')) {
+    return;
+  }
+
+  const untypedProps = /(\(\s*props\s*\)|:\s*any[\s,}\n])/;
+  if (untypedProps.test(text)) {
     lines.unshift('// FIXME: Props nicht typisiert');
+    add(fixmeMap, pkg, comp, 'Props nicht typisiert');
     added = true;
   }
 
-  // Detect useEffect without cleanup
-  if (/useEffect\([^)]*\{[^]*?\}\)/.test(text) && !/return\s*\(\s*\(\)\s*=>/.test(text) && !lines[0].includes('// FIXME: useEffect')) {
+  const untypedCallback = /on[A-Z]\w*=\(e\) =>/;
+  if (untypedCallback.test(text)) {
+    lines.unshift('// FIXME: Callback nicht typisiert');
+    add(fixmeMap, pkg, comp, 'Callback nicht typisiert');
+    added = true;
+  }
+
+  const useEffectNoCleanup = /useEffect\([^)]*\{[^]*?\}\)/s;
+  if (useEffectNoCleanup.test(text) && !/return\s*\(\s*\(\)\s*=>/.test(text)) {
     lines.unshift('// FIXME: useEffect ohne Cleanup');
+    add(fixmeMap, pkg, comp, 'useEffect ohne Cleanup');
+    added = true;
+  }
+
+  if (!text.includes('forwardRef')) {
+    lines.unshift('// TODO: forwardRef hinzufügen');
+    add(todoMap, pkg, comp, 'forwardRef hinzufügen');
+    added = true;
+  }
+
+  const dir = path.dirname(filePath);
+  const stories = fs.readdirSync(dir).filter(f => f.endsWith('.stories.tsx')).length;
+  if (stories === 0) {
+    lines.unshift('// TODO: Storybook fehlt');
+    add(todoMap, pkg, comp, 'Storybook fehlt');
+    added = true;
+  }
+  const tests = fs.readdirSync(dir).filter(f => f.endsWith('.test.tsx')).length;
+  if (tests === 0) {
+    lines.unshift('// TODO: Tests fehlen');
+    add(todoMap, pkg, comp, 'Tests fehlen');
     added = true;
   }
 
   if (added) {
     fs.writeFileSync(filePath, lines.join('\n'));
-    return true;
   }
-  return false;
 }
 
-function scanDir(dir) {
+function scanComponent(dir, pkg, comp) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      scanDir(full);
-    } else if (entry.isFile() && entry.name.endsWith('.tsx')) {
-      scanFile(full);
+    if (entry.isFile() && entry.name.endsWith('.tsx') && !entry.name.includes('.stories') && !entry.name.includes('.test') && !entry.name.includes('.a11y')) {
+      annotateFile(full, pkg, comp);
     }
   }
 }
 
-scanDir(packagesDir);
+function scanPackages() {
+  const packages = fs.readdirSync(packagesDir, { withFileTypes: true });
+  for (const pkgDir of packages) {
+    if (!pkgDir.isDirectory()) continue;
+    const pkgName = pkgDir.name;
+    const compRoot = path.join(packagesDir, pkgName, 'src', 'components');
+    if (!fs.existsSync(compRoot)) continue;
+    const comps = fs.readdirSync(compRoot, { withFileTypes: true });
+    for (const compDir of comps) {
+      if (compDir.isDirectory()) {
+        scanComponent(path.join(compRoot, compDir.name), pkgName, compDir.name);
+      }
+    }
+  }
+}
+
+function formatTable(map, type) {
+  const sections = [];
+  for (const pkg of Object.keys(map)) {
+    sections.push(`## @smolitux/${pkg}`);
+    sections.push('');
+    sections.push(`| Komponente | ${type} |`);
+    sections.push('|------------|-------|');
+    for (const comp of Object.keys(map[pkg])) {
+      const msgs = Array.from(map[pkg][comp]).join(', ');
+      sections.push(`| ${comp} | ${msgs} |`);
+    }
+    sections.push('');
+  }
+  return sections.join('\n');
+}
+
+function updateDocs() {
+  const date = new Date().toISOString().split('T')[0];
+  if (Object.keys(todoMap).length) {
+    let todoDoc = fs.readFileSync(path.join(baseDir, 'docs/wiki/development/component-todo.md'), 'utf8');
+    todoDoc += `\n### Update ${date} - Automated annotations\n` + formatTable(todoMap, 'TODOs') + '\n';
+    fs.writeFileSync(path.join(baseDir, 'docs/wiki/development/component-todo.md'), todoDoc);
+  }
+  if (Object.keys(fixmeMap).length) {
+    let fixmeDoc = fs.readFileSync(path.join(baseDir, 'docs/wiki/development/component-fixme.md'), 'utf8');
+    fixmeDoc += `\n### Update ${date} - Automated annotations\n` + formatTable(fixmeMap, 'FIXMEs') + '\n';
+    fs.writeFileSync(path.join(baseDir, 'docs/wiki/development/component-fixme.md'), fixmeDoc);
+  }
+  const statusFiles = [
+    path.join(baseDir, 'docs/wiki/development/component-status.md'),
+    path.join(baseDir, 'COMPONENT_STATUS.md'),
+    path.join(baseDir, 'docs/wiki/testing/test-coverage-dashboard.md')
+  ];
+  for (const file of statusFiles) {
+    if (fs.existsSync(file)) {
+      let txt = fs.readFileSync(file, 'utf8');
+      txt += `\n### Update ${date} - Automated TODO/FIXME scan executed.`;
+      fs.writeFileSync(file, txt);
+    }
+  }
+}
+
+scanPackages();
+updateDocs();


### PR DESCRIPTION
## Summary
- add automated script to annotate TODO/FIXME comments
- update docs with tables of TODOs and FIXMEs
- annotate components with TODO and FIXME comments

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b72333808324a92b2ce511f6e90e