### PR TITLE
Add tokens test and story

### DIFF
--- a/packages/@smolitux/theme/src/tokens/Tokens.stories.tsx
+++ b/packages/@smolitux/theme/src/tokens/Tokens.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { tokens } from './index';
+
+const meta: Meta = {
+  title: 'Theme/Tokens',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+      {Object.entries(tokens.colors.primary).map(([k, v]) => (
+        <div key={k} style={{ backgroundColor: v, width: 40, height: 40 }} title={k} />
+      ))}
+    </div>
+  ),
+};
+
+export const Spacing: Story = {
+  render: () => (
+    <ul style={{ listStyle: 'none', padding: 0 }}>
+      {Object.entries(tokens.spacing).map(([k, v]) => (
+        <li key={k} style={{ marginBottom: '0.25rem' }}>
+          {k}: {v}
+        </li>
+      ))}
+    </ul>
+  ),
+};
+
+export const Breakpoints: Story = {
+  render: () => (
+    <ul style={{ listStyle: 'none', padding: 0 }}>
+      {Object.entries(tokens.breakpoints).map(([k, v]) => (
+        <li key={k}>{k}: {v}px</li>
+      ))}
+    </ul>
+  ),
+};
+
+export const Typography: Story = {
+  render: () => (
+    <ul style={{ listStyle: 'none', padding: 0 }}>
+      {Object.entries(tokens.typography.fontWeight).map(([k, v]) => (
+        <li key={k}>{k}: {v}</li>
+      ))}
+    </ul>
+  ),
+};

--- a/packages/@smolitux/theme/src/tokens/index.test.ts
+++ b/packages/@smolitux/theme/src/tokens/index.test.ts
@@ -1,0 +1,22 @@
+import { tokens } from './index';
+
+describe('tokens', () => {
+  it('contains expected color palette', () => {
+    expect(tokens.colors).toHaveProperty('primary');
+    expect(tokens.colors.primary[500]).toBe('#0075E1');
+  });
+
+  it('contains spacing scale', () => {
+    expect(tokens.spacing).toHaveProperty('4');
+    expect(tokens.spacing[4]).toBe('1rem');
+  });
+
+  it('contains breakpoints', () => {
+    expect(tokens.breakpoints.md).toBe(768);
+  });
+
+  it('contains typography settings', () => {
+    expect(tokens.typography.fontFamily.sans).toContain('Inter');
+    expect(tokens.typography.fontWeight.bold).toBe(700);
+  });
+});


### PR DESCRIPTION
## Summary
- add `Tokens.stories.tsx` for documenting theme tokens
- add unit test for tokens index

## Testing
- `npm test --workspace=@smolitux/theme -- --testPathPattern=tokens/index.test.ts` *(fails: jest not found)*
- `npm run lint --workspace=@smolitux/theme` *(fails: cannot find module '../lib/cli')*
- `npm run build --workspace=@smolitux/theme` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ee6e3dd88324a152b27739b5289d