### PR TITLE
Fix Option forwardRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 ## [0.3.3] - 2025-06-17
 ### Added
 - Component counts documented in component-status.md
+
+## [0.3.4] - 2025-06-18
+### Changed
+- Added forwardRef and data-testid to `Option` component
+- Updated related tests and stories
 ## [0.3.2] - 2025-06-08
 ### Added
 - Offline Komponentenscan und TODO-Liste erstellt

--- a/packages/@smolitux/core/src/components/Select/Option.stories.tsx
+++ b/packages/@smolitux/core/src/components/Select/Option.stories.tsx
@@ -2,10 +2,15 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Option } from './Option';
 
 const meta: Meta<typeof Option> = {
-  title: 'Components/Option',
+  title: 'Components/Select/Option',
   component: Option,
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component: 'Repräsentiert eine einzelne Option innerhalb einer Select-Komponente.',
+      },
+    },
   },
   tags: ['autodocs'],
 };
@@ -14,21 +19,27 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    children: 'Option',
-  },
+  render: () => (
+    <select>
+      <Option value="option1">Option 1</Option>
+    </select>
+  ),
 };
 
 export const CustomStyle: Story = {
-  args: {
-    children: 'Custom Option',
-    className: 'custom-style',
-  },
+  render: () => (
+    <select className="custom-style">
+      <Option value="option1">Styled Option</Option>
+    </select>
+  ),
 };
 
-export const Interactive: Story = {
-  args: {
-    children: 'Interactive Option',
-    onClick: () => alert('Clicked!'),
-  },
+export const Disabled: Story = {
+  render: () => (
+    <select>
+      <Option value="option1" disabled>
+        Disabled Option
+      </Option>
+    </select>
+  ),
 };

--- a/packages/@smolitux/core/src/components/Select/Option.test.tsx
+++ b/packages/@smolitux/core/src/components/Select/Option.test.tsx
@@ -1,21 +1,53 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { Option } from './Option';
 
+expect.extend(toHaveNoViolations);
+
 describe('Option', () => {
-  it('renders without crashing', () => {
-    render(<Option />);
-    expect(screen.getByRole('button', { name: /Option/i })).toBeInTheDocument();
+  it('renders value and label', () => {
+    render(
+      <select>
+        <Option value="1">Label</Option>
+      </select>
+    );
+    const option = screen.getByTestId('option');
+    expect(option).toHaveValue('1');
+    expect(option).toHaveTextContent('Label');
   });
 
-  it('applies custom className', () => {
-    render(<Option className="custom-class" />);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+  it('sets disabled attribute', () => {
+    render(
+      <select>
+        <Option value="1" disabled>
+          Disabled
+        </Option>
+      </select>
+    );
+    const option = screen.getByTestId('option');
+    expect(option).toBeDisabled();
   });
 
   it('forwards ref correctly', () => {
-    const ref = React.createRef<HTMLButtonElement>();
-    render(<Option ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    const ref = React.createRef<HTMLOptionElement>();
+    render(
+      <select>
+        <Option ref={ref} value="1">
+          Option
+        </Option>
+      </select>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLOptionElement);
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <select>
+        <Option value="1">Label</Option>
+      </select>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/@smolitux/core/src/components/Select/Option.tsx
+++ b/packages/@smolitux/core/src/components/Select/Option.tsx
@@ -1,5 +1,4 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 export interface OptionProps extends React.OptionHTMLAttributes<HTMLOptionElement> {
   /** Wert der Option */
@@ -26,29 +25,37 @@ export interface OptionProps extends React.OptionHTMLAttributes<HTMLOptionElemen
  * <Option value="option3" description="Beschreibung für Option 3">Option 3</Option>
  * ```
  */
-export const Option: React.FC<OptionProps> = ({
-  value,
-  children,
-  disabled,
-  description,
-  icon,
-  group,
-  ...props
-}) => {
-  return (
+export const Option = forwardRef<HTMLOptionElement, OptionProps>(
+  (
+    {
+      value,
+      children,
+      disabled,
+      description,
+      icon,
+      group,
+      'data-testid': dataTestId = 'option',
+      ...props
+    },
+    ref
+  ) => (
     <option
+      ref={ref}
       value={value}
       disabled={disabled}
       title={description}
       data-icon={icon ? 'true' : undefined}
       data-description={description}
       data-group={group}
+      data-testid={dataTestId}
       {...props}
     >
       {children}
       {disabled && <span className="sr-only"> (nicht verfügbar)</span>}
     </option>
-  );
-};
+  )
+);
+
+Option.displayName = 'Option';
 
 export default Option;

--- a/packages/@smolitux/core/src/components/Select/README.md
+++ b/packages/@smolitux/core/src/components/Select/README.md
@@ -1,0 +1,31 @@
+# Option-Komponente
+
+Die `Option`-Komponente repräsentiert einen auswählbaren Eintrag innerhalb der `Select`-Komponente.
+
+## Verwendung
+
+```tsx
+import { Select } from '@smolitux/core';
+
+<Select>
+  <Select.Option value="1">Option 1</Select.Option>
+  <Select.Option value="2" disabled>
+    Option 2
+  </Select.Option>
+</Select>;
+```
+
+## Props
+
+| Prop          | Typ               | Standard | Beschreibung              |
+| ------------- | ----------------- | -------- | ------------------------- |
+| `value`       | `string`          | –        | Wert der Option           |
+| `children`    | `React.ReactNode` | –        | Anzeigeinhalt             |
+| `disabled`    | `boolean`         | `false`  | Deaktiviert die Option    |
+| `description` | `string`          | –        | Zusätzliche Beschreibung  |
+| `icon`        | `React.ReactNode` | –        | Optionales Icon           |
+| `group`       | `string`          | –        | Gruppierung für Optgroups |
+
+```
+
+```


### PR DESCRIPTION
## Summary
- add forwardRef and data-testid to Option
- update stories and tests for Option
- document Option component
- update CHANGELOG

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `bash scripts/validation/validate-build.sh --package core` *(fails: Cannot find module '@smolitux/utils')*
- `npm test` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68487d1fbaac8324aecb578f78410726