### PR TITLE
Implement federation extensions

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -46,6 +46,7 @@
 10. Added guard utilities in @smolitux/utils.
 11. Added DonutChart tests in charts package
 12. Added global config utility for @smolitux/testing.
+13. Added ActivityPubViewer, IdentityBridge and FederationSettings components.
 
 ---
 *Updated by Codex AI*

--- a/docs/wiki/development/component-fixme.md
+++ b/docs/wiki/development/component-fixme.md
@@ -21,6 +21,20 @@ Diese Datei sammelt automatisch erkannte FIXMEs in den Komponenten.
 | Grid | Props nicht typisiert |
 | Navigation | – |
 
+## @smolitux/federation
+
+| Komponente | FIXMEs |
+|------------|-------|
+| ActivityStream | Props nicht typisiert |
+| CrossPlatformShare | Props nicht typisiert |
+| FederatedSearch | Props nicht typisiert |
+| FederationStatus | Props nicht typisiert |
+| PlatformSelector | Props nicht typisiert |
+| ProtocolHandler | Props nicht typisiert |
+| ActivityPubViewer | Props nicht typisiert |
+| IdentityBridge | Props nicht typisiert |
+| FederationSettings | Props nicht typisiert |
+
 
 ### Update 2025-06-09
 - Fixed ESLint config to enable linting.
@@ -39,3 +53,4 @@ Diese Datei sammelt automatisch erkannte FIXMEs in den Komponenten.
 - [@smolitux/theme] Remove legacy provider file
 ### Update 2025-06-16
 - No remaining FIXMEs for @smolitux/testing after adding config utility.
+- Added federation component FIXMEs for new components.

--- a/docs/wiki/development/component-status-federation.md
+++ b/docs/wiki/development/component-status-federation.md
@@ -12,6 +12,9 @@ This page tracks the progress and quality of the **federation** package. Compone
 | FederationStatus | ✅ | ❌ | ❌ | Needs A11y Tests |
 | PlatformSelector | ✅ | ❌ | ❌ | Needs A11y Tests |
 | ProtocolHandler | ✅ | ❌ | ❌ | Needs A11y Tests |
+| ActivityPubViewer | ✅ | ❌ | ❌ | Needs A11y Tests |
+| IdentityBridge | ✅ | ❌ | ❌ | Needs A11y Tests |
+| FederationSettings | ✅ | ❌ | ❌ | Needs A11y Tests |
 
 ## Next Steps
 

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -74,6 +74,10 @@ This document provides a comprehensive test status report for all components in 
 | @smolitux/federation | FederatedSearch | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
 | @smolitux/federation | FederationStatus | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
 | @smolitux/federation | PlatformSelector | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
+| @smolitux/federation | ProtocolHandler | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
+| @smolitux/federation | ActivityPubViewer | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
+| @smolitux/federation | IdentityBridge | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
+| @smolitux/federation | FederationSettings | ✅ | ❌ | ❌ | ❌ | Needs A11y Tests |
 | @smolitux/media | AudioPlayer | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/media | MediaCarousel | ✅ | ✅ | ❌ | ❌ | Ready |
 | @smolitux/media | ImageGallery | ✅ | ✅ | ❌ | ❌ | Ready |
@@ -121,7 +125,7 @@ This document provides a comprehensive test status report for all components in 
 - **@smolitux/ai**: 9 components need A11y tests
 - **@smolitux/blockchain**: All components complete with A11y tests
 - **@smolitux/community**: 5 components need A11y tests
-- **@smolitux/federation**: 5 components need A11y tests
+ - **@smolitux/federation**: 9 components need A11y tests
 - **@smolitux/media**: 6 components ready, 1 needs A11y tests
 - **@smolitux/resonance**: 17 components ready
 - **@smolitux/utils**: Ready
@@ -241,6 +245,10 @@ Dieser Bericht wird mit jeder Version aktualisiert, um den Fortschritt bei der T
 | @smolitux/federation | FederatedSearch | ⚠️ Teilweise |
 | @smolitux/federation | FederationStatus | ❌ Offen |
 | @smolitux/federation | PlatformSelector | ❌ Offen |
+| @smolitux/federation | ProtocolHandler | ❌ Offen |
+| @smolitux/federation | ActivityPubViewer | ❌ Offen |
+| @smolitux/federation | IdentityBridge | ❌ Offen |
+| @smolitux/federation | FederationSettings | ❌ Offen |
 | @smolitux/layout | Container | ✅ Fertig |
 | @smolitux/layout | DashboardLayout | ❌ Offen |
 | @smolitux/layout | Flex | ✅ Fertig |
@@ -328,3 +336,4 @@ See also [Resonance Component Status](./component-status-resonance.md) for packa
 - Added guard utilities to @smolitux/utils package.
 ### Update 2025-06-16
 - Added global config utility for testing package.
+- Added ActivityPubViewer, IdentityBridge and FederationSettings components in @smolitux/federation.

--- a/docs/wiki/development/component-todo.md
+++ b/docs/wiki/development/component-todo.md
@@ -109,22 +109,17 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 | voice            | a11y-Test fehlt                          |
 
 ## @smolitux/federation
-
-| Komponente         | TODOs                                     |
-| ------------------ | ----------------------------------------- |
-| ActivityStream     | Fehlende Tests, Kein Storybook vorhanden  |
-| CrossPlatformShare | Fehlende Tests, Kein Storybook vorhanden  |
-| FederatedSearch    | a11y-Test fehlt, Kein Storybook vorhanden |
-| FederationStatus   | Fehlende Tests, Kein Storybook vorhanden  |
-| PlatformSelector   | Fehlende Tests, Kein Storybook vorhanden  |
-
-## @smolitux/layout
-
-| Komponente      | TODOs                                    |
-| --------------- | ---------------------------------------- |
-| Container       | –                                        |
-| Flex | – |
-| Footer | Fehlende Tests, Kein Storybook vorhanden |
+| Komponente | TODOs |
+|------------|-------|
+| ActivityStream | Fehlende Tests, Kein Storybook vorhanden |
+| CrossPlatformShare | Fehlende Tests, Kein Storybook vorhanden |
+| FederatedSearch | a11y-Test fehlt, Kein Storybook vorhanden |
+| FederationStatus | Fehlende Tests, Kein Storybook vorhanden |
+| PlatformSelector | Fehlende Tests, Kein Storybook vorhanden |
+| ProtocolHandler | Fehlende Tests, Kein Storybook vorhanden |
+| ActivityPubViewer | Fehlende Tests, Kein Storybook vorhanden |
+| IdentityBridge | Fehlende Tests, Kein Storybook vorhanden |
+| FederationSettings | Fehlende Tests, Kein Storybook vorhanden |
 | Grid | – |
 | Header | Fehlende Tests, Kein Storybook vorhanden |
 | Sidebar | – |
@@ -245,12 +240,13 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 | ------------------ | --------------------- |
 | ActivityStream     | forwardRef hinzufügen |
 | CrossPlatformShare | forwardRef hinzufügen |
-| FederatedSearch    | forwardRef hinzufügen |
-| FederationStatus   | forwardRef hinzufügen |
-| PlatformSelector   | forwardRef hinzufügen |
-| ProtocolHandler    | forwardRef hinzufügen |
-
-## @smolitux/layout
+| FederatedSearch | forwardRef hinzufügen |
+| FederationStatus | forwardRef hinzufügen |
+| PlatformSelector | forwardRef hinzufügen |
+| ProtocolHandler | forwardRef hinzufügen |
+| ActivityPubViewer | forwardRef hinzufügen |
+| IdentityBridge | forwardRef hinzufügen |
+| FederationSettings | forwardRef hinzufügen |
 
 | Komponente      | TODOs                 |
 | --------------- | --------------------- |
@@ -309,3 +305,4 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 - [@smolitux/theme] Document tokens directory
 ### Update 2025-06-16
 - Added configuration utility to @smolitux/testing; no todos pending.
+- Added ActivityPubViewer, IdentityBridge and FederationSettings to TODO lists.

--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -46,3 +46,5 @@
 - Added global config utility for testing package.
 ### Update 2025-06-09
 - Added tests for Badge forwardRef implementation in core package.
+### Update 2025-06-09
+- Added test coverage entries for new federation components.

--- a/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.stories.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActivityPubViewer } from './ActivityPubViewer';
+
+const meta: Meta<typeof ActivityPubViewer> = {
+  title: 'Federation/ActivityPubViewer',
+  component: ActivityPubViewer,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    activity: {
+      type: 'Note',
+      id: '1',
+      actor: 'Alice',
+      content: 'Hello world',
+      published: new Date().toISOString(),
+    },
+  },
+};

--- a/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.test.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ActivityPubViewer } from './ActivityPubViewer';
+
+const activity = { type: 'Note', id: '1', actor: 'Alice', content: 'Hello world' };
+
+describe('ActivityPubViewer', () => {
+  it('renders activity content', () => {
+    render(<ActivityPubViewer activity={activity} />);
+    expect(screen.getByTestId('content')).toHaveTextContent('Hello world');
+  });
+
+  it('applies custom className', () => {
+    render(<ActivityPubViewer activity={activity} className="custom" />);
+    expect(screen.getByTestId('activitypub-viewer')).toHaveClass('custom');
+  });
+});

--- a/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Card } from '@smolitux/core';
+
+export interface ActivityPubViewerProps {
+  activity: {
+    '@context'?: string | string[];
+    type: string;
+    id: string;
+    actor: string;
+    object?: string | Record<string, unknown>;
+    content?: string;
+    published?: string;
+    to?: string[];
+    cc?: string[];
+  };
+  className?: string;
+}
+
+export const ActivityPubViewer: React.FC<ActivityPubViewerProps> = ({ activity, className }) => {
+  return (
+    <Card className={className} data-testid="activitypub-viewer">
+      <h3 className="font-semibold" data-testid="actor">
+        {activity.actor}
+      </h3>
+      {activity.content && <p data-testid="content">{activity.content}</p>}
+      {activity.published && (
+        <p className="text-sm text-gray-500" data-testid="published">
+          {new Date(activity.published).toLocaleString()}
+        </p>
+      )}
+    </Card>
+  );
+};
+
+export default ActivityPubViewer;

--- a/packages/@smolitux/federation/src/components/ActivityPubViewer/index.ts
+++ b/packages/@smolitux/federation/src/components/ActivityPubViewer/index.ts
@@ -1,0 +1,1 @@
+export * from './ActivityPubViewer';

--- a/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.stories.tsx
+++ b/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FederationSettings } from './FederationSettings';
+
+const meta: Meta<typeof FederationSettings> = {
+  title: 'Federation/FederationSettings',
+  component: FederationSettings,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    protocols: ['ActivityPub', 'ATProtocol', 'Matrix'],
+    enabled: ['ActivityPub'],
+    onToggle: () => {},
+  },
+};

--- a/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.test.tsx
+++ b/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FederationSettings } from './FederationSettings';
+
+const protocols = ['ActivityPub', 'ATProtocol', 'Matrix'];
+
+describe('FederationSettings', () => {
+  it('renders checkboxes', () => {
+    render(<FederationSettings protocols={protocols} enabled={[]} onToggle={jest.fn()} />);
+    expect(screen.getByLabelText('ActivityPub')).toBeInTheDocument();
+  });
+
+  it('calls onToggle when checkbox changed', () => {
+    const onToggle = jest.fn();
+    render(
+      <FederationSettings protocols={protocols} enabled={[]} onToggle={onToggle} />
+    );
+    fireEvent.click(screen.getByLabelText('Matrix'));
+    expect(onToggle).toHaveBeenCalledWith('Matrix', true);
+  });
+});

--- a/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.tsx
+++ b/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Card, Checkbox } from '@smolitux/core';
+
+export interface FederationSettingsProps {
+  protocols: string[];
+  enabled: string[];
+  onToggle: (name: string, enabled: boolean) => void;
+  className?: string;
+}
+
+export const FederationSettings: React.FC<FederationSettingsProps> = ({ protocols, enabled, onToggle, className }) => {
+  return (
+    <Card className={className} data-testid="federation-settings">
+      <h3 className="font-semibold mb-2">Protocols</h3>
+      <div className="space-y-2">
+        {protocols.map((p) => (
+          <div key={p} className="flex items-center gap-2">
+            <Checkbox
+              checked={enabled.includes(p)}
+              onChange={(e) => onToggle(p, e.target.checked)}
+              id={`protocol-${p}`}
+            />
+            <label htmlFor={`protocol-${p}`}>{p}</label>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+};
+
+export default FederationSettings;

--- a/packages/@smolitux/federation/src/components/FederationSettings/index.ts
+++ b/packages/@smolitux/federation/src/components/FederationSettings/index.ts
@@ -1,0 +1,1 @@
+export * from './FederationSettings';

--- a/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.stories.tsx
+++ b/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IdentityBridge } from './IdentityBridge';
+
+const meta: Meta<typeof IdentityBridge> = {
+  title: 'Federation/IdentityBridge',
+  component: IdentityBridge,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    identities: [
+      { platform: 'Mastodon', handle: '@alice@mastodon.social' },
+      { platform: 'Matrix', handle: '@alice:matrix.org' },
+    ],
+  },
+};

--- a/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.test.tsx
+++ b/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IdentityBridge } from './IdentityBridge';
+
+const identities = [
+  { platform: 'Mastodon', handle: '@alice@mastodon.social' },
+  { platform: 'Matrix', handle: '@alice:matrix.org' },
+];
+
+describe('IdentityBridge', () => {
+  it('renders list of identities', () => {
+    render(<IdentityBridge identities={identities} />);
+    expect(screen.getByText('Mastodon: @alice@mastodon.social')).toBeInTheDocument();
+  });
+
+  it('calls onUnlink when button clicked', () => {
+    const onUnlink = jest.fn();
+    render(<IdentityBridge identities={identities} onUnlink={onUnlink} />);
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(onUnlink).toHaveBeenCalledWith('Mastodon');
+  });
+});

--- a/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.tsx
+++ b/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Card, Button } from '@smolitux/core';
+
+export interface LinkedIdentity {
+  platform: string;
+  handle: string;
+}
+
+export interface IdentityBridgeProps {
+  identities: LinkedIdentity[];
+  onUnlink?: (platform: string) => void;
+  className?: string;
+}
+
+export const IdentityBridge: React.FC<IdentityBridgeProps> = ({ identities, onUnlink, className }) => {
+  return (
+    <Card className={className} data-testid="identity-bridge">
+      <h3 className="font-semibold mb-2">Linked Identities</h3>
+      <ul className="space-y-1">
+        {identities.map((id) => (
+          <li key={id.platform} className="flex items-center justify-between">
+            <span>{id.platform}: {id.handle}</span>
+            {onUnlink && (
+              <Button size="sm" onClick={() => onUnlink(id.platform)}>
+                Unlink
+              </Button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+export default IdentityBridge;

--- a/packages/@smolitux/federation/src/components/IdentityBridge/index.ts
+++ b/packages/@smolitux/federation/src/components/IdentityBridge/index.ts
@@ -1,0 +1,1 @@
+export * from './IdentityBridge';

--- a/packages/@smolitux/federation/src/index.ts
+++ b/packages/@smolitux/federation/src/index.ts
@@ -10,3 +10,6 @@ export { ActivityStream } from './components/ActivityStream';
 export { FederationStatus } from './components/FederationStatus';
 export { CrossPlatformShare } from './components/CrossPlatformShare';
 export { ProtocolHandler } from './components/ProtocolHandler';
+export { ActivityPubViewer } from './components/ActivityPubViewer';
+export { IdentityBridge } from './components/IdentityBridge';
+export { FederationSettings } from './components/FederationSettings';


### PR DESCRIPTION
## Summary
- add ActivityPubViewer, IdentityBridge and FederationSettings components
- document new federation components across wiki reports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd68d5548324848e287600f45543