### PR TITLE
Fix Heatmap theme typing

### DIFF
--- a/packages/@smolitux/charts/src/components/Heatmap/Heatmap.tsx
+++ b/packages/@smolitux/charts/src/components/Heatmap/Heatmap.tsx
@@ -76,12 +76,7 @@ export interface HeatmapProps extends Omit<React.SVGProps<SVGSVGElement>, 'data'
   onCellClick?: (cell: HeatmapDataPoint) => void;
 }
 
-// Import the correct type from theme package if available
-// If not available, we can use a more flexible approach
-interface ThemeContext {
-  themeMode?: 'light' | 'dark';
-  [key: string]: unknown; // Allow any other properties
-}
+
 
 /**
  * Heatmap-Komponente für zweidimensionale Datenvisualisierung
@@ -136,10 +131,7 @@ export const Heatmap = forwardRef<SVGSVGElement, HeatmapProps>(
     },
     ref
   ) => {
-    // Access the theme object without strict typing
-    const theme = useTheme();
-    // Safely access themeMode with a fallback
-    const themeMode = (theme as any)?.themeMode || 'light';
+    const { mode: themeMode } = useTheme();
 
     // Hover state for tooltips
     const [hoveredCell, setHoveredCell] = useState<HeatmapDataPoint | null>(null);


### PR DESCRIPTION
## Summary
- remove unused ThemeContext type
- use `useTheme` hook directly instead of casting to `any`

## Testing
- `npm run lint --workspace=@smolitux/charts` *(fails: "parserOptions.project" errors)*
- `npm test --workspace=@smolitux/charts -- Heatmap` *(fails: Jest configuration directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_684739e1c3a483248b103360c7c57a98