### PR TITLE
Add privacy consent management across community components

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -46,3 +46,4 @@
 ---
 *Updated by Codex AI*
 - 2025-06-09: Added Navigation component to @smolitux/layout
+- Updated community components with privacy consent management

--- a/docs/wiki/development/component-fixme.md
+++ b/docs/wiki/development/component-fixme.md
@@ -30,3 +30,4 @@ Diese Datei sammelt automatisch erkannte FIXMEs in den Komponenten.
 - Updated linting workflow using ESLint flat configuration.
 ### Update 2025-06-09
 - Added DeFiDashboard implementation notes.
+- Added privacy preference hooks; no FIXMEs

--- a/docs/wiki/development/component-status-community.md
+++ b/docs/wiki/development/component-status-community.md
@@ -14,3 +14,4 @@ This file tracks the current implementation and test status for the social featu
 
 - Added realistic stories with mock social data for all components.
 - Extended interaction tests for ActivityFeed and FollowButton.
+- Integrated privacy consent management with GDPR controls across components (2025-06-09)

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -315,3 +315,4 @@ See also [Resonance Component Status](./component-status-resonance.md) for packa
 - Migrated ESLint configuration to flat config and removed legacy `.eslintrc.js`.
 ### Update 2025-06-09
 - Added DeFiDashboard component implementation with tests and stories.
+- Added privacy consent context to community components (2025-06-09)

--- a/docs/wiki/development/component-todo.md
+++ b/docs/wiki/development/component-todo.md
@@ -297,3 +297,4 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 - General tooling upgrade with ESLint flat config.
 ### Update 2025-06-09
 - Added DeFiDashboard to blockchain TODO list.
+- Implemented GDPR privacy controls in community package

--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -35,3 +35,4 @@
 ### Update 2025-06-15
 
 - Updated tooling instructions after ESLint flat config migration.
+- PrivacyContext tests added for community package

--- a/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
@@ -1,6 +1,8 @@
 // TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
+import { usePrivacyConsent } from '../../privacy';
+import { PrivacySettings } from '../../privacy';
 
 export type ActivityType =
   | 'post'
@@ -73,6 +75,8 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   hasMore = false,
 }) => {
   const [loadingMore, setLoadingMore] = useState(false);
+  const { preferences } = usePrivacyConsent();
+  const [showPrivacy, setShowPrivacy] = useState(false);
 
   // Weitere Aktivitäten laden
   const handleLoadMore = async () => {
@@ -400,156 +404,169 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({
   };
 
   return (
-    <Card className={`overflow-hidden ${className}`}>
-      {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Aktivitäten</h3>
-      </div>
-
-      {/* Aktivitätsliste */}
-      <div className="divide-y divide-gray-200 dark:divide-gray-700">
-        {loading && activities.length === 0 ? (
-          renderPlaceholders()
-        ) : activities.length === 0 ? (
-          <div className="py-12 text-center text-gray-500 dark:text-gray-400">
-            <svg
-              className="w-16 h-16 mx-auto mb-4 text-gray-400 dark:text-gray-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 10h16M4 14h16M4 18h16"
-              />
-            </svg>
-            <p className="text-lg font-medium">Keine Aktivitäten vorhanden</p>
-            <p className="mt-2">Es wurden noch keine Aktivitäten aufgezeichnet.</p>
-          </div>
-        ) : (
-          activities.map((activity) => (
-            <div
-              key={activity.id}
-              className="p-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer transition-colors"
-              onClick={() => handleActivityClick(activity)}
-            >
-              <div className="flex items-start">
-                {/* Benutzeravatar oder Aktivitätsicon */}
-                <div className="flex-shrink-0">
-                  {activity.user.avatarUrl ? (
-                    <div
-                      className="w-10 h-10 rounded-full overflow-hidden cursor-pointer"
-                      onClick={(e) => handleUserClick(activity.user.id, e)}
-                    >
-                      <img
-                        src={activity.user.avatarUrl}
-                        alt={activity.user.name}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                  ) : (
-                    getActivityIcon(activity.type)
-                  )}
-                </div>
-
-                {/* Aktivitätsinhalt */}
-                <div className="ml-4 flex-1 min-w-0">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <p className="text-sm">
-                        <span
-                          className="font-medium text-gray-900 dark:text-white hover:underline cursor-pointer"
-                          onClick={(e) => handleUserClick(activity.user.id, e)}
-                        >
-                          {activity.user.name}
-                        </span>{' '}
-                        <span className="text-gray-600 dark:text-gray-300">
-                          {getActivityText(activity)}
-                        </span>
-                      </p>
-
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                        {formatTimestamp(activity.timestamp)}
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Zielinhalt (falls vorhanden) */}
-                  {activity.target && activity.target.content && (
-                    <div className="mt-2 p-3 bg-gray-50 dark:bg-gray-800 rounded-md">
-                      <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3">
-                        {activity.target.content}
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Mediavorschau (falls vorhanden) */}
-                  {activity.target && activity.target.thumbnailUrl && (
-                    <div className="mt-2 rounded-md overflow-hidden">
-                      <img
-                        src={activity.target.thumbnailUrl}
-                        alt={activity.target.title || 'Medienvorschau'}
-                        className="w-full h-32 object-cover"
-                      />
-                    </div>
-                  )}
-
-                  {/* Metadaten (falls vorhanden) */}
-                  {activity.metadata && activity.type === 'reward' && (
-                    <div className="mt-2 flex items-center text-sm text-gray-600 dark:text-gray-300">
-                      <svg
-                        className="w-4 h-4 mr-1 text-yellow-500"
-                        fill="currentColor"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.31-8.86c-1.77-.45-2.34-.94-2.34-1.67 0-.84.79-1.43 2.1-1.43 1.38 0 1.9.66 1.94 1.64h1.71c-.05-1.34-.87-2.57-2.49-2.97V5H10.9v1.69c-1.51.32-2.72 1.3-2.72 2.81 0 1.79 1.49 2.69 3.66 3.21 1.95.46 2.34 1.15 2.34 1.87 0 .53-.39 1.39-2.1 1.39-1.6 0-2.23-.72-2.32-1.64H8.04c.1 1.7 1.36 2.66 2.86 2.97V19h2.34v-1.67c1.52-.29 2.72-1.16 2.73-2.77-.01-2.2-1.9-2.96-3.66-3.42z" />
-                      </svg>
-                      <span>
-                        {activity.metadata.amount} {activity.metadata.tokenSymbol || 'Token'}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          ))
-        )}
-
-        {/* Lade-Indikator */}
-        {loading && activities.length > 0 && (
-          <div className="p-4 text-center">
-            <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-solid border-primary-500 border-r-transparent" />
-            <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-              Aktivitäten werden geladen...
-            </p>
-          </div>
-        )}
-      </div>
-
-      {/* Weitere laden */}
-      {!loading && hasMore && (
-        <div className="p-4 border-t border-gray-200 dark:border-gray-700">
-          <Button
-            variant="outline"
-            onClick={handleLoadMore}
-            disabled={loadingMore}
-            className="w-full"
-          >
-            {loadingMore ? (
-              <>
-                <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-solid border-primary-500 border-r-transparent mr-2" />
-                Wird geladen...
-              </>
-            ) : (
-              'Weitere Aktivitäten laden'
-            )}
+    <>
+      <Card className={`overflow-hidden ${className}`}>
+        {/* Header */}
+        <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Aktivitäten</h3>
+          <Button variant="text" size="sm" onClick={() => setShowPrivacy(true)}>
+            Privacy
           </Button>
         </div>
-      )}
-    </Card>
+
+        {!preferences.personalization && (
+          <div className="p-4 text-sm bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300">
+            Personalisierte Inhalte sind deaktiviert. Sie können diese Einstellung im
+            Datenschutzmenü ändern.
+          </div>
+        )}
+
+        {/* Aktivitätsliste */}
+        <div className="divide-y divide-gray-200 dark:divide-gray-700">
+          {loading && activities.length === 0 ? (
+            renderPlaceholders()
+          ) : activities.length === 0 ? (
+            <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+              <svg
+                className="w-16 h-16 mx-auto mb-4 text-gray-400 dark:text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 10h16M4 14h16M4 18h16"
+                />
+              </svg>
+              <p className="text-lg font-medium">Keine Aktivitäten vorhanden</p>
+              <p className="mt-2">Es wurden noch keine Aktivitäten aufgezeichnet.</p>
+            </div>
+          ) : (
+            activities.map((activity) => (
+              <div
+                key={activity.id}
+                className="p-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer transition-colors"
+                onClick={() => handleActivityClick(activity)}
+              >
+                <div className="flex items-start">
+                  {/* Benutzeravatar oder Aktivitätsicon */}
+                  <div className="flex-shrink-0">
+                    {activity.user.avatarUrl ? (
+                      <div
+                        className="w-10 h-10 rounded-full overflow-hidden cursor-pointer"
+                        onClick={(e) => handleUserClick(activity.user.id, e)}
+                      >
+                        <img
+                          src={activity.user.avatarUrl}
+                          alt={activity.user.name}
+                          className="w-full h-full object-cover"
+                        />
+                      </div>
+                    ) : (
+                      getActivityIcon(activity.type)
+                    )}
+                  </div>
+
+                  {/* Aktivitätsinhalt */}
+                  <div className="ml-4 flex-1 min-w-0">
+                    <div className="flex items-start justify-between">
+                      <div>
+                        <p className="text-sm">
+                          <span
+                            className="font-medium text-gray-900 dark:text-white hover:underline cursor-pointer"
+                            onClick={(e) => handleUserClick(activity.user.id, e)}
+                          >
+                            {activity.user.name}
+                          </span>{' '}
+                          <span className="text-gray-600 dark:text-gray-300">
+                            {getActivityText(activity)}
+                          </span>
+                        </p>
+
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          {formatTimestamp(activity.timestamp)}
+                        </p>
+                      </div>
+                    </div>
+
+                    {/* Zielinhalt (falls vorhanden) */}
+                    {activity.target && activity.target.content && (
+                      <div className="mt-2 p-3 bg-gray-50 dark:bg-gray-800 rounded-md">
+                        <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3">
+                          {activity.target.content}
+                        </p>
+                      </div>
+                    )}
+
+                    {/* Mediavorschau (falls vorhanden) */}
+                    {activity.target && activity.target.thumbnailUrl && (
+                      <div className="mt-2 rounded-md overflow-hidden">
+                        <img
+                          src={activity.target.thumbnailUrl}
+                          alt={activity.target.title || 'Medienvorschau'}
+                          className="w-full h-32 object-cover"
+                        />
+                      </div>
+                    )}
+
+                    {/* Metadaten (falls vorhanden) */}
+                    {activity.metadata && activity.type === 'reward' && (
+                      <div className="mt-2 flex items-center text-sm text-gray-600 dark:text-gray-300">
+                        <svg
+                          className="w-4 h-4 mr-1 text-yellow-500"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.31-8.86c-1.77-.45-2.34-.94-2.34-1.67 0-.84.79-1.43 2.1-1.43 1.38 0 1.9.66 1.94 1.64h1.71c-.05-1.34-.87-2.57-2.49-2.97V5H10.9v1.69c-1.51.32-2.72 1.3-2.72 2.81 0 1.79 1.49 2.69 3.66 3.21 1.95.46 2.34 1.15 2.34 1.87 0 .53-.39 1.39-2.1 1.39-1.6 0-2.23-.72-2.32-1.64H8.04c.1 1.7 1.36 2.66 2.86 2.97V19h2.34v-1.67c1.52-.29 2.72-1.16 2.73-2.77-.01-2.2-1.9-2.96-3.66-3.42z" />
+                        </svg>
+                        <span>
+                          {activity.metadata.amount} {activity.metadata.tokenSymbol || 'Token'}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+
+          {/* Lade-Indikator */}
+          {loading && activities.length > 0 && (
+            <div className="p-4 text-center">
+              <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-solid border-primary-500 border-r-transparent" />
+              <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                Aktivitäten werden geladen...
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Weitere laden */}
+        {!loading && hasMore && (
+          <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+            <Button
+              variant="outline"
+              onClick={handleLoadMore}
+              disabled={loadingMore}
+              className="w-full"
+            >
+              {loadingMore ? (
+                <>
+                  <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-solid border-primary-500 border-r-transparent mr-2" />
+                  Wird geladen...
+                </>
+              ) : (
+                'Weitere Aktivitäten laden'
+              )}
+            </Button>
+          </div>
+        )}
+      </Card>
+      <PrivacySettings open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+    </>
   );
 };

--- a/packages/@smolitux/community/src/components/CommentSection/CommentSection.tsx
+++ b/packages/@smolitux/community/src/components/CommentSection/CommentSection.tsx
@@ -1,6 +1,7 @@
 // TODO: forwardRef hinzufügen
 import React, { useState, ChangeEvent } from 'react';
 import { Button, Input } from '@smolitux/core';
+import { usePrivacyConsent, PrivacySettings } from '../../privacy';
 
 export interface CommentData {
   /** Eindeutige ID des Kommentars */
@@ -61,6 +62,8 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
   const [replyContent, setReplyContent] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [expandedReplies, setExpandedReplies] = useState<Record<string, boolean>>({});
+  const { preferences } = usePrivacyConsent();
+  const [showPrivacy, setShowPrivacy] = useState(false);
 
   // Kommentar hinzufügen
   const handleAddComment = async () => {
@@ -329,51 +332,65 @@ export const CommentSection: React.FC<CommentSectionProps> = ({
   };
 
   return (
-    <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 ${className}`}>
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-        Kommentare ({comments.length})
-      </h3>
+    <>
+      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 ${className}`}>
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Kommentare ({comments.length})
+          </h3>
+          <Button variant="text" size="sm" onClick={() => setShowPrivacy(true)}>
+            Privacy
+          </Button>
+        </div>
 
-      {/* Kommentar-Eingabe */}
-      {currentUser ? (
-        <div className="mt-4 flex">
-          <Avatar src={currentUser.avatar} alt={currentUser.name} size="md" className="mr-4" />
+        {!preferences.personalization && (
+          <div className="mt-2 p-2 text-sm bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300 rounded">
+            Personalisierte Inhalte sind deaktiviert. Datenschutzoptionen können angepasst werden.
+          </div>
+        )}
 
-          <div className="flex-1">
-            <Input
-              value={newComment}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setNewComment(e.target.value)}
-              placeholder="Kommentar schreiben..."
-              className="mb-2"
-            />
+        {/* Kommentar-Eingabe */}
+        {currentUser ? (
+          <div className="mt-4 flex">
+            <Avatar src={currentUser.avatar} alt={currentUser.name} size="md" className="mr-4" />
 
-            <div className="flex justify-end">
-              <Button
-                variant="primary"
-                onClick={handleAddComment}
-                disabled={!newComment.trim() || isSubmitting}
-              >
-                Kommentieren
-              </Button>
+            <div className="flex-1">
+              <Input
+                value={newComment}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setNewComment(e.target.value)}
+                placeholder="Kommentar schreiben..."
+                className="mb-2"
+              />
+
+              <div className="flex justify-end">
+                <Button
+                  variant="primary"
+                  onClick={handleAddComment}
+                  disabled={!newComment.trim() || isSubmitting}
+                >
+                  Kommentieren
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
-      ) : (
-        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
-          Bitte melden Sie sich an, um zu kommentieren.
-        </p>
-      )}
-
-      {/* Kommentarliste */}
-      <div className="mt-6 space-y-6">
-        {comments.length === 0 ? (
-          <p className="text-center text-gray-500 dark:text-gray-400 py-4">
-            Noch keine Kommentare. Sei der Erste!
-          </p>
         ) : (
-          comments.map((comment) => <Comment key={comment.id} comment={comment} />)
+          <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+            Bitte melden Sie sich an, um zu kommentieren.
+          </p>
         )}
+
+        {/* Kommentarliste */}
+        <div className="mt-6 space-y-6">
+          {comments.length === 0 ? (
+            <p className="text-center text-gray-500 dark:text-gray-400 py-4">
+              Noch keine Kommentare. Sei der Erste!
+            </p>
+          ) : (
+            comments.map((comment) => <Comment key={comment.id} comment={comment} />)
+          )}
+        </div>
       </div>
-    </div>
+      <PrivacySettings open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+    </>
   );
 };

--- a/packages/@smolitux/community/src/components/FollowButton/FollowButton.tsx
+++ b/packages/@smolitux/community/src/components/FollowButton/FollowButton.tsx
@@ -1,6 +1,7 @@
 // TODO: forwardRef hinzufügen
 import React, { useState, useEffect } from 'react';
 import { Button } from '@smolitux/core';
+import { usePrivacyConsent, PrivacySettings } from '../../privacy';
 
 export interface FollowButtonProps {
   /** Benutzer-ID des zu folgenden Benutzers */
@@ -50,6 +51,8 @@ export const FollowButton: React.FC<FollowButtonProps> = ({
   const [count, setCount] = useState(followerCount || 0);
   const [isLoading, setIsLoading] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+  const { preferences } = usePrivacyConsent();
+  const [showPrivacy, setShowPrivacy] = useState(false);
 
   // Aktualisiere den Status, wenn sich die Props ändern
   useEffect(() => {
@@ -125,7 +128,7 @@ export const FollowButton: React.FC<FollowButtonProps> = ({
 
   // Icon-Variante
   if (variant === 'icon') {
-    return (
+    const element = (
       <button
         onClick={handleFollowClick}
         disabled={isLoading || isSelf}
@@ -189,14 +192,20 @@ export const FollowButton: React.FC<FollowButtonProps> = ({
           </svg>
         )}
 
-        {showCount && <span className="ml-1 text-xs">{count}</span>}
+        {showCount && preferences.analytics && <span className="ml-1 text-xs">{count}</span>}
       </button>
+    );
+    return (
+      <>
+        {element}
+        <PrivacySettings open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+      </>
     );
   }
 
   // Text-Variante
   if (variant === 'text') {
-    return (
+    const element = (
       <button
         onClick={handleFollowClick}
         disabled={isLoading || isSelf}
@@ -265,15 +274,21 @@ export const FollowButton: React.FC<FollowButtonProps> = ({
 
         <span>{getButtonText()}</span>
 
-        {showCount && (
+        {showCount && preferences.analytics && (
           <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">({count})</span>
         )}
       </button>
     );
+    return (
+      <>
+        {element}
+        <PrivacySettings open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+      </>
+    );
   }
 
   // Standard-Button (primary oder outline)
-  return (
+  const element = (
     <Button
       variant={getButtonVariant()}
       size={size}
@@ -348,7 +363,13 @@ export const FollowButton: React.FC<FollowButtonProps> = ({
 
       <span>{getButtonText()}</span>
 
-      {showCount && <span className="ml-1 text-xs">({count})</span>}
+      {showCount && preferences.analytics && <span className="ml-1 text-xs">({count})</span>}
     </Button>
+  );
+  return (
+    <>
+      {element}
+      <PrivacySettings open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+    </>
   );
 };

--- a/packages/@smolitux/community/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/packages/@smolitux/community/src/components/NotificationCenter/NotificationCenter.tsx
@@ -1,6 +1,7 @@
 // TODO: forwardRef hinzufügen
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@smolitux/core';
+import { usePrivacyConsent, PrivacySettings } from '../../privacy';
 
 export type NotificationType =
   | 'info'
@@ -65,6 +66,8 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'all' | 'unread'>('all');
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { preferences } = usePrivacyConsent();
+  const [showPrivacy, setShowPrivacy] = useState(false);
 
   // Anzahl der ungelesenen Benachrichtigungen
   const unreadCount = notifications.filter((notification) => !notification.read).length;
@@ -371,208 +374,220 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({
   };
 
   return (
-    <div className={`relative ${className}`} ref={dropdownRef}>
-      {/* Benachrichtigungsicon */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white focus:outline-none"
-        aria-label="Benachrichtigungen"
-      >
-        <svg
-          className="w-6 h-6"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+    <>
+      <div className={`relative ${className}`} ref={dropdownRef}>
+        {/* Benachrichtigungsicon */}
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="relative p-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white focus:outline-none"
+          aria-label="Benachrichtigungen"
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-          />
-        </svg>
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+            />
+          </svg>
 
-        {/* Badge für ungelesene Benachrichtigungen */}
-        {unreadCount > 0 && (
-          <span className="absolute top-0 right-0 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white transform translate-x-1/2 -translate-y-1/2 bg-red-500 rounded-full">
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
-        )}
-      </button>
-
-      {/* Dropdown */}
-      {isOpen && (
-        <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden z-50">
-          {/* Header */}
-          <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-              Benachrichtigungen
-            </h3>
-
-            {unreadCount > 0 && (
-              <button
-                onClick={handleMarkAllAsRead}
-                className="text-sm text-primary-600 dark:text-primary-400 hover:underline"
-              >
-                Alle als gelesen markieren
-              </button>
-            )}
-          </div>
-
-          {/* Tabs */}
-          <div className="flex border-b border-gray-200 dark:border-gray-700">
-            <button
-              onClick={() => setActiveTab('all')}
-              className={`flex-1 py-2 text-sm font-medium ${
-                activeTab === 'all'
-                  ? 'text-primary-600 dark:text-primary-400 border-b-2 border-primary-600 dark:border-primary-400'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
-              }`}
-            >
-              Alle
-            </button>
-
-            <button
-              onClick={() => setActiveTab('unread')}
-              className={`flex-1 py-2 text-sm font-medium ${
-                activeTab === 'unread'
-                  ? 'text-primary-600 dark:text-primary-400 border-b-2 border-primary-600 dark:border-primary-400'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
-              }`}
-            >
-              Ungelesen {unreadCount > 0 && `(${unreadCount})`}
-            </button>
-          </div>
-
-          {/* Benachrichtigungsliste */}
-          <div className="max-h-96 overflow-y-auto">
-            {filteredNotifications.length === 0 ? (
-              <div className="py-8 text-center text-gray-500 dark:text-gray-400">
-                <svg
-                  className="w-12 h-12 mx-auto mb-2 text-gray-400 dark:text-gray-500"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
-                  />
-                </svg>
-                <p>Keine Benachrichtigungen vorhanden</p>
-              </div>
-            ) : (
-              filteredNotifications.map((notification) => (
-                <div
-                  key={notification.id}
-                  onClick={() => handleClick(notification)}
-                  className={`px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-start hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer ${
-                    !notification.read ? 'bg-blue-50 dark:bg-blue-900/10' : ''
-                  }`}
-                >
-                  {/* Icon oder Avatar */}
-                  {notification.user?.avatar ? (
-                    <div className="w-10 h-10 rounded-full overflow-hidden mr-3 flex-shrink-0">
-                      <img
-                        src={notification.user.avatar}
-                        alt={notification.user.name}
-                        className="w-full h-full object-cover"
-                      />
-                    </div>
-                  ) : (
-                    <div className="mr-3 flex-shrink-0">
-                      {getNotificationIcon(notification.type)}
-                    </div>
-                  )}
-
-                  {/* Inhalt */}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-start justify-between">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">
-                        {notification.title}
-                      </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 ml-2">
-                        {formatTimestamp(notification.timestamp)}
-                      </p>
-                    </div>
-
-                    <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 line-clamp-2">
-                      {notification.content}
-                    </p>
-                  </div>
-
-                  {/* Aktionen */}
-                  <div className="ml-2 flex-shrink-0 flex flex-col space-y-1">
-                    {!notification.read && (
-                      <button
-                        onClick={(e) => handleMarkAsRead(notification.id, e)}
-                        className="p-1 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-                        aria-label="Als gelesen markieren"
-                      >
-                        <svg
-                          className="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M5 13l4 4L19 7"
-                          />
-                        </svg>
-                      </button>
-                    )}
-
-                    {onDelete && (
-                      <button
-                        onClick={(e) => handleDelete(notification.id, e)}
-                        className="p-1 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-                        aria-label="Löschen"
-                      >
-                        <svg
-                          className="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M6 18L18 6M6 6l12 12"
-                          />
-                        </svg>
-                      </button>
-                    )}
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
-
-          {/* Footer */}
-          {filteredNotifications.length > 0 && (
-            <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 text-center">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setIsOpen(false)}
-                className="w-full"
-              >
-                Alle Benachrichtigungen anzeigen
-              </Button>
-            </div>
+          {/* Badge für ungelesene Benachrichtigungen */}
+          {unreadCount > 0 && (
+            <span className="absolute top-0 right-0 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white transform translate-x-1/2 -translate-y-1/2 bg-red-500 rounded-full">
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
           )}
-        </div>
-      )}
-    </div>
+        </button>
+
+        {/* Dropdown */}
+        {isOpen && (
+          <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden z-50">
+            {/* Header */}
+            <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Benachrichtigungen
+              </h3>
+              <div className="flex items-center gap-2">
+                <Button variant="text" size="sm" onClick={() => setShowPrivacy(true)}>
+                  Privacy
+                </Button>
+                {unreadCount > 0 && (
+                  <button
+                    onClick={handleMarkAllAsRead}
+                    className="text-sm text-primary-600 dark:text-primary-400 hover:underline"
+                  >
+                    Alle als gelesen markieren
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Tabs */}
+            <div className="flex border-b border-gray-200 dark:border-gray-700">
+              <button
+                onClick={() => setActiveTab('all')}
+                className={`flex-1 py-2 text-sm font-medium ${
+                  activeTab === 'all'
+                    ? 'text-primary-600 dark:text-primary-400 border-b-2 border-primary-600 dark:border-primary-400'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                }`}
+              >
+                Alle
+              </button>
+
+              <button
+                onClick={() => setActiveTab('unread')}
+                className={`flex-1 py-2 text-sm font-medium ${
+                  activeTab === 'unread'
+                    ? 'text-primary-600 dark:text-primary-400 border-b-2 border-primary-600 dark:border-primary-400'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                }`}
+              >
+                Ungelesen {unreadCount > 0 && `(${unreadCount})`}
+              </button>
+            </div>
+
+            {/* Benachrichtigungsliste */}
+            <div className="max-h-96 overflow-y-auto">
+              {!preferences.personalization && (
+                <div className="p-2 text-sm bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300">
+                  Personalisierte Inhalte sind deaktiviert.
+                </div>
+              )}
+              {filteredNotifications.length === 0 ? (
+                <div className="py-8 text-center text-gray-500 dark:text-gray-400">
+                  <svg
+                    className="w-12 h-12 mx-auto mb-2 text-gray-400 dark:text-gray-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+                    />
+                  </svg>
+                  <p>Keine Benachrichtigungen vorhanden</p>
+                </div>
+              ) : (
+                filteredNotifications.map((notification) => (
+                  <div
+                    key={notification.id}
+                    onClick={() => handleClick(notification)}
+                    className={`px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-start hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer ${
+                      !notification.read ? 'bg-blue-50 dark:bg-blue-900/10' : ''
+                    }`}
+                  >
+                    {/* Icon oder Avatar */}
+                    {notification.user?.avatar ? (
+                      <div className="w-10 h-10 rounded-full overflow-hidden mr-3 flex-shrink-0">
+                        <img
+                          src={notification.user.avatar}
+                          alt={notification.user.name}
+                          className="w-full h-full object-cover"
+                        />
+                      </div>
+                    ) : (
+                      <div className="mr-3 flex-shrink-0">
+                        {getNotificationIcon(notification.type)}
+                      </div>
+                    )}
+
+                    {/* Inhalt */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-start justify-between">
+                        <p className="text-sm font-medium text-gray-900 dark:text-white">
+                          {notification.title}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 ml-2">
+                          {formatTimestamp(notification.timestamp)}
+                        </p>
+                      </div>
+
+                      <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 line-clamp-2">
+                        {notification.content}
+                      </p>
+                    </div>
+
+                    {/* Aktionen */}
+                    <div className="ml-2 flex-shrink-0 flex flex-col space-y-1">
+                      {!notification.read && (
+                        <button
+                          onClick={(e) => handleMarkAsRead(notification.id, e)}
+                          className="p-1 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                          aria-label="Als gelesen markieren"
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M5 13l4 4L19 7"
+                            />
+                          </svg>
+                        </button>
+                      )}
+
+                      {onDelete && (
+                        <button
+                          onClick={(e) => handleDelete(notification.id, e)}
+                          className="p-1 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                          aria-label="Löschen"
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M6 18L18 6M6 6l12 12"
+                            />
+                          </svg>
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            {/* Footer */}
+            {filteredNotifications.length > 0 && (
+              <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 text-center">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsOpen(false)}
+                  className="w-full"
+                >
+                  Alle Benachrichtigungen anzeigen
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <PrivacySettings open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+    </>
   );
 };

--- a/packages/@smolitux/community/src/components/UserProfile/UserProfile.tsx
+++ b/packages/@smolitux/community/src/components/UserProfile/UserProfile.tsx
@@ -1,6 +1,7 @@
 // TODO: forwardRef hinzufügen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
+import { usePrivacyConsent, PrivacySettings } from '../../privacy';
 
 export interface UserStats {
   /** Anzahl der Follower */
@@ -83,6 +84,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
 }) => {
   const [following, setFollowing] = useState(isFollowing);
   const [isLoading, setIsLoading] = useState(false);
+  const { preferences } = usePrivacyConsent();
+  const [showPrivacy, setShowPrivacy] = useState(false);
 
   // Datum formatieren
   const formatDate = (date: Date): string => {
@@ -115,193 +118,209 @@ export const UserProfile: React.FC<UserProfileProps> = ({
   };
 
   return (
-    <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden ${className}`}>
-      {/* Cover-Bild */}
-      <div className="relative h-48 bg-gray-200 dark:bg-gray-700">
-        {coverImageUrl ? (
-          <img
-            src={coverImageUrl}
-            alt={`${displayName} Cover`}
-            className="w-full h-full object-cover"
-          />
-        ) : (
-          <div className="w-full h-full bg-gradient-to-r from-blue-500 to-purple-600" />
-        )}
+    <>
+      <div
+        className={`bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden ${className}`}
+      >
+        {/* Cover-Bild */}
+        <div className="relative h-48 bg-gray-200 dark:bg-gray-700">
+          {coverImageUrl ? (
+            <img
+              src={coverImageUrl}
+              alt={`${displayName} Cover`}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full bg-gradient-to-r from-blue-500 to-purple-600" />
+          )}
 
-        {/* Avatar */}
-        <div className="absolute -bottom-16 left-6">
-          <div className="w-32 h-32 rounded-full border-4 border-white dark:border-gray-800 overflow-hidden bg-gray-200 dark:bg-gray-700">
-            {avatarUrl ? (
-              <img src={avatarUrl} alt={displayName} className="w-full h-full object-cover" />
+          {/* Avatar */}
+          <div className="absolute -bottom-16 left-6">
+            <div className="w-32 h-32 rounded-full border-4 border-white dark:border-gray-800 overflow-hidden bg-gray-200 dark:bg-gray-700">
+              {avatarUrl ? (
+                <img src={avatarUrl} alt={displayName} className="w-full h-full object-cover" />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-gray-500 dark:text-gray-400 text-4xl font-bold">
+                  {displayName.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Aktionen */}
+          <div className="absolute top-4 right-4 flex space-x-2">
+            {isCurrentUser ? (
+              <Button
+                variant="outline"
+                onClick={onEdit}
+                className="bg-white/80 dark:bg-gray-800/80 hover:bg-white dark:hover:bg-gray-800"
+              >
+                Profil bearbeiten
+              </Button>
             ) : (
-              <div className="w-full h-full flex items-center justify-center text-gray-500 dark:text-gray-400 text-4xl font-bold">
-                {displayName.charAt(0).toUpperCase()}
-              </div>
+              <Button
+                variant={following ? 'outline' : 'primary'}
+                onClick={handleFollow}
+                disabled={isLoading}
+              >
+                {following ? 'Entfolgen' : 'Folgen'}
+              </Button>
             )}
+            <Button variant="text" size="sm" onClick={() => setShowPrivacy(true)}>
+              Privacy
+            </Button>
           </div>
         </div>
 
-        {/* Aktionen */}
-        <div className="absolute top-4 right-4 flex space-x-2">
-          {isCurrentUser ? (
-            <Button
-              variant="outline"
-              onClick={onEdit}
-              className="bg-white/80 dark:bg-gray-800/80 hover:bg-white dark:hover:bg-gray-800"
-            >
-              Profil bearbeiten
-            </Button>
-          ) : (
-            <Button
-              variant={following ? 'outline' : 'primary'}
-              onClick={handleFollow}
-              disabled={isLoading}
-            >
-              {following ? 'Entfolgen' : 'Folgen'}
-            </Button>
+        {/* Profilinformationen */}
+        {!preferences.personalization && (
+          <div className="px-6 py-2 text-sm bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-300">
+            Personalisierte Inhalte sind deaktiviert.
+          </div>
+        )}
+
+        <div className="pt-20 px-6 pb-6">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{displayName}</h1>
+              <p className="text-gray-600 dark:text-gray-400">@{username}</p>
+            </div>
+
+            <div className="mt-4 md:mt-0 flex items-center text-sm text-gray-500 dark:text-gray-400">
+              <span>Mitglied seit {formatDate(joinDate)}</span>
+              {walletAddress && (
+                <span className="ml-4 flex items-center">
+                  <svg
+                    className="w-4 h-4 mr-1"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+                    />
+                  </svg>
+                  {formatWalletAddress(walletAddress)}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Biografie */}
+          {bio && (
+            <div className="mt-6">
+              <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line">{bio}</p>
+            </div>
+          )}
+
+          {/* Statistiken */}
+          <div className="mt-6 grid grid-cols-2 md:grid-cols-5 gap-4">
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.followers}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Follower</p>
+            </div>
+
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.following}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Folgt</p>
+            </div>
+
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {stats.contentCount}
+              </p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Inhalte</p>
+            </div>
+
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.totalLikes}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Likes</p>
+            </div>
+
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.totalViews}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Aufrufe</p>
+            </div>
+          </div>
+
+          {/* Soziale Links */}
+          {socialLinks && Object.keys(socialLinks).length > 0 && (
+            <div className="mt-6 flex flex-wrap gap-2">
+              {socialLinks.twitter && (
+                <a
+                  href={socialLinks.twitter}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  aria-label="Twitter"
+                >
+                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
+                  </svg>
+                </a>
+              )}
+
+              {socialLinks.instagram && (
+                <a
+                  href={socialLinks.instagram}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  aria-label="Instagram"
+                >
+                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
+                  </svg>
+                </a>
+              )}
+
+              {socialLinks.youtube && (
+                <a
+                  href={socialLinks.youtube}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  aria-label="YouTube"
+                >
+                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+                  </svg>
+                </a>
+              )}
+
+              {socialLinks.website && (
+                <a
+                  href={socialLinks.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  aria-label="Website"
+                >
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+                    />
+                  </svg>
+                </a>
+              )}
+            </div>
           )}
         </div>
       </div>
-
-      {/* Profilinformationen */}
-      <div className="pt-20 px-6 pb-6">
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{displayName}</h1>
-            <p className="text-gray-600 dark:text-gray-400">@{username}</p>
-          </div>
-
-          <div className="mt-4 md:mt-0 flex items-center text-sm text-gray-500 dark:text-gray-400">
-            <span>Mitglied seit {formatDate(joinDate)}</span>
-            {walletAddress && (
-              <span className="ml-4 flex items-center">
-                <svg
-                  className="w-4 h-4 mr-1"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
-                  />
-                </svg>
-                {formatWalletAddress(walletAddress)}
-              </span>
-            )}
-          </div>
-        </div>
-
-        {/* Biografie */}
-        {bio && (
-          <div className="mt-6">
-            <p className="text-gray-700 dark:text-gray-300 whitespace-pre-line">{bio}</p>
-          </div>
-        )}
-
-        {/* Statistiken */}
-        <div className="mt-6 grid grid-cols-2 md:grid-cols-5 gap-4">
-          <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.followers}</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Follower</p>
-          </div>
-
-          <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.following}</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Folgt</p>
-          </div>
-
-          <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.contentCount}</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Inhalte</p>
-          </div>
-
-          <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.totalLikes}</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Likes</p>
-          </div>
-
-          <div className="text-center">
-            <p className="text-2xl font-bold text-gray-900 dark:text-white">{stats.totalViews}</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Aufrufe</p>
-          </div>
-        </div>
-
-        {/* Soziale Links */}
-        {socialLinks && Object.keys(socialLinks).length > 0 && (
-          <div className="mt-6 flex flex-wrap gap-2">
-            {socialLinks.twitter && (
-              <a
-                href={socialLinks.twitter}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                aria-label="Twitter"
-              >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
-                </svg>
-              </a>
-            )}
-
-            {socialLinks.instagram && (
-              <a
-                href={socialLinks.instagram}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                aria-label="Instagram"
-              >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
-                </svg>
-              </a>
-            )}
-
-            {socialLinks.youtube && (
-              <a
-                href={socialLinks.youtube}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                aria-label="YouTube"
-              >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
-                </svg>
-              </a>
-            )}
-
-            {socialLinks.website && (
-              <a
-                href={socialLinks.website}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="p-2 bg-gray-100 dark:bg-gray-700 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                aria-label="Website"
-              >
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
-                  />
-                </svg>
-              </a>
-            )}
-          </div>
-        )}
-      </div>
-    </div>
+      <PrivacySettings open={showPrivacy} onClose={() => setShowPrivacy(false)} />
+    </>
   );
 };

--- a/packages/@smolitux/community/src/index.ts
+++ b/packages/@smolitux/community/src/index.ts
@@ -4,3 +4,4 @@ export * from './components/UserProfile';
 export * from './components/NotificationCenter';
 export * from './components/ActivityFeed';
 export * from './components/FollowButton';
+export * from './privacy';

--- a/packages/@smolitux/community/src/privacy/PrivacyContext.tsx
+++ b/packages/@smolitux/community/src/privacy/PrivacyContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export interface PrivacyPreferences {
+  analytics: boolean;
+  personalization: boolean;
+  marketing: boolean;
+}
+
+interface PrivacyConsentContextProps {
+  preferences: PrivacyPreferences;
+  updatePreferences: (prefs: Partial<PrivacyPreferences>) => void;
+}
+
+const DEFAULT_PREFERENCES: PrivacyPreferences = {
+  analytics: false,
+  personalization: false,
+  marketing: false,
+};
+
+const LOCAL_STORAGE_KEY = 'smolitux-community-privacy';
+
+const PrivacyConsentContext = createContext<PrivacyConsentContextProps>({
+  preferences: DEFAULT_PREFERENCES,
+  updatePreferences: () => {},
+});
+
+export const PrivacyConsentProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [preferences, setPreferences] = useState<PrivacyPreferences>(() => {
+    try {
+      const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+      return stored ? { ...DEFAULT_PREFERENCES, ...JSON.parse(stored) } : DEFAULT_PREFERENCES;
+    } catch {
+      return DEFAULT_PREFERENCES;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(preferences));
+    } catch {
+      /* ignore */
+    }
+  }, [preferences]);
+
+  const updatePreferences = (prefs: Partial<PrivacyPreferences>) => {
+    setPreferences((prev) => ({ ...prev, ...prefs }));
+  };
+
+  return (
+    <PrivacyConsentContext.Provider value={{ preferences, updatePreferences }}>
+      {children}
+    </PrivacyConsentContext.Provider>
+  );
+};
+
+export const usePrivacyConsent = () => useContext(PrivacyConsentContext);

--- a/packages/@smolitux/community/src/privacy/PrivacySettings.stories.tsx
+++ b/packages/@smolitux/community/src/privacy/PrivacySettings.stories.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { PrivacyConsentProvider } from './PrivacyContext';
+import { PrivacySettings } from './PrivacySettings';
+
+const meta: Meta<typeof PrivacySettings> = {
+  title: 'Community/PrivacySettings',
+  component: PrivacySettings,
+  parameters: { layout: 'centered' },
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <PrivacyConsentProvider>
+        <PrivacySettings open={open} onClose={() => setOpen(false)} />
+      </PrivacyConsentProvider>
+    );
+  },
+};

--- a/packages/@smolitux/community/src/privacy/PrivacySettings.tsx
+++ b/packages/@smolitux/community/src/privacy/PrivacySettings.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Modal, Checkbox, Button } from '@smolitux/core';
+import { usePrivacyConsent } from './PrivacyContext';
+
+interface PrivacySettingsProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const PrivacySettings: React.FC<PrivacySettingsProps> = ({ open, onClose }) => {
+  const { preferences, updatePreferences } = usePrivacyConsent();
+
+  return (
+    <Modal open={open} onClose={onClose} title="Privacy Preferences">
+      <div className="space-y-4 p-4" data-testid="privacy-settings">
+        <Checkbox
+          label="Analytics cookies"
+          checked={preferences.analytics}
+          onChange={(e) => updatePreferences({ analytics: e.target.checked })}
+        />
+        <Checkbox
+          label="Personalized content"
+          checked={preferences.personalization}
+          onChange={(e) => updatePreferences({ personalization: e.target.checked })}
+        />
+        <Checkbox
+          label="Marketing emails"
+          checked={preferences.marketing}
+          onChange={(e) => updatePreferences({ marketing: e.target.checked })}
+        />
+        <div className="pt-2 text-right">
+          <Button onClick={onClose}>Close</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/packages/@smolitux/community/src/privacy/__tests__/PrivacyContext.test.tsx
+++ b/packages/@smolitux/community/src/privacy/__tests__/PrivacyContext.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { PrivacyConsentProvider, usePrivacyConsent } from '../PrivacyContext';
+
+describe('PrivacyConsentProvider', () => {
+  it('updates preferences', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <PrivacyConsentProvider>{children}</PrivacyConsentProvider>
+    );
+    const { result } = renderHook(() => usePrivacyConsent(), { wrapper });
+
+    act(() => {
+      result.current.updatePreferences({ analytics: true });
+    });
+
+    expect(result.current.preferences.analytics).toBe(true);
+  });
+});

--- a/packages/@smolitux/community/src/privacy/index.ts
+++ b/packages/@smolitux/community/src/privacy/index.ts
@@ -1,0 +1,2 @@
+export * from './PrivacyContext';
+export * from './PrivacySettings';


### PR DESCRIPTION
## Summary
- add PrivacyConsent context and settings modal
- integrate privacy controls into UserProfile, ActivityFeed, CommentSection, FollowButton and NotificationCenter
- document privacy update in status docs
- add tests for PrivacyConsentProvider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd547f5483248e79d4c685593058