### PR TITLE
Add analysis scripts and report

### DIFF
--- a/COMPREHENSIVE_ANALYSIS_REPORT.md
+++ b/COMPREHENSIVE_ANALYSIS_REPORT.md
@@ -1,0 +1,5 @@
+# Smolitux UI Comprehensive Analysis Report
+Generated: Mon Jun  9 19:29:01 UTC 2025
+- GitHub open issues: 11
+- Local issues: 0
+- Direct scan issues: 102

--- a/NEXT_STEPS.txt
+++ b/NEXT_STEPS.txt
@@ -1,0 +1,1 @@
+Next steps: fix GitHub labels

--- a/create_issues.sh
+++ b/create_issues.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+create_analyzer_issues() {
+    echo "🚀 Creating GitHub issues for validation problems..."
+    
+    TOTAL_CREATED=0
+    
+    for status_file in status/*.log; do
+        [ ! -f "$status_file" ] && continue
+        
+        PACKAGE=$(basename "$status_file" .log)
+        echo "📦 Processing @smolitux/$PACKAGE..."
+        
+        while IFS=':' read -r type file line message; do
+            [ -z "$type" ] && continue
+            [[ "$type" =~ ^# ]] && continue
+            
+            TITLE="[$type] $PACKAGE: $(echo "$message" | cut -c1-40)..."
+            LABELS="bug,$type,package:$PACKAGE"
+            
+            if [ "$type" = "ERROR" ]; then
+                LABELS="$LABELS,priority:high"
+            fi
+            
+            BODY="**Problem:** $message
+**File:** $file:$line  
+**Package:** @smolitux/$PACKAGE
+**Type:** $type
+
+**Reproduction:**
+\`\`\`bash
+cd packages/@smolitux/$PACKAGE
+grep -n \"$(echo "$message" | cut -d: -f1)\" $file
+\`\`\`"
+
+            echo "Creating issue: $TITLE"
+            gh issue create \
+                --title "$TITLE" \
+                --label "$LABELS" \
+                --body "$BODY" && TOTAL_CREATED=$((TOTAL_CREATED + 1))
+                
+        done < "$status_file"
+    done
+    
+    echo "✅ Created $TOTAL_CREATED GitHub issues!"
+}
+
+# Export function
+export -f create_analyzer_issues


### PR DESCRIPTION
## Summary
- add helper script `create_issues.sh` for creating GitHub issues from logs
- generate `COMPREHENSIVE_ANALYSIS_REPORT.md`
- add `NEXT_STEPS.txt` with follow-up actions

## Testing
- `gh issue list --state open`


------
https://chatgpt.com/codex/tasks/task_e_6847343a26ac8324aca53be814817164