### PR TITLE
Fix any casts in animations

### DIFF
--- a/packages/@smolitux/core/src/animations/Motion.tsx
+++ b/packages/@smolitux/core/src/animations/Motion.tsx
@@ -158,14 +158,14 @@ export const Motion = forwardRef<HTMLElement, MotionProps>(
       animationRef.current = ref.current.animate(keyframeValue as Keyframe[], {
         duration: transitionPreset.duration,
         easing: transitionPreset.easing,
-        delay: (transitionPreset as any).delay || 0,
+        delay: (transitionPreset as TransitionPreset).delay || 0,
         iterations: repeat === 'infinite' ? Infinity : repeat,
         fill: 'both',
       });
 
       // Event-Listener für Animation
       if (onAnimationStart) {
-        (animationRef.current as any).onstart = onAnimationStart;
+        (animationRef.current as unknown as { onstart?: () => void }).onstart = onAnimationStart;
       }
 
       if (onAnimationComplete) {
@@ -223,7 +223,7 @@ export const Motion = forwardRef<HTMLElement, MotionProps>(
       }
 
       // Transition hinzufügen
-      const delay = (transitionPreset as any).delay || 0;
+      const delay = (transitionPreset as TransitionPreset).delay || 0;
       const transitionValue = `all ${transitionPreset.duration}ms ${transitionPreset.easing}${
         delay > 0 ? ` ${delay}ms` : ''
       }`;

--- a/packages/@smolitux/core/src/animations/useAnimation.ts
+++ b/packages/@smolitux/core/src/animations/useAnimation.ts
@@ -51,7 +51,7 @@ export const useAnimation = (
     return {
       duration: options.duration || transitionPreset.duration,
       easing: options.easing || transitionPreset.easing,
-      delay: options.delay || (transitionPreset as any).delay || 0,
+      delay: options.delay || (transitionPreset as TransitionPreset).delay || 0,
       iterations: options.iterationCount || 1,
       direction: options.direction || 'normal',
       fill: options.fillMode || 'both',


### PR DESCRIPTION
## Summary
- remove `any` usage in animation utilities

## Testing
- `npx tsc --noEmit -p tsconfig.json` *(fails: Cannot find package '@eslint/js')*
- `npm run lint --workspaces` *(fails: Cannot find package '@eslint/js')*
- `npm test --workspaces` *(fails: jest not found)*
- `npm run build --workspaces` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474616f5b08324819e7de0b1605aad