### PR TITLE
Add Codex lint fix engine scripts

### DIFF
--- a/scripts/codex-lint-fix-engine.sh
+++ b/scripts/codex-lint-fix-engine.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Codex Lint Fix Engine
+# This script automates a multi-phase approach to resolve lint errors.
+# Phase 0 - Analysis
+# Phase 1 - Auto-fix
+# Phase 2 - Manual fix guidance
+# Phase 3 - Final validation
+
+set -e
+
+PHASE0_LOG="lint_analysis/ANALYSIS_SUMMARY.md"
+PHASE1_LOG="auto_fix_progress/AUTO_FIX_REPORT.md"
+PHASE2_LOG="manual_fix_progress/MANUAL_FIX_SESSION_REPORT.md"
+PHASE3_LOG="final_validation/CODEX_LINT_FIX_FINAL_REPORT.md"
+
+mkdir -p lint_analysis auto_fix_progress manual_fix_progress final_validation backups
+
+bash scripts/smolitux-analyzer.sh
+
+# Phase 0: Lint analysis
+bash -c "${BASH_SOURCE[0]%/*}/codex-lint-phase0.sh"
+
+# Phase 1: Auto-fix engine
+bash -c "${BASH_SOURCE[0]%/*}/codex-lint-phase1.sh"
+
+# Phase 2: Manual fix guidance
+bash -c "${BASH_SOURCE[0]%/*}/codex-lint-phase2.sh"
+
+# Phase 3: Final validation
+bash -c "${BASH_SOURCE[0]%/*}/codex-lint-phase3.sh"
+
+echo "\nReports generated:"
+echo "- $PHASE0_LOG"
+echo "- $PHASE1_LOG"
+echo "- $PHASE2_LOG"
+echo "- $PHASE3_LOG"

--- a/scripts/codex-lint-phase0.sh
+++ b/scripts/codex-lint-phase0.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Phase 0: Lint problem analysis and categorization
+set -e
+
+mkdir -p lint_analysis
+cd lint_analysis
+
+echo "🔍 Running comprehensive lint analysis..."
+npm run lint -- --format=json --output-file=full_report.json 2>/dev/null || true
+npm run lint -- --format=compact > compact_report.txt 2>&1 || true
+npm run lint > human_readable.txt 2>&1 || true
+
+TOTAL_PROBLEMS=$(grep -c "problem" human_readable.txt 2>/dev/null || echo 0)
+if [ "$TOTAL_PROBLEMS" -eq 0 ]; then
+  TOTAL_PROBLEMS=$(wc -l < compact_report.txt 2>/dev/null || echo 0)
+fi
+
+AUTO_FIXABLE=0
+npm run lint -- --fix-dry-run --format=compact > auto_fixable.txt 2>&1 || true
+if [ -f auto_fixable.txt ]; then
+  AUTO_FIXABLE=$(wc -l < auto_fixable.txt)
+fi
+
+cat > ANALYSIS_SUMMARY.md <<EOF2
+# Lint Analysis Summary
+
+Generated: $(date)
+Total Problems: $TOTAL_PROBLEMS
+Auto-fixable: $AUTO_FIXABLE
+Manual Fixes: $((TOTAL_PROBLEMS - AUTO_FIXABLE))
+EOF2
+
+cd ..
+echo "📊 LINT ANALYSIS COMPLETE"

--- a/scripts/codex-lint-phase1.sh
+++ b/scripts/codex-lint-phase1.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Phase 1: Auto-fix lint issues
+set -e
+
+PACKAGES=(core theme utils testing layout charts media ai blockchain community resonance federation voice-control)
+
+mkdir -p auto_fix_progress
+
+for pkg in "${PACKAGES[@]}"; do
+  pkg_path="packages/@smolitux/$pkg"
+  [ -d "$pkg_path" ] || continue
+  echo "Processing $pkg_path"
+  npx eslint "$pkg_path" --ext .ts,.tsx --fix >/dev/null 2>&1 || true
+done
+
+echo "Auto-fix phase complete" > auto_fix_progress/AUTO_FIX_REPORT.md

--- a/scripts/codex-lint-phase2.sh
+++ b/scripts/codex-lint-phase2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Phase 2: Manual fix guidance
+set -e
+
+mkdir -p manual_fix_progress
+npm run lint -- --format=json --output-file=manual_fix_progress/remaining.json 2>/dev/null || true
+
+echo "Manual fix guidance generated" > manual_fix_progress/MANUAL_FIX_SESSION_REPORT.md

--- a/scripts/codex-lint-phase3.sh
+++ b/scripts/codex-lint-phase3.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Phase 3: Final validation
+set -e
+
+mkdir -p final_validation
+npm run lint > final_validation/final_lint.log 2>&1 || true
+
+PROBLEMS=$(grep -c "problem" final_validation/final_lint.log || echo 0)
+cat > final_validation/CODEX_LINT_FIX_FINAL_REPORT.md <<EOF2
+# Final Validation Report
+Remaining problems: $PROBLEMS
+Generated: $(date)
+EOF2
+
+echo "Final validation complete"


### PR DESCRIPTION
## Summary
- add `codex-lint-fix-engine.sh` to orchestrate lint fixing phases
- add helper scripts for phase0–phase3 steps

## Testing
- `bash scripts/smolitux-analyzer.sh`
- `npm test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68474f389ff88324ab16c03fc1150848