### PR TITLE
Fix jest root path for blockchain package

### DIFF
--- a/packages/@smolitux/blockchain/jest.config.js
+++ b/packages/@smolitux/blockchain/jest.config.js
@@ -1,6 +1,9 @@
+const path = require('path');
 const base = require('../../../jest.config');
+
 module.exports = {
   ...base,
-  rootDir: __dirname,
-  setupFilesAfterEnv: ['../../../jest.setup.js'],
+  rootDir: path.resolve(__dirname, '../../..'),
+  roots: ['<rootDir>/packages/@smolitux/blockchain'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };


### PR DESCRIPTION
## Summary
- correct Jest rootDir for blockchain package so tests run

## Testing
- `npm test --workspace=@smolitux/blockchain` *(fails: TokenDisplay.test.tsx errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848a29686b88324a1dfe11f8b7a6d5d