### PR TITLE
Add Navigation layout component

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,6 +1,7 @@
 # Smolitux UI - Codex Progress
 
 **Started:** Mon Jun  9 13:10:56 UTC 2025
+**Last Updated:** Mon Jun  9 13:12:09 UTC 2025
 **Strategy:** Work with existing codebase, no setup dependencies
 
 ## 🎯 Package Priority (from AGENTS.md):
@@ -44,3 +45,4 @@
 
 ---
 *Updated by Codex AI*
+- 2025-06-09: Added Navigation component to @smolitux/layout

--- a/docs/wiki/development/component-fixme.md
+++ b/docs/wiki/development/component-fixme.md
@@ -19,6 +19,7 @@ Diese Datei sammelt automatisch erkannte FIXMEs in den Komponenten.
 | Komponente | FIXMEs |
 |------------|-------|
 | Grid | Props nicht typisiert |
+| Navigation | – |
 
 
 ### Update 2025-06-09

--- a/docs/wiki/development/component-status-layout.md
+++ b/docs/wiki/development/component-status-layout.md
@@ -11,5 +11,6 @@ This document tracks the current implementation and test status for the `@smolit
 | Footer | ✅ | ❌ | ✅ | Needs A11y Tests |
 | Sidebar | ✅ | ✅ | ✅ | Ready |
 | Stack | ✅ | ❌ | ✅ | Pending |
+| Navigation | ✅ | ❌ | ✅ | Needs A11y Tests |
 
 *Updated: 2025-06-09*

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -39,6 +39,7 @@ This document provides a comprehensive test status report for all components in 
 | @smolitux/layout | Grid | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
 | @smolitux/layout | Flex | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/layout | Sidebar | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
+| @smolitux/layout | Navigation | ✅ | ❌ | ❌ | ❌ | Ready |
 | @smolitux/charts | AreaChart | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/charts | BarChart | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/charts | LineChart | ✅ | ✅ | ❌ | ❌ | Ready |
@@ -112,7 +113,7 @@ This document provides a comprehensive test status report for all components in 
 ### Status by Package (Version 0.2.2)
 - **@smolitux/core**: 12 components ready, 17 need A11y tests
 - **@smolitux/theme**: 1 component ready
-- **@smolitux/layout**: 2 components ready, 2 need A11y tests
+- **@smolitux/layout**: 2 components ready, 3 need A11y tests
 - **@smolitux/charts**: 7 components ready
 - **@smolitux/ai**: 8 components need A11y tests
 - **@smolitux/blockchain**: All components complete with A11y tests

--- a/docs/wiki/development/component-todo.md
+++ b/docs/wiki/development/component-todo.md
@@ -130,6 +130,7 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 | Grid | – |
 | Header | Fehlende Tests, Kein Storybook vorhanden |
 | Sidebar | – |
+| Navigation | – |
 
 ## @smolitux/media
 

--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -16,7 +16,7 @@
 | @smolitux/testing         | ✅ Getestet  | –          | –        | –         | –     |
 | @smolitux/voice-control | ❌ Offen     | –          | –        | –         | –     |
 
-> Letzte Aktualisierung: 2025-06-09 – DeFiDashboard component covered
+> Letzte Aktualisierung: 2025-06-09 – DeFiDashboard component covered; Navigation component added
 
 ### Update 2025-06-13
 - Added annotation script entry in docs.

--- a/packages/@smolitux/layout/src/components/Navigation/Navigation.stories.tsx
+++ b/packages/@smolitux/layout/src/components/Navigation/Navigation.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Navigation } from './Navigation';
+
+const meta: Meta<typeof Navigation> = {
+  title: 'Layout/Navigation',
+  component: Navigation,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof Navigation>;
+
+const sampleItems = [
+  { id: 'home', label: 'Home', href: '#' },
+  { id: 'about', label: 'About', href: '#' },
+  { id: 'contact', label: 'Contact', href: '#' },
+];
+
+export const Default: Story = {
+  args: {
+    items: sampleItems,
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    items: sampleItems,
+    orientation: 'vertical',
+  },
+};
+
+export const Responsive: Story = {
+  args: {
+    items: sampleItems,
+    orientation: { base: 'vertical', md: 'horizontal' },
+  },
+};

--- a/packages/@smolitux/layout/src/components/Navigation/Navigation.test.tsx
+++ b/packages/@smolitux/layout/src/components/Navigation/Navigation.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Navigation } from './Navigation';
+
+const items = [{ id: 'home', label: 'Home', href: '#' }];
+
+describe('Navigation', () => {
+  it('renders without crashing', () => {
+    render(<Navigation items={items} data-testid="nav" />);
+    expect(screen.getByTestId('nav')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<Navigation items={items} data-testid="nav" className="custom" />);
+    const ul = screen.getByTestId('nav').querySelector('ul');
+    expect(ul).toHaveClass('custom');
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = React.createRef<HTMLElement>();
+    render(<Navigation ref={ref} items={items} />);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/packages/@smolitux/layout/src/components/Navigation/Navigation.tsx
+++ b/packages/@smolitux/layout/src/components/Navigation/Navigation.tsx
@@ -1,0 +1,85 @@
+import React, { forwardRef } from 'react';
+import type { ResponsiveProp } from '../../types';
+import { cn } from '@smolitux/utils';
+
+export interface NavigationItem {
+  id: string;
+  label: React.ReactNode;
+  href?: string;
+  onClick?: () => void;
+}
+
+export interface NavigationProps extends React.HTMLAttributes<HTMLElement> {
+  /** Navigation items */
+  items: NavigationItem[];
+  /** Orientation of the item list */
+  orientation?: ResponsiveProp<'horizontal' | 'vertical'>;
+  /** Gap between items */
+  gap?: ResponsiveProp<0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12>;
+  /** Accessible label for the nav element */
+  ariaLabel?: string;
+}
+
+const getClasses = <T extends string | number>(
+  prop: ResponsiveProp<T> | undefined,
+  prefix: string,
+  map?: Record<string, string>
+) => {
+  if (prop === undefined) return '';
+  const convert = (value: any) => (map ? map[value] || value : value);
+  if (typeof prop === 'object') {
+    return Object.entries(prop)
+      .map(([bp, val]) => `${bp}:${prefix}-${convert(val)}`)
+      .join(' ');
+  }
+  return `${prefix}-${convert(prop)}`;
+};
+
+export const Navigation = forwardRef<HTMLElement, NavigationProps>(
+  (
+    {
+      items,
+      orientation = 'horizontal',
+      gap = 2,
+      ariaLabel = 'Main Navigation',
+      className = '',
+      ...rest
+    },
+    ref
+  ) => {
+    const listClasses = cn(
+      'flex',
+      getClasses(orientation, 'flex', { horizontal: 'row', vertical: 'col' }),
+      getClasses(gap, 'gap'),
+      className
+    );
+
+    return (
+      <nav ref={ref} aria-label={ariaLabel} {...rest}>
+        <ul className={listClasses}>
+          {items.map((item) => (
+            <li key={item.id} className="list-none">
+              {item.href ? (
+                <a href={item.href} onClick={item.onClick} className="block">
+                  {item.label}
+                </a>
+              ) : (
+                <button
+                  type="button"
+                  onClick={item.onClick}
+                  className="block bg-transparent border-0 p-0"
+                >
+                  {item.label}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </nav>
+    );
+  }
+);
+
+Navigation.displayName = 'Navigation';
+
+export default Navigation;

--- a/packages/@smolitux/layout/src/index.ts
+++ b/packages/@smolitux/layout/src/index.ts
@@ -7,6 +7,11 @@ export {
   type SidebarProps,
   type SidebarItem,
 } from './components/Sidebar/Sidebar';
+export {
+  default as Navigation,
+  type NavigationProps,
+  type NavigationItem,
+} from './components/Navigation/Navigation';
 export { default as Header, type HeaderProps } from './components/Header/Header';
 export { default as Footer, type FooterProps } from './components/Footer/Footer';
 export {


### PR DESCRIPTION
## Summary
- implement `Navigation` component with responsive orientation
- add tests and stories for Navigation
- export Navigation in layout package
- document component status updates

## Testing
- `npm run lint --workspace=@smolitux/layout` *(fails: Cannot find module '../lib/cli')*
- `npm run test --workspace=@smolitux/layout` *(fails: jest not found)*
- `npm run build --workspace=@smolitux/layout` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd7bc79c832494cd36b38bc714fb