### PR TITLE
Fix primitive tests and script sourcing

### DIFF
--- a/packages/@smolitux/utils/src/components/primitives/Box.test.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Box.test.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Box } from './Box';
 
 describe('Box', () => {
   it('renders without crashing', () => {
-    render(<Box />);
-    expect(screen.getByRole('button', { name: /Box/i })).toBeInTheDocument();
+    const { container } = render(<Box />);
+    expect(container.firstChild).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
-    render(<Box className="custom-class" />);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+    const { container } = render(<Box className="custom-class" />);
+    expect(container.firstChild).toHaveClass('custom-class');
   });
 
   it('forwards ref correctly', () => {
-    const ref = React.createRef<HTMLButtonElement>();
+    const ref = React.createRef<HTMLDivElement>();
     render(<Box ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
   });
 });

--- a/packages/@smolitux/utils/src/components/primitives/Flex.test.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Flex.test.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Flex } from './Flex';
 
 describe('Flex', () => {
   it('renders without crashing', () => {
-    render(<Flex />);
-    expect(screen.getByRole('button', { name: /Flex/i })).toBeInTheDocument();
+    const { container } = render(<Flex />);
+    expect(container.firstChild).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
-    render(<Flex className="custom-class" />);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+    const { container } = render(<Flex className="custom-class" />);
+    expect(container.firstChild).toHaveClass('custom-class');
   });
 
   it('forwards ref correctly', () => {
-    const ref = React.createRef<HTMLButtonElement>();
+    const ref = React.createRef<HTMLDivElement>();
     render(<Flex ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
   });
 });

--- a/packages/@smolitux/utils/src/components/primitives/Grid.test.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Grid.test.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Grid } from './Grid';
 
 describe('Grid', () => {
   it('renders without crashing', () => {
-    render(<Grid />);
-    expect(screen.getByRole('button', { name: /Grid/i })).toBeInTheDocument();
+    const { container } = render(<Grid />);
+    expect(container.firstChild).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
-    render(<Grid className="custom-class" />);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+    const { container } = render(<Grid className="custom-class" />);
+    expect(container.firstChild).toHaveClass('custom-class');
   });
 
   it('forwards ref correctly', () => {
-    const ref = React.createRef<HTMLButtonElement>();
+    const ref = React.createRef<HTMLDivElement>();
     render(<Grid ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
   });
 });

--- a/packages/@smolitux/utils/src/components/primitives/Text.test.tsx
+++ b/packages/@smolitux/utils/src/components/primitives/Text.test.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Text } from './Text';
 
 describe('Text', () => {
   it('renders without crashing', () => {
-    render(<Text />);
-    expect(screen.getByRole('button', { name: /Text/i })).toBeInTheDocument();
+    const { container } = render(<Text />);
+    expect(container.firstChild).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
-    render(<Text className="custom-class" />);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+    const { container } = render(<Text className="custom-class" />);
+    expect(container.firstChild).toHaveClass('custom-class');
   });
 
   it('forwards ref correctly', () => {
-    const ref = React.createRef<HTMLButtonElement>();
+    const ref = React.createRef<HTMLSpanElement>();
     render(<Text ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
   });
 });

--- a/scripts/core/analysis.sh
+++ b/scripts/core/analysis.sh
@@ -3,8 +3,9 @@
 # SMOLITUX CORE ANALYSIS
 # Core analysis functions for Smolitux scripts
 
-# Source utils
-source "$(dirname "$0")/utils.sh"
+# Source utils using the script's directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 
 # Analyze repository
 analyze_repository() {

--- a/scripts/core/completion.sh
+++ b/scripts/core/completion.sh
@@ -3,8 +3,9 @@
 # SMOLITUX CORE COMPLETION
 # Core completion functions for Smolitux scripts
 
-# Source utils
-source "$(dirname "$0")/utils.sh"
+# Source utils using the script's directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 
 # Generate component file
 generate_component_file() {

--- a/scripts/core/validation.sh
+++ b/scripts/core/validation.sh
@@ -3,8 +3,9 @@
 # SMOLITUX CORE VALIDATION
 # Core validation functions for Smolitux scripts
 
-# Source utils
-source "$(dirname "$0")/utils.sh"
+# Source utils using the script's directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 
 # Validate component
 validate_component_quality() {


### PR DESCRIPTION
## Summary
- fix path resolution in core scripts
- update Box, Flex, Grid and Text tests

## Testing
- `npm test` *(fails: jest errors)*
- `npm run lint` *(fails: ESLint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68485700aed883249a74071e327099ab