### PR TITLE
chore: standardize todo comments

### DIFF
--- a/docs/wiki/development/comment-todo-log.md
+++ b/docs/wiki/development/comment-todo-log.md
@@ -1,0 +1,130 @@
+# 🧾 Kommentar-Backlog: Aufgaben aus `@smolitux/*` Quellcode
+
+## Paket: @ai
+- [ ] `src/components/EngagementScore/EngagementScore.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/ContentAnalytics/ContentAnalytics.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/SentimentDisplay/SentimentDisplay.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/RecommendationCarousel/RecommendationCarousel.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/FakeNewsDetector/FakeNewsDetector.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/TrollFilter/TrollFilter.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/ContentModerator/ContentModerator.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/TrendingTopics/TrendingTopics.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+
+## Paket: @blockchain
+- [ ] `src/components/TransactionHistory/TransactionHistory.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/TransactionHistory/TransactionHistory.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/TokenDistributionChart/TokenDistributionChart.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/TokenDistributionChart/TokenDistributionChart.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/NFTGallery/NFTGallery.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/NFTGallery/NFTGallery.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/StakingInterface/StakingInterface.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/StakingInterface/StakingInterface.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/WalletConnect/WalletConnect.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/WalletConnect/WalletConnect.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/TokenEconomy/TokenEconomy.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/TokenEconomy/TokenEconomy.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/SmartContractInteraction/SmartContractInteraction.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/SmartContractInteraction/SmartContractInteraction.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/TokenDisplay/TokenDisplay.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/TokenDisplay/TokenDisplay.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+
+## Paket: @charts
+- [ ] `src/components/Histogram/Histogram.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/ChartAxis/ChartAxis.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+- [ ] `src/components/ChartLegend/ChartLegend.tsx`: 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+
+## Paket: @community
+- [ ] `src/components/CommentSection/CommentSection.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/FollowButton/FollowButton.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/NotificationCenter/NotificationCenter.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/ActivityFeed/ActivityFeed.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/UserProfile/UserProfile.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+
+## Paket: @core
+- [ ] `src/components/ColorPicker/ColorPicker.original.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Tooltip/Tooltip.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Toast/ToastProvider.original.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Toast/ToastProvider.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/LanguageSwitcher/LanguageSwitcher.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/LanguageSwitcher/LanguageSwitcher.original.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Select/Option.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Textarea/Textarea.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Menu/MenuItem.tsx`: 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
+- [ ] `src/components/Menu/MenuItem.original.tsx`: 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
+- [ ] `src/components/Menu/MenuDropdown.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Stepper/Stepper.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Collapse/Collapse.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Form/Form.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Dialog/Dialog.original.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Dialog/Dialog.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Alert/Alert.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/TabView/TabView.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/TabView/TabView.fixed.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Slide/Slide.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/voice/VoiceSelect.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/voice/VoiceModal.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/voice/VoiceButton.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/voice/VoiceCard.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/voice/VoiceInput.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/RadioGroup/RadioGroup.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/FormField/FormField.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Drawer/Drawer.original.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Drawer/Drawer.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Tabs/Tabs.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Avatar/Avatar.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Modal/Modal.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Dropdown/DropdownItem.tsx`: 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
+- [ ] `src/components/Accordion/Accordion.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Accordion/AccordionItem.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Popover/Popover.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Popover/Popover.original.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/__tests__/integration/Theme.test.tsx`:     // 🔍 NOTE [Codex]: In a real test, we would need to check the computed style – prüfen
+- [ ] `src/components/Table/Table.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+
+## Paket: @federation
+- [ ] `src/components/FederatedSearch/FederatedSearch.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/FederationStatus/FederationStatus.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/PlatformSelector/PlatformSelector.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/ProtocolHandler/ProtocolHandler.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/ActivityStream/ActivityStream.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/CrossPlatformShare/CrossPlatformShare.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+
+## Paket: @layout
+- [ ] `src/components/DashboardLayout/DashboardLayout.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/Grid/Grid.tsx`: 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
+
+## Paket: @media
+- [ ] `src/components/VideoPlayer/VideoPlayer.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/ImageGallery/ImageGallery.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/MediaGrid/MediaGrid.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/MediaUploader/MediaUploader.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/MediaCarousel/MediaCarousel.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/AudioPlayer/AudioPlayer.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+
+## Paket: @resonance
+- [ ] `src/components/monetization/RevenueModel.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/monetization/RewardSystem.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/monetization/CreatorDashboard.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/platform/PlatformIntegration.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/platform/PlatformNotice.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/feed/FeedItem.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/feed/FeedView.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/feed/FeedSidebar.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/feed/FeedFilter.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/post/PostView.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/post/PostInteractions.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/post/PostMetrics.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/post/PostCreator.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/governance/VotingSystem.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/governance/ProposalView.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/governance/GovernanceDashboard.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/profile/ProfileHeader.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/profile/ProfileEditor.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/profile/ProfileContent.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/profile/__tests__/ProfileContent.test.tsx`:     // 🔍 NOTE [Codex]: The exact format might depend on the date formatting library used – prüfen
+- [ ] `src/components/profile/ProfileWallet.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+
+## Paket: @utils
+- [ ] `src/components/patterns/Tooltip.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/patterns/Button.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [ ] `src/components/patterns/TabView.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen

--- a/packages/@smolitux/ai/src/components/ContentAnalytics/ContentAnalytics.tsx
+++ b/packages/@smolitux/ai/src/components/ContentAnalytics/ContentAnalytics.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 

--- a/packages/@smolitux/ai/src/components/ContentModerator/ContentModerator.tsx
+++ b/packages/@smolitux/ai/src/components/ContentModerator/ContentModerator.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/ai/src/components/EngagementScore/EngagementScore.tsx
+++ b/packages/@smolitux/ai/src/components/EngagementScore/EngagementScore.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, ProgressBar, Tooltip } from '@smolitux/core';
 

--- a/packages/@smolitux/ai/src/components/FakeNewsDetector/FakeNewsDetector.tsx
+++ b/packages/@smolitux/ai/src/components/FakeNewsDetector/FakeNewsDetector.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, Tooltip, ProgressBar } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/ai/src/components/RecommendationCarousel/RecommendationCarousel.tsx
+++ b/packages/@smolitux/ai/src/components/RecommendationCarousel/RecommendationCarousel.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 
 export interface RecommendationItem {

--- a/packages/@smolitux/ai/src/components/SentimentDisplay/SentimentDisplay.tsx
+++ b/packages/@smolitux/ai/src/components/SentimentDisplay/SentimentDisplay.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { useResponseCache } from '../../utils/useResponseCache';
 import { Card, Button, ProgressBar } from '@smolitux/core';

--- a/packages/@smolitux/ai/src/components/TrendingTopics/TrendingTopics.tsx
+++ b/packages/@smolitux/ai/src/components/TrendingTopics/TrendingTopics.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 

--- a/packages/@smolitux/ai/src/components/TrollFilter/TrollFilter.tsx
+++ b/packages/@smolitux/ai/src/components/TrollFilter/TrollFilter.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button, ProgressBar } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.tsx
+++ b/packages/@smolitux/blockchain/src/components/NFTGallery/NFTGallery.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card } from '@smolitux/core';
 

--- a/packages/@smolitux/blockchain/src/components/SmartContractInteraction/SmartContractInteraction.tsx
+++ b/packages/@smolitux/blockchain/src/components/SmartContractInteraction/SmartContractInteraction.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/blockchain/src/components/StakingInterface/StakingInterface.tsx
+++ b/packages/@smolitux/blockchain/src/components/StakingInterface/StakingInterface.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, Input, ProgressBar } from '@smolitux/core';
 

--- a/packages/@smolitux/blockchain/src/components/TokenDisplay/TokenDisplay.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenDisplay/TokenDisplay.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card } from '@smolitux/core';
 import { TokenInfo } from '../types';

--- a/packages/@smolitux/blockchain/src/components/TokenDistributionChart/TokenDistributionChart.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenDistributionChart/TokenDistributionChart.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 import { Card } from '@smolitux/core';
 

--- a/packages/@smolitux/blockchain/src/components/TokenEconomy/TokenEconomy.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenEconomy/TokenEconomy.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/blockchain/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/@smolitux/blockchain/src/components/TransactionHistory/TransactionHistory.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 import { TransactionType, Transaction } from '../types';

--- a/packages/@smolitux/blockchain/src/components/WalletConnect/WalletConnect.tsx
+++ b/packages/@smolitux/blockchain/src/components/WalletConnect/WalletConnect.tsx
@@ -1,5 +1,5 @@
-// TODO: Tests fehlen
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Button, Card } from '@smolitux/core';
 import { EthereumProvider } from '../types';

--- a/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/@smolitux/charts/src/components/ChartAxis/ChartAxis.tsx
@@ -1,4 +1,4 @@
-// TODO: Tests fehlen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
 import React, { forwardRef } from 'react';
 
 export interface ChartAxisTick {

--- a/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/@smolitux/charts/src/components/ChartLegend/ChartLegend.tsx
@@ -1,4 +1,4 @@
-// TODO: Tests fehlen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
 import React, { forwardRef } from 'react';
 
 export interface LegendItem {

--- a/packages/@smolitux/charts/src/components/Histogram/Histogram.tsx
+++ b/packages/@smolitux/charts/src/components/Histogram/Histogram.tsx
@@ -1,4 +1,4 @@
-// TODO: Tests fehlen
+// 🔧 TODO [Codex]: Tests fehlen – prüfen & umsetzen
 import React, { forwardRef, useMemo } from 'react';
 import BarChart, { type BarChartProps, type BarChartSeries } from '../BarChart/BarChart';
 

--- a/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/packages/@smolitux/community/src/components/ActivityFeed/ActivityFeed.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 import { usePrivacyConsent } from '../../privacy';

--- a/packages/@smolitux/community/src/components/CommentSection/CommentSection.tsx
+++ b/packages/@smolitux/community/src/components/CommentSection/CommentSection.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, ChangeEvent } from 'react';
 import { Button, Input } from '@smolitux/core';
 import { usePrivacyConsent, PrivacySettings } from '../../privacy';

--- a/packages/@smolitux/community/src/components/FollowButton/FollowButton.tsx
+++ b/packages/@smolitux/community/src/components/FollowButton/FollowButton.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Button } from '@smolitux/core';
 import { usePrivacyConsent, PrivacySettings } from '../../privacy';

--- a/packages/@smolitux/community/src/components/NotificationCenter/NotificationCenter.tsx
+++ b/packages/@smolitux/community/src/components/NotificationCenter/NotificationCenter.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@smolitux/core';
 import { usePrivacyConsent, PrivacySettings } from '../../privacy';

--- a/packages/@smolitux/community/src/components/UserProfile/UserProfile.tsx
+++ b/packages/@smolitux/community/src/components/UserProfile/UserProfile.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 import { usePrivacyConsent, PrivacySettings } from '../../privacy';

--- a/packages/@smolitux/core/src/components/Accordion/Accordion.tsx
+++ b/packages/@smolitux/core/src/components/Accordion/Accordion.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Accordion/Accordion.tsx
 import React, { useState, createContext, useContext } from 'react';
 

--- a/packages/@smolitux/core/src/components/Accordion/AccordionItem.tsx
+++ b/packages/@smolitux/core/src/components/Accordion/AccordionItem.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Accordion/AccordionItem.tsx
 import React, { useRef, useState, useEffect } from 'react';
 import { useAccordionContext } from './Accordion';

--- a/packages/@smolitux/core/src/components/Alert/Alert.tsx
+++ b/packages/@smolitux/core/src/components/Alert/Alert.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useRef, useEffect, useState } from 'react';
 import './animations.css';
 

--- a/packages/@smolitux/core/src/components/Avatar/Avatar.tsx
+++ b/packages/@smolitux/core/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Avatar/Avatar.tsx
 import React, { useState } from 'react';
 

--- a/packages/@smolitux/core/src/components/Collapse/Collapse.tsx
+++ b/packages/@smolitux/core/src/components/Collapse/Collapse.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useRef, useEffect, useState } from 'react';
 import { useTransition } from '../../animations/useTransition';
 import { TransitionPresetName, TransitionPreset } from '../../animations/transitions';

--- a/packages/@smolitux/core/src/components/ColorPicker/ColorPicker.original.tsx
+++ b/packages/@smolitux/core/src/components/ColorPicker/ColorPicker.original.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 
 export interface ColorPickerProps {

--- a/packages/@smolitux/core/src/components/Dialog/Dialog.original.tsx
+++ b/packages/@smolitux/core/src/components/Dialog/Dialog.original.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Dialog/Dialog.tsx
 import React, { useEffect, useRef } from 'react';
 import { Button } from '../Button/Button';

--- a/packages/@smolitux/core/src/components/Dialog/Dialog.tsx
+++ b/packages/@smolitux/core/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Dialog/Dialog.improved.tsx
 import React, { useEffect, useRef, useCallback } from 'react';
 

--- a/packages/@smolitux/core/src/components/Drawer/Drawer.original.tsx
+++ b/packages/@smolitux/core/src/components/Drawer/Drawer.original.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Drawer/Drawer.tsx
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 

--- a/packages/@smolitux/core/src/components/Drawer/Drawer.tsx
+++ b/packages/@smolitux/core/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Drawer/Drawer.improved.tsx
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 

--- a/packages/@smolitux/core/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/@smolitux/core/src/components/Dropdown/DropdownItem.tsx
@@ -1,4 +1,4 @@
-// FIXME: Props nicht typisiert
+// 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
 // packages/@smolitux/core/src/components/Dropdown/DropdownItem.tsx
 import React, { useRef, useEffect } from 'react';
 import { useDropdownContext } from './Dropdown';

--- a/packages/@smolitux/core/src/components/Form/Form.tsx
+++ b/packages/@smolitux/core/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Form as ValidationForm, FormProps as ValidationFormProps } from '../../validation/Form';
 

--- a/packages/@smolitux/core/src/components/FormField/FormField.tsx
+++ b/packages/@smolitux/core/src/components/FormField/FormField.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import {
   FormField as ValidationFormField,

--- a/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.original.tsx
+++ b/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.original.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { useI18n } from '../../i18n/I18nProvider';
 import { LOCALE_NAMES, LOCALE_CODES, LOCALE_DIRECTIONS } from '../../i18n/constants';

--- a/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/LanguageSwitcher/LanguageSwitcher.improved.tsx
 import React, { useState, useEffect } from 'react';
 

--- a/packages/@smolitux/core/src/components/Menu/MenuDropdown.tsx
+++ b/packages/@smolitux/core/src/components/Menu/MenuDropdown.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Menu/MenuDropdown.tsx
 import React, { useState, useRef, useEffect } from 'react';
 import ReactDOM from 'react-dom';

--- a/packages/@smolitux/core/src/components/Menu/MenuItem.original.tsx
+++ b/packages/@smolitux/core/src/components/Menu/MenuItem.original.tsx
@@ -1,4 +1,4 @@
-// FIXME: Props nicht typisiert
+// 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
 // packages/@smolitux/core/src/components/Menu/MenuItem.tsx
 import React, { useState, useEffect } from 'react';
 import { useMenuContext } from './Menu';

--- a/packages/@smolitux/core/src/components/Menu/MenuItem.tsx
+++ b/packages/@smolitux/core/src/components/Menu/MenuItem.tsx
@@ -1,4 +1,4 @@
-// FIXME: Props nicht typisiert
+// 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
 // packages/@smolitux/core/src/components/Menu/MenuItem.improved.tsx
 import React, { useState, useEffect, useRef, useId } from 'react';
 import { useMenuContext } from './Menu';

--- a/packages/@smolitux/core/src/components/Modal/Modal.tsx
+++ b/packages/@smolitux/core/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 import './animations.css';

--- a/packages/@smolitux/core/src/components/Popover/Popover.original.tsx
+++ b/packages/@smolitux/core/src/components/Popover/Popover.original.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Popover/Popover.tsx
 import React, { useState, useRef, useEffect } from 'react';
 

--- a/packages/@smolitux/core/src/components/Popover/Popover.tsx
+++ b/packages/@smolitux/core/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Popover/Popover.improved.tsx
 import React, { useState, useRef, useEffect, useId } from 'react';
 

--- a/packages/@smolitux/core/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/@smolitux/core/src/components/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { createContext } from 'react';
 import Radio from '../Radio/Radio';
 

--- a/packages/@smolitux/core/src/components/Select/Option.tsx
+++ b/packages/@smolitux/core/src/components/Select/Option.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 
 export interface OptionProps extends React.OptionHTMLAttributes<HTMLOptionElement> {

--- a/packages/@smolitux/core/src/components/Slide/Slide.tsx
+++ b/packages/@smolitux/core/src/components/Slide/Slide.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useRef } from 'react';
 import { useTransition } from '../../animations/useTransition';
 import { TransitionPresetName, TransitionPreset } from '../../animations/transitions';

--- a/packages/@smolitux/core/src/components/Stepper/Stepper.tsx
+++ b/packages/@smolitux/core/src/components/Stepper/Stepper.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Stepper/Stepper.tsx
 import React, { createContext, useContext, useMemo } from 'react';
 import './Stepper.css';

--- a/packages/@smolitux/core/src/components/TabView/TabView.fixed.tsx
+++ b/packages/@smolitux/core/src/components/TabView/TabView.fixed.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 
 export interface TabItem {

--- a/packages/@smolitux/core/src/components/TabView/TabView.tsx
+++ b/packages/@smolitux/core/src/components/TabView/TabView.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef, createContext, useContext } from 'react';
 import './TabView.css';
 

--- a/packages/@smolitux/core/src/components/Table/Table.tsx
+++ b/packages/@smolitux/core/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useMemo } from 'react';
 
 export type SortDirection = 'asc' | 'desc' | null;

--- a/packages/@smolitux/core/src/components/Tabs/Tabs.tsx
+++ b/packages/@smolitux/core/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Tabs/Tabs.tsx
 import React, { useState, useEffect, useRef, createContext, useContext, useMemo } from 'react';
 import './Tabs.css';

--- a/packages/@smolitux/core/src/components/Textarea/Textarea.tsx
+++ b/packages/@smolitux/core/src/components/Textarea/Textarea.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Textarea/Textarea.tsx
 // Diese Datei dient als Kompatibilitätsschicht für die TextArea-Komponente
 // und leitet alle Aufrufe an die TextArea-Komponente weiter.

--- a/packages/@smolitux/core/src/components/Toast/ToastProvider.original.tsx
+++ b/packages/@smolitux/core/src/components/Toast/ToastProvider.original.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Toast/ToastProvider.tsx
 import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
 import { Toast, ToastProps, ToastType } from './Toast';

--- a/packages/@smolitux/core/src/components/Toast/ToastProvider.tsx
+++ b/packages/@smolitux/core/src/components/Toast/ToastProvider.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/core/src/components/Toast/ToastProvider.improved.tsx
 import React, { createContext, useContext, useState, useCallback, ReactNode, useId } from 'react';
 import { Toast, ToastProps, ToastType } from './Toast';

--- a/packages/@smolitux/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/@smolitux/core/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useRef, useEffect } from 'react';
 import './Tooltip.css';
 

--- a/packages/@smolitux/core/src/components/voice/VoiceButton.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceButton.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Button, ButtonProps } from '../Button';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceCard.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceCard.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, CardProps } from '../Card';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceInput.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceInput.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Input, InputProps } from '../Input';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceModal.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceModal.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Modal, ModalProps } from '../Modal';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/core/src/components/voice/VoiceSelect.tsx
+++ b/packages/@smolitux/core/src/components/voice/VoiceSelect.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Select, SelectProps } from '../Select';
 import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';

--- a/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 import { Card, Button, Input } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/CrossPlatformShare/CrossPlatformShare.tsx
+++ b/packages/@smolitux/federation/src/components/CrossPlatformShare/CrossPlatformShare.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Checkbox, Tooltip, Alert } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
+++ b/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 import { Input, Button, Card } from '@smolitux/core';
 import { SearchResult, FederatedSearchProps } from '../../types';

--- a/packages/@smolitux/federation/src/components/FederationStatus/FederationStatus.tsx
+++ b/packages/@smolitux/federation/src/components/FederationStatus/FederationStatus.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, ProgressBar } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/PlatformSelector/PlatformSelector.tsx
+++ b/packages/@smolitux/federation/src/components/PlatformSelector/PlatformSelector.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Input } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';

--- a/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
+++ b/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useEffect, useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 import {

--- a/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
+++ b/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
 import React, { useState, useEffect } from 'react';
 import Header, { HeaderProps } from '../Header/Header';

--- a/packages/@smolitux/layout/src/components/Grid/Grid.tsx
+++ b/packages/@smolitux/layout/src/components/Grid/Grid.tsx
@@ -1,4 +1,4 @@
-// FIXME: Props nicht typisiert
+// 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
 import React, { forwardRef } from 'react';
 import type {
   GridBreakpoint,

--- a/packages/@smolitux/media/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/packages/@smolitux/media/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useRef, useEffect } from 'react';
 import type { MediaSrc } from '../../types';
 

--- a/packages/@smolitux/media/src/components/ImageGallery/ImageGallery.tsx
+++ b/packages/@smolitux/media/src/components/ImageGallery/ImageGallery.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { GalleryConfig } from '../../types';
 

--- a/packages/@smolitux/media/src/components/MediaCarousel/MediaCarousel.tsx
+++ b/packages/@smolitux/media/src/components/MediaCarousel/MediaCarousel.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 import { Card, Button } from '@smolitux/core';
 

--- a/packages/@smolitux/media/src/components/MediaGrid/MediaGrid.tsx
+++ b/packages/@smolitux/media/src/components/MediaGrid/MediaGrid.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Card } from '@smolitux/core';
 

--- a/packages/@smolitux/media/src/components/MediaUploader/MediaUploader.tsx
+++ b/packages/@smolitux/media/src/components/MediaUploader/MediaUploader.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useRef, useCallback } from 'react';
 import { Button } from '@smolitux/core';
 import { ProgressBar } from '@smolitux/core';

--- a/packages/@smolitux/media/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/@smolitux/media/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useRef, useEffect } from 'react';
 import type { MediaSrc } from '../../types';
 

--- a/packages/@smolitux/resonance/src/components/feed/FeedFilter.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedFilter.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Flex } from '../primitives';
 import { TabView } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/feed/FeedSidebar.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedSidebar.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Card, Button } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/feed/FeedView.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedView.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useEffect, useRef, useState } from 'react';
 import { Box, Flex } from '../primitives';
 import { Button } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/governance/GovernanceDashboard.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/GovernanceDashboard.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/governance/ProposalView.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/ProposalView.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/governance/VotingSystem.tsx
+++ b/packages/@smolitux/resonance/src/components/governance/VotingSystem.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, ProgressBar } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/monetization/CreatorDashboard.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/CreatorDashboard.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/monetization/RevenueModel.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/RevenueModel.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/monetization/RewardSystem.tsx
+++ b/packages/@smolitux/resonance/src/components/monetization/RewardSystem.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/platform/PlatformIntegration.tsx
+++ b/packages/@smolitux/resonance/src/components/platform/PlatformIntegration.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/platform/PlatformNotice.tsx
+++ b/packages/@smolitux/resonance/src/components/platform/PlatformNotice.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Box, Text } from '../primitives';
 import { PlatformInfo } from '../../platform/types';

--- a/packages/@smolitux/resonance/src/components/post/PostCreator.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostCreator.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useRef } from 'react';
 import { Card, Button, TabView } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/post/PostInteractions.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostInteractions.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Button, Tooltip } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/post/PostMetrics.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostMetrics.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/post/PostView.tsx
+++ b/packages/@smolitux/resonance/src/components/post/PostView.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card, Button } from '@smolitux/core';
 import { Box, Flex, Text } from '../primitives';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileContent.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileContent.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Card, TabView } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileEditor.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileEditor.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Box, Flex } from '../primitives';
 import { Button, Input, TextArea } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileHeader.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileHeader.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Button } from '@smolitux/core';

--- a/packages/@smolitux/resonance/src/components/profile/ProfileWallet.tsx
+++ b/packages/@smolitux/resonance/src/components/profile/ProfileWallet.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Box, Flex, Text } from '../primitives';
 import { Card, Button } from '@smolitux/core';

--- a/packages/@smolitux/utils/src/components/patterns/Button.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/Button.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 
 export interface ButtonProps {

--- a/packages/@smolitux/utils/src/components/patterns/TabView.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/TabView.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Box } from '../primitives/Box';
 import { Flex } from '../primitives/Flex';

--- a/packages/@smolitux/utils/src/components/patterns/Tooltip.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/Tooltip.tsx
@@ -1,4 +1,4 @@
-// TODO: forwardRef hinzufügen
+// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useRef, useEffect } from 'react';
 import { Box } from '../primitives/Box';
 


### PR DESCRIPTION
## Summary
- standardize TODO and FIXME comments across all packages
- add comment backlog `comment-todo-log.md` summarizing all tasks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_684746309250832482d53cb4c05c09bd