### PR TITLE
Add Lightbox component to media package

### DIFF
--- a/docs/wiki/development/component-status-media.md
+++ b/docs/wiki/development/component-status-media.md
@@ -1,9 +1,12 @@
 # Media Component Status
 
-| Component    | Status |
-| ------------ | ------ |
-| AudioPlayer  | Ready  |
-| VideoPlayer  | Ready  |
-| ImageGallery | Ready  |
-| MediaGrid    | Ready  |
-| ImageViewer  | Ready  |
+| Component     | Status |
+| ------------- | ------ |
+| AudioPlayer   | Ready  |
+| VideoPlayer   | Ready  |
+| ImageGallery  | Ready  |
+| MediaGrid     | Ready  |
+| ImageViewer   | Ready  |
+| MediaUploader | Ready  |
+| MediaCarousel | Ready  |
+| Lightbox      | Ready  |

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -78,6 +78,7 @@ This document provides a comprehensive test status report for all components in 
 | @smolitux/media | MediaGrid | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/media | MediaUploader | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/media | VideoPlayer | ✅ | ✅ | ❌ | ❌ | Ready |
+| @smolitux/media | Lightbox | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/resonance | FeedFilter | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/resonance | FeedItem | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/resonance | FeedSidebar | ✅ | ✅ | ❌ | ❌ | Ready |

--- a/docs/wiki/development/component-todo.md
+++ b/docs/wiki/development/component-todo.md
@@ -4,25 +4,23 @@ Diese Liste basiert auf einem Offline-Scan vom 2025-06-08. Tests konnten mangels
 
 _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 
-
 ## @smolitux/ai
 
-| Komponente | TODOs |
-|------------|-------|
-| ContentAnalytics | a11y-Test fehlt, Kein Storybook vorhanden |
-| ContentModerator | a11y-Test fehlt, Kein Storybook vorhanden |
-| EngagementScore | a11y-Test fehlt, Kein Storybook vorhanden |
-| FakeNewsDetector | a11y-Test fehlt, Kein Storybook vorhanden |
+| Komponente             | TODOs                                     |
+| ---------------------- | ----------------------------------------- |
+| ContentAnalytics       | a11y-Test fehlt, Kein Storybook vorhanden |
+| ContentModerator       | a11y-Test fehlt, Kein Storybook vorhanden |
+| EngagementScore        | a11y-Test fehlt, Kein Storybook vorhanden |
+| FakeNewsDetector       | a11y-Test fehlt, Kein Storybook vorhanden |
 | RecommendationCarousel | a11y-Test fehlt, Kein Storybook vorhanden |
-| SentimentDisplay | Kein Storybook vorhanden |
-| TrendingTopics | a11y-Test fehlt, Kein Storybook vorhanden |
-| TrollFilter | a11y-Test fehlt, Kein Storybook vorhanden |
+| SentimentDisplay       | Kein Storybook vorhanden                  |
+| TrendingTopics         | a11y-Test fehlt, Kein Storybook vorhanden |
+| TrollFilter            | a11y-Test fehlt, Kein Storybook vorhanden |
 
 ## @smolitux/blockchain
 
-| Komponente | TODOs |
-|------------|-------|
-| SmartContractInteraction | a11y-Test fehlt, Kein Storybook vorhanden |
+| Komponente               | TODOs                                     |
+| ------------------------ | ----------------------------------------- |
 | StakingInterface | a11y-Test fehlt, Kein Storybook vorhanden |
 | TokenDisplay | a11y-Test fehlt, Kein Storybook vorhanden |
 | TokenDistributionChart | a11y-Test fehlt, Kein Storybook vorhanden |
@@ -33,98 +31,97 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 
 ## @smolitux/charts
 
-| Komponente | TODOs |
-|------------|-------|
-| AreaChart | – |
-| BarChart | – |
-| Heatmap | Kein Storybook vorhanden |
-| LineChart | – |
-| PieChart | – |
-| RadarChart | Kein Storybook vorhanden |
+| Komponente  | TODOs                    |
+| ----------- | ------------------------ |
+| AreaChart   | –                        |
+| BarChart    | –                        |
+| Heatmap     | Kein Storybook vorhanden |
+| LineChart   | –                        |
+| PieChart    | –                        |
+| RadarChart  | Kein Storybook vorhanden |
 | ScatterPlot | Kein Storybook vorhanden |
 
 ## @smolitux/community
 
-| Komponente | TODOs |
-|------------|-------|
-| ActivityFeed | Fehlende Tests, Kein Storybook vorhanden |
-| CommentSection | a11y-Test fehlt, Kein Storybook vorhanden |
-| FollowButton | Fehlende Tests, Kein Storybook vorhanden |
-| NotificationCenter | Fehlende Tests, Kein Storybook vorhanden |
-| UserProfile | Fehlende Tests, Kein Storybook vorhanden |
+| Komponente         | TODOs                                     |
+| ------------------ | ----------------------------------------- |
+| ActivityFeed       | Fehlende Tests, Kein Storybook vorhanden  |
+| CommentSection     | a11y-Test fehlt, Kein Storybook vorhanden |
+| FollowButton       | Fehlende Tests, Kein Storybook vorhanden  |
+| NotificationCenter | Fehlende Tests, Kein Storybook vorhanden  |
+| UserProfile        | Fehlende Tests, Kein Storybook vorhanden  |
 
 ## @smolitux/core
 
-| Komponente | TODOs |
-|------------|-------|
-| Accordion | – |
-| Alert | – |
-| Avatar | – |
-| Badge | – |
-| Breadcrumb | – |
-| Button | – |
-| Card | – |
-| Carousel | – |
-| Checkbox | – |
-| Collapse | – |
-| ColorPicker | – |
-| DatePicker | – |
-| Dialog | – |
-| Drawer | – |
-| Dropdown | – |
-| Fade | – |
-| FileUpload | – |
-| Flex | – |
-| Form | – |
-| FormControl | – |
-| FormField | – |
-| Grid | – |
-| Input | – |
-| LanguageSwitcher | – |
-| List | – |
-| MediaPlayer | – |
-| Menu | – |
-| Modal | – |
-| Pagination | – |
-| Popover | – |
-| ProgressBar | – |
-| Radio | – |
-| RadioGroup | – |
-| Select | – |
-| Skeleton | – |
-| Slide | – |
-| Slider | – |
-| Spinner | – |
-| Stepper | – |
-| Switch | – |
-| TabView | – |
-| Table | – |
-| Tabs | – |
-| TextArea | – |
-| Textarea | – |
-| TimePicker | – |
-| Toast | – |
-| Tooltip | – |
-| Zoom | – |
-| __tests__ | Fehlende Tests, Kein Storybook vorhanden |
-| voice | a11y-Test fehlt |
+| Komponente       | TODOs                                    |
+| ---------------- | ---------------------------------------- |
+| Accordion        | –                                        |
+| Alert            | –                                        |
+| Avatar           | –                                        |
+| Badge            | –                                        |
+| Breadcrumb       | –                                        |
+| Button           | –                                        |
+| Card             | –                                        |
+| Carousel         | –                                        |
+| Checkbox         | –                                        |
+| Collapse         | –                                        |
+| ColorPicker      | –                                        |
+| DatePicker       | –                                        |
+| Dialog           | –                                        |
+| Drawer           | –                                        |
+| Dropdown         | –                                        |
+| Fade             | –                                        |
+| FileUpload       | –                                        |
+| Flex             | –                                        |
+| Form             | –                                        |
+| FormControl      | –                                        |
+| FormField        | –                                        |
+| Grid             | –                                        |
+| Input            | –                                        |
+| LanguageSwitcher | –                                        |
+| List             | –                                        |
+| MediaPlayer      | –                                        |
+| Menu             | –                                        |
+| Modal            | –                                        |
+| Pagination       | –                                        |
+| Popover          | –                                        |
+| ProgressBar      | –                                        |
+| Radio            | –                                        |
+| RadioGroup       | –                                        |
+| Select           | –                                        |
+| Skeleton         | –                                        |
+| Slide            | –                                        |
+| Slider           | –                                        |
+| Spinner          | –                                        |
+| Stepper          | –                                        |
+| Switch           | –                                        |
+| TabView          | –                                        |
+| Table            | –                                        |
+| Tabs             | –                                        |
+| TextArea         | –                                        |
+| Textarea         | –                                        |
+| TimePicker       | –                                        |
+| Toast            | –                                        |
+| Tooltip          | –                                        |
+| Zoom             | –                                        |
+| **tests**        | Fehlende Tests, Kein Storybook vorhanden |
+| voice            | a11y-Test fehlt                          |
 
 ## @smolitux/federation
 
-| Komponente | TODOs |
-|------------|-------|
-| ActivityStream | Fehlende Tests, Kein Storybook vorhanden |
-| CrossPlatformShare | Fehlende Tests, Kein Storybook vorhanden |
-| FederatedSearch | a11y-Test fehlt, Kein Storybook vorhanden |
-| FederationStatus | Fehlende Tests, Kein Storybook vorhanden |
-| PlatformSelector | Fehlende Tests, Kein Storybook vorhanden |
+| Komponente         | TODOs                                     |
+| ------------------ | ----------------------------------------- |
+| ActivityStream     | Fehlende Tests, Kein Storybook vorhanden  |
+| CrossPlatformShare | Fehlende Tests, Kein Storybook vorhanden  |
+| FederatedSearch    | a11y-Test fehlt, Kein Storybook vorhanden |
+| FederationStatus   | Fehlende Tests, Kein Storybook vorhanden  |
+| PlatformSelector   | Fehlende Tests, Kein Storybook vorhanden  |
 
 ## @smolitux/layout
 
-| Komponente | TODOs |
-|------------|-------|
-| Container | – |
-| DashboardLayout | Fehlende Tests, Kein Storybook vorhanden |
+| Komponente      | TODOs                                    |
+| --------------- | ---------------------------------------- |
+| Container       | –                                        |
 | Flex | – |
 | Footer | Fehlende Tests, Kein Storybook vorhanden |
 | Grid | – |
@@ -134,164 +131,169 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 
 ## @smolitux/media
 
-| Komponente | TODOs |
-|------------|-------|
-| AudioPlayer | a11y-Test fehlt, Kein Storybook vorhanden |
-| MediaCarousel | Kein Storybook vorhanden |
-| MediaGrid | Kein Storybook vorhanden |
-| MediaUploader | Kein Storybook vorhanden |
-| VideoPlayer | Kein Storybook vorhanden |
+| Komponente    | TODOs                                     |
+| ------------- | ----------------------------------------- |
+| AudioPlayer   | a11y-Test fehlt, Kein Storybook vorhanden |
+| MediaCarousel | Kein Storybook vorhanden                  |
+| MediaGrid     | Kein Storybook vorhanden                  |
+| MediaUploader | Kein Storybook vorhanden                  |
+| VideoPlayer   | Kein Storybook vorhanden                  |
+| Lightbox      | –                                         |
 
 ## @smolitux/resonance
 
-| Komponente | TODOs |
-|------------|-------|
-| feed | a11y-Test fehlt |
-| governance | a11y-Test fehlt, Kein Storybook vorhanden |
+| Komponente   | TODOs                                     |
+| ------------ | ----------------------------------------- |
+| feed         | a11y-Test fehlt                           |
+| governance   | a11y-Test fehlt, Kein Storybook vorhanden |
 | monetization | a11y-Test fehlt, Kein Storybook vorhanden |
-| post | a11y-Test fehlt |
-| profile | a11y-Test fehlt |
+| post         | a11y-Test fehlt                           |
+| profile      | a11y-Test fehlt                           |
 
 ## @smolitux/utils
 
-| Komponente | TODOs |
-|------------|-------|
-| patterns | a11y-Test fehlt |
+| Komponente | TODOs                                     |
+| ---------- | ----------------------------------------- |
+| patterns   | a11y-Test fehlt                           |
 | primitives | a11y-Test fehlt, Kein Storybook vorhanden |
 
-
-
 ### Update 2025-06-13
+
 - Added automate TODO/FIXME annotator script `scripts/annotate-components.js`.
 
-
 ### Update 2025-06-09 - Automated annotations
+
 ## @smolitux/ai
 
-| Komponente | TODOs |
-|------------|-------|
-| ContentAnalytics | forwardRef hinzufügen |
-| ContentModerator | forwardRef hinzufügen |
-| EngagementScore | forwardRef hinzufügen |
-| FakeNewsDetector | forwardRef hinzufügen |
+| Komponente             | TODOs                 |
+| ---------------------- | --------------------- |
+| ContentAnalytics       | forwardRef hinzufügen |
+| ContentModerator       | forwardRef hinzufügen |
+| EngagementScore        | forwardRef hinzufügen |
+| FakeNewsDetector       | forwardRef hinzufügen |
 | RecommendationCarousel | forwardRef hinzufügen |
-| SentimentDisplay | forwardRef hinzufügen |
-| TrendingTopics | forwardRef hinzufügen |
-| TrollFilter | forwardRef hinzufügen |
+| SentimentDisplay       | forwardRef hinzufügen |
+| TrendingTopics         | forwardRef hinzufügen |
+| TrollFilter            | forwardRef hinzufügen |
 
 ## @smolitux/blockchain
 
-| Komponente | TODOs |
-|------------|-------|
-| NFTGallery | forwardRef hinzufügen, Tests fehlen |
+| Komponente               | TODOs                               |
+| ------------------------ | ----------------------------------- |
+| NFTGallery               | forwardRef hinzufügen, Tests fehlen |
 | SmartContractInteraction | forwardRef hinzufügen, Tests fehlen |
-| StakingInterface | forwardRef hinzufügen, Tests fehlen |
-| TokenDisplay | forwardRef hinzufügen, Tests fehlen |
-| TokenDistributionChart | forwardRef hinzufügen, Tests fehlen |
-| TokenEconomy | forwardRef hinzufügen, Tests fehlen |
-| TransactionHistory | forwardRef hinzufügen, Tests fehlen |
-| WalletConnect | forwardRef hinzufügen, Tests fehlen |
+| StakingInterface         | forwardRef hinzufügen, Tests fehlen |
+| TokenDisplay             | forwardRef hinzufügen, Tests fehlen |
+| TokenDistributionChart   | forwardRef hinzufügen, Tests fehlen |
+| TokenEconomy             | forwardRef hinzufügen, Tests fehlen |
+| TransactionHistory       | forwardRef hinzufügen, Tests fehlen |
+| WalletConnect            | forwardRef hinzufügen, Tests fehlen |
 
 ## @smolitux/charts
 
-| Komponente | TODOs |
-|------------|-------|
-| ChartAxis | Tests fehlen |
+| Komponente  | TODOs        |
+| ----------- | ------------ |
+| ChartAxis   | Tests fehlen |
 | ChartLegend | Tests fehlen |
-| DonutChart | Tests fehlen |
-| Histogram | Tests fehlen |
+| DonutChart  | Tests fehlen |
+| Histogram   | Tests fehlen |
 
 ## @smolitux/community
 
-| Komponente | TODOs |
-|------------|-------|
-| ActivityFeed | forwardRef hinzufügen |
-| CommentSection | forwardRef hinzufügen |
-| FollowButton | forwardRef hinzufügen |
+| Komponente         | TODOs                 |
+| ------------------ | --------------------- |
+| ActivityFeed       | forwardRef hinzufügen |
+| CommentSection     | forwardRef hinzufügen |
+| FollowButton       | forwardRef hinzufügen |
 | NotificationCenter | forwardRef hinzufügen |
-| UserProfile | forwardRef hinzufügen |
+| UserProfile        | forwardRef hinzufügen |
 
 ## @smolitux/core
 
-| Komponente | TODOs |
-|------------|-------|
-| Accordion | forwardRef hinzufügen |
-| Alert | forwardRef hinzufügen |
-| Avatar | forwardRef hinzufügen |
-| Badge | forwardRef hinzufügen |
-| Collapse | forwardRef hinzufügen |
-| ColorPicker | forwardRef hinzufügen |
-| Dialog | forwardRef hinzufügen |
-| Drawer | forwardRef hinzufügen |
-| Form | forwardRef hinzufügen |
-| FormField | forwardRef hinzufügen |
+| Komponente       | TODOs                 |
+| ---------------- | --------------------- |
+| Accordion        | forwardRef hinzufügen |
+| Alert            | forwardRef hinzufügen |
+| Avatar           | forwardRef hinzufügen |
+| Badge            | forwardRef hinzufügen |
+| Collapse         | forwardRef hinzufügen |
+| ColorPicker      | forwardRef hinzufügen |
+| Dialog           | forwardRef hinzufügen |
+| Drawer           | forwardRef hinzufügen |
+| Form             | forwardRef hinzufügen |
+| FormField        | forwardRef hinzufügen |
 | LanguageSwitcher | forwardRef hinzufügen |
-| Menu | forwardRef hinzufügen |
-| Modal | forwardRef hinzufügen |
-| Popover | forwardRef hinzufügen |
-| RadioGroup | forwardRef hinzufügen |
-| Select | forwardRef hinzufügen |
-| Slide | forwardRef hinzufügen |
-| Stepper | forwardRef hinzufügen |
-| TabView | forwardRef hinzufügen |
-| Table | forwardRef hinzufügen |
-| Tabs | forwardRef hinzufügen |
-| Textarea | forwardRef hinzufügen |
-| Toast | forwardRef hinzufügen |
-| Tooltip | forwardRef hinzufügen |
-| voice | forwardRef hinzufügen |
+| Menu             | forwardRef hinzufügen |
+| Modal            | forwardRef hinzufügen |
+| Popover          | forwardRef hinzufügen |
+| RadioGroup       | forwardRef hinzufügen |
+| Select           | forwardRef hinzufügen |
+| Slide            | forwardRef hinzufügen |
+| Stepper          | forwardRef hinzufügen |
+| TabView          | forwardRef hinzufügen |
+| Table            | forwardRef hinzufügen |
+| Tabs             | forwardRef hinzufügen |
+| Textarea         | forwardRef hinzufügen |
+| Toast            | forwardRef hinzufügen |
+| Tooltip          | forwardRef hinzufügen |
+| voice            | forwardRef hinzufügen |
 
 ## @smolitux/federation
 
-| Komponente | TODOs |
-|------------|-------|
-| ActivityStream | forwardRef hinzufügen |
+| Komponente         | TODOs                 |
+| ------------------ | --------------------- |
+| ActivityStream     | forwardRef hinzufügen |
 | CrossPlatformShare | forwardRef hinzufügen |
-| FederatedSearch | forwardRef hinzufügen |
-| FederationStatus | forwardRef hinzufügen |
-| PlatformSelector | forwardRef hinzufügen |
-| ProtocolHandler | forwardRef hinzufügen |
+| FederatedSearch    | forwardRef hinzufügen |
+| FederationStatus   | forwardRef hinzufügen |
+| PlatformSelector   | forwardRef hinzufügen |
+| ProtocolHandler    | forwardRef hinzufügen |
 
 ## @smolitux/layout
 
-| Komponente | TODOs |
-|------------|-------|
+| Komponente      | TODOs                 |
+| --------------- | --------------------- |
 | DashboardLayout | forwardRef hinzufügen |
 
 ## @smolitux/media
 
-| Komponente | TODOs |
-|------------|-------|
-| AudioPlayer | forwardRef hinzufügen |
-| ImageGallery | forwardRef hinzufügen |
+| Komponente    | TODOs                 |
+| ------------- | --------------------- |
+| AudioPlayer   | forwardRef hinzufügen |
+| ImageGallery  | forwardRef hinzufügen |
 | MediaCarousel | forwardRef hinzufügen |
-| MediaGrid | forwardRef hinzufügen |
+| MediaGrid     | forwardRef hinzufügen |
 | MediaUploader | forwardRef hinzufügen |
-| VideoPlayer | forwardRef hinzufügen |
+| VideoPlayer   | forwardRef hinzufügen |
+| Lightbox      | forwardRef hinzufügen |
 
 ## @smolitux/resonance
 
-| Komponente | TODOs |
-|------------|-------|
-| feed | forwardRef hinzufügen |
-| governance | forwardRef hinzufügen |
+| Komponente   | TODOs                 |
+| ------------ | --------------------- |
+| feed         | forwardRef hinzufügen |
+| governance   | forwardRef hinzufügen |
 | monetization | forwardRef hinzufügen |
-| platform | forwardRef hinzufügen |
-| post | forwardRef hinzufügen |
-| profile | forwardRef hinzufügen |
+| platform     | forwardRef hinzufügen |
+| post         | forwardRef hinzufügen |
+| profile      | forwardRef hinzufügen |
 
 ## @smolitux/utils
 
-| Komponente | TODOs |
-|------------|-------|
-| patterns | forwardRef hinzufügen |
-
+| Komponente | TODOs                 |
+| ---------- | --------------------- |
+| patterns   | forwardRef hinzufügen |
 
 ### Update 2025-06-09
+
 - No component changes. Fixed ESLint config.
+
 ### Update 2025-06-14
+
 - Flex component marked complete; props typed.
+
 ### Update 2025-06-15
+
 - General tooling upgrade with ESLint flat config.
 ### Update 2025-06-09
 - Added DeFiDashboard to blockchain TODO list.

--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -13,18 +13,25 @@
 | @smolitux/media         | ✅ Getestet  | –          | –        | –         | –     |
 | @smolitux/resonance     | ⚠️ Teilweise | –          | –        | –         | –     |
 | @smolitux/utils         | ✅ Getestet  | –          | –        | –         | –     |
-| @smolitux/testing         | ✅ Getestet  | –          | –        | –         | –     |
+| @smolitux/testing       | ✅ Getestet  | –          | –        | –         | –     |
 | @smolitux/voice-control | ❌ Offen     | –          | –        | –         | –     |
 
-> Letzte Aktualisierung: 2025-06-09 – DeFiDashboard component covered; Navigation component added
+> Letzte Aktualisierung: 2025-06-18 – Lightbox component added; DeFiDashboard component covered; Navigation component added
 
 ### Update 2025-06-13
+
 - Added annotation script entry in docs.
 
 ### Update 2025-06-09 - Automated TODO/FIXME scan executed.
+
 ### Update 2025-06-09
+
 - Fixed ESLint configuration; lint command works.
+
 ### Update 2025-06-14
+
 - Documentation updated for Flex component props typing fix.
+
 ### Update 2025-06-15
+
 - Updated tooling instructions after ESLint flat config migration.

--- a/packages/@smolitux/media/src/components/Lightbox/Lightbox.stories.tsx
+++ b/packages/@smolitux/media/src/components/Lightbox/Lightbox.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Lightbox } from './Lightbox';
+
+const meta: Meta<typeof Lightbox> = {
+  title: 'Media/Lightbox',
+  component: Lightbox,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <img
+          src="https://via.placeholder.com/150"
+          alt="thumb"
+          className="cursor-pointer"
+          onClick={() => setOpen(true)}
+        />
+        <Lightbox
+          open={open}
+          onClose={() => setOpen(false)}
+          src="https://via.placeholder.com/600"
+          alt="Demo"
+        />
+      </>
+    );
+  },
+};

--- a/packages/@smolitux/media/src/components/Lightbox/Lightbox.test.tsx
+++ b/packages/@smolitux/media/src/components/Lightbox/Lightbox.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { Lightbox } from './Lightbox';
+
+describe('Lightbox', () => {
+  const src = 'https://via.placeholder.com/300';
+
+  it('renders when open', () => {
+    render(<Lightbox open onClose={() => {}} src={src} alt="demo" />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('calls onClose on overlay click', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<Lightbox open onClose={onClose} src={src} alt="demo" />);
+    await user.click(screen.getByRole('dialog'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<Lightbox open onClose={onClose} src={src} alt="demo" />);
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('is accessible', async () => {
+    const { container } = render(<Lightbox open onClose={() => {}} src={src} alt="demo" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/media/src/components/Lightbox/Lightbox.tsx
+++ b/packages/@smolitux/media/src/components/Lightbox/Lightbox.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef } from 'react';
+
+export interface LightboxProps {
+  /** Whether the lightbox is open */
+  open: boolean;
+  /** Callback when the lightbox should be closed */
+  onClose: () => void;
+  /** Source URL for the image to display */
+  src: string;
+  /** Alternative text for the image */
+  alt?: string;
+  /** Additional class name */
+  className?: string;
+}
+
+/**
+ * Lightbox component for displaying an image in a modal overlay.
+ * Supports closing via overlay click or Escape key for accessibility.
+ */
+export const Lightbox: React.FC<LightboxProps> = ({
+  open,
+  onClose,
+  src,
+  alt = '',
+  className = '',
+}) => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/75 ${className}`}
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose();
+      }}
+    >
+      <img src={src} alt={alt} className="max-h-full max-w-full" />
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute top-4 right-4 text-white text-2xl"
+      >
+        ×
+      </button>
+    </div>
+  );
+};
+
+export default Lightbox;

--- a/packages/@smolitux/media/src/components/Lightbox/index.ts
+++ b/packages/@smolitux/media/src/components/Lightbox/index.ts
@@ -1,0 +1,1 @@
+export * from './Lightbox';

--- a/packages/@smolitux/media/src/index.ts
+++ b/packages/@smolitux/media/src/index.ts
@@ -6,4 +6,5 @@ export * from './components/MediaGrid';
 export * from './components/MediaCarousel';
 export * from './components/ImageGallery';
 export * from './components/ImageViewer';
+export * from './components/Lightbox';
 export * from './types';


### PR DESCRIPTION
## Summary
- implement `Lightbox` component with keyboard and overlay close support
- add accompanying tests and Storybook story
- export `Lightbox` from media package
- document new component in status files and TODO list
- refresh coverage dashboard entry

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd93a2d083249925ea3c504967a0