### PR TITLE
Add voice control user guide

### DIFF
--- a/docs/wiki/features/voice-control/README.md
+++ b/docs/wiki/features/voice-control/README.md
@@ -18,6 +18,8 @@ Diese Dokumentation beschreibt die Sprachsteuerungsfunktionalität für die Smol
 
 Die Sprachsteuerungsfunktionalität ermöglicht Benutzern, mit Smolitux-UI-Komponenten durch Sprachbefehle zu interagieren. Dies verbessert die Barrierefreiheit und bietet eine alternative Eingabemethode für verschiedene Anwendungsfälle.
 
+Eine Schritt-für-Schritt-Anleitung zur praktischen Nutzung finden Sie im [Voice Control Guide](../guides/voice-control-guide.md).
+
 ### Hauptfunktionen
 
 - **Vollständige Komponentensteuerung**: Alle Smolitux-UI-Komponenten können mit Sprachbefehlen gesteuert werden

--- a/docs/wiki/guides/voice-control-guide.md
+++ b/docs/wiki/guides/voice-control-guide.md
@@ -1,0 +1,143 @@
+# Sprachsteuerung in Smolitux UI
+
+Diese Anleitung zeigt, wie Sie die Sprachsteuerungsfunktionen von Smolitux UI nutzen und insbesondere ein Modal per Sprachbefehl öffnen und schließen können.
+
+## 1. Voice Control Infrastruktur
+
+Die Sprachsteuerung basiert auf dem `VoiceControlProvider` und dem `withVoiceControl` Higher-Order Component (HOC). Der Provider stellt Registrierungsfunktionen bereit:
+
+```ts
+const registerComponent = (id: string, commands: string[]) =>
+  manager.registerComponent(id, commands);
+const unregisterComponent = (id: string) => manager.unregisterComponent(id);
+```
+
+## 2. Komponenten mit `withVoiceControl` erweitern
+
+Binden Sie interaktive Komponenten mit dem HOC ein. Dadurch werden sie automatisch registriert und reagieren auf erkannte Befehle:
+
+```ts
+export function withVoiceControl<P extends object>(
+  Component: React.ComponentType<P>,
+  defaultCommands: string[] = []
+) {
+  return React.forwardRef<unknown, P & VoiceControlProps>((props, ref) => {
+    const { voiceCommands = defaultCommands, voiceEnabled = true, onVoiceCommand, ...rest } = props;
+    ...
+    useEffect(() => {
+      if (voiceEnabled && voiceCommands.length > 0) {
+        registerComponent(id, voiceCommands);
+      }
+      return () => {
+        if (voiceEnabled) {
+          unregisterComponent(id);
+        }
+      };
+    }, [id, registerComponent, unregisterComponent, voiceEnabled, voiceCommands]);
+
+    useEffect(() => {
+      if (targetComponent === id && lastCommand && onVoiceCommand) {
+        onVoiceCommand(lastCommand);
+      }
+    }, [id, lastCommand, onVoiceCommand, targetComponent]);
+
+    return <Component ref={ref || componentRef} {...(rest as P)} />;
+  });
+}
+```
+
+## 3. Modal per Sprachbefehl steuern
+
+Das folgende Beispiel zeigt eine `VoiceModal`, die auf Befehle wie „schließen“ oder „cancel" reagiert. Ein `VoiceButton` öffnet das Modal mit Befehlen wie „öffnen" oder „open":
+
+```tsx
+// src/components/voice/VoiceModal.tsx
+import React from 'react';
+import { Modal, ModalProps } from '@smolitux/core';
+import { withVoiceControl, VoiceControlProps } from '@smolitux/voice-control';
+
+export type VoiceModalProps = ModalProps & VoiceControlProps;
+
+const VoiceModalBase: React.FC<VoiceModalProps> = ({
+  onVoiceCommand,
+  onClose,
+  children,
+  ...props
+}) => {
+  const handleVoiceCommand = (command: string) => {
+    const lowerCommand = command.toLowerCase();
+
+    // Befehle zum Schließen des Modals
+    if (
+      lowerCommand === 'schließen' ||
+      lowerCommand === 'close' ||
+      lowerCommand === 'abbrechen' ||
+      lowerCommand === 'cancel'
+    ) {
+      if (onClose) {
+        onClose();
+      }
+    }
+
+    if (onVoiceCommand) {
+      onVoiceCommand(command);
+    }
+  };
+
+  return (
+    <Modal onClose={onClose} {...props}>
+      {children}
+    </Modal>
+  );
+};
+
+export const VoiceModal = withVoiceControl(
+  VoiceModalBase,
+  ['schließen', 'close', 'abbrechen', 'cancel']
+);
+
+const [isOpen, setIsOpen] = useState(false);
+
+<VoiceButton onClick={() => setIsOpen(true)} voiceCommands={['öffnen', 'open']}>
+  Modal öffnen
+</VoiceButton>
+
+<VoiceModal isOpen={isOpen} onClose={() => setIsOpen(false)} title="Beispiel-Modal">
+  <p>Dieses Modal kann mit Sprachbefehlen geschlossen werden.</p>
+  <VoiceButton onClick={() => setIsOpen(false)}>Schließen</VoiceButton>
+</VoiceModal>
+```
+
+## 4. Provider einbinden
+
+Um die Sprachsteuerung zu aktivieren, umgeben Sie Ihre App mit dem `VoiceControlProvider` und konfigurieren Sie ggf. eine Erkennungs-Engine:
+
+```tsx
+import React from 'react';
+import { VoiceControlProvider } from '@smolitux/voice-control';
+
+function App() {
+  return (
+    <VoiceControlProvider
+      engineType="tensorFlow"
+      tensorFlowOptions={{
+        modelType: 'BROWSER_FFT',
+        vocabulary: 'general',
+        scoreThreshold: 0.75,
+      }}
+    >
+      <YourApp />
+    </VoiceControlProvider>
+  );
+}
+```
+
+## Zusammenfassung
+
+1. Binden Sie `VoiceControlProvider` global ein.
+2. Verwenden Sie `withVoiceControl`, um Komponenten mit Sprachbefehlen auszustatten.
+3. Nutzen Sie eine `VoiceModal`, um Dialoge per Sprache zu öffnen und zu schließen.
+4. Registrieren Sie individuelle Befehle über die `voiceCommands`‑Prop.
+
+Damit lässt sich die Modalsteuerung vollständig per Sprache bedienen.
+

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -142,6 +142,7 @@ Our component library is organized into functional categories for easy navigatio
 - **[Form Validation](guides/form-validation.md)** - How to handle form validation
 - **[Internationalization](guides/internationalization.md)** - Multi-language support
 - **[Migration Guide](guides/migration-guide.md)** - Migrating between versions
+- **[Voice Control Guide](guides/voice-control-guide.md)** - Sprachsteuerung in der Praxis
 - **[Examples](examples/form-examples.md)** - Code examples:
   - [Form Examples](examples/form-examples.md)
   - [Layout Examples](examples/layout-examples.md)


### PR DESCRIPTION
## Summary
- document voice control usage in a new guide
- link the guide from the voice-control feature docs and from the main index

## Testing
- `npm test` *(fails: Could not find modules, TS errors)*
- `npm run lint` *(fails: 1140 errors, 4 warnings)*
- `npx tsc --noEmit` *(fails with numerous type errors)*
- `bash scripts/validation/validate-build.sh` *(fails to resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848809de93c8324a6762a3e0b51558b