### PR TITLE
docs: mark Flex props typed

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -51,3 +51,5 @@
 
 ### Update 2025-06-09
 - Fixed ESLint configuration in root.
+### Update 2025-06-14
+- Flex component props typed; updated docs.

--- a/docs/wiki/development/component-fixme.md
+++ b/docs/wiki/development/component-fixme.md
@@ -11,7 +11,7 @@ Diese Datei sammelt automatisch erkannte FIXMEs in den Komponenten.
 | Komponente | FIXMEs |
 |------------|-------|
 | Dropdown | Props nicht typisiert |
-| Flex | Props nicht typisiert |
+| Flex | Props typisiert (behoben) |
 | Menu | Props nicht typisiert |
 
 ## @smolitux/layout
@@ -23,3 +23,5 @@ Diese Datei sammelt automatisch erkannte FIXMEs in den Komponenten.
 
 ### Update 2025-06-09
 - Fixed ESLint config to enable linting.
+### Update 2025-06-14
+- Marked Flex props as typed.

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -307,3 +307,5 @@ See also [Resonance Component Status](./component-status-resonance.md) for packa
 ### Update 2025-06-09 - Automated TODO/FIXME scan executed.
 ### Update 2025-06-09
 - Fixed ESLint configuration in root to resolve missing config error.
+### Update 2025-06-14
+- Marked Flex component as fixed in documentation.

--- a/docs/wiki/development/component-todo.md
+++ b/docs/wiki/development/component-todo.md
@@ -287,3 +287,5 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 
 ### Update 2025-06-09
 - No component changes. Fixed ESLint config.
+### Update 2025-06-14
+- Flex component marked complete; props typed.

--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -24,3 +24,5 @@
 ### Update 2025-06-09 - Automated TODO/FIXME scan executed.
 ### Update 2025-06-09
 - Fixed ESLint configuration; lint command works.
+### Update 2025-06-14
+- Documentation updated for Flex component props typing fix.

--- a/packages/@smolitux/core/src/components/Flex/Flex.tsx
+++ b/packages/@smolitux/core/src/components/Flex/Flex.tsx
@@ -1,4 +1,3 @@
-// FIXME: Props nicht typisiert
 import React, { forwardRef } from 'react';
 
 export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
@@ -113,8 +112,8 @@ export const Flex = forwardRef<HTMLDivElement, FlexProps>(
     ref
   ) => {
     // Hilfsfunktion zum Generieren von Klassen für responsive Eigenschaften
-    const getResponsiveClasses = (
-      prop: any,
+    const getResponsiveClasses = <T extends string>(
+      prop: T | Partial<Record<FlexBreakpoint, T>> | undefined,
       classPrefix: string,
       valueMap: Record<string, Record<string, string>>
     ): string => {


### PR DESCRIPTION
## Summary
- mark Flex props typed and update fixme list
- document update notes across docs

## Testing
- `npm run lint` *(fails: ESLint issues)*
- `npm run build`
- `npm test` *(fails: cannot find react-test-renderer)*

------
https://chatgpt.com/codex/tasks/task_e_6846ccbc77388324ba5e637e0d464fbd