### PR TITLE
Fix layout package test config and utilities

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,7 @@ const config = {
   },
   testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/__tests__/**/*.spec.{ts,tsx}'],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
   },
   transformIgnorePatterns: [
     '/node_modules/(?!y18n)/'

--- a/packages/@smolitux/layout/jest.config.js
+++ b/packages/@smolitux/layout/jest.config.js
@@ -1,6 +1,7 @@
+const path = require('path');
 const base = require('../../../jest.config');
 module.exports = {
   ...base,
-  rootDir: __dirname,
-  setupFilesAfterEnv: ['../../../jest.setup.js'],
+  rootDir: path.resolve(__dirname, '../../..'),
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/packages/@smolitux/layout/src/components/DashboardLayout/__tests__/DashboardLayout.test.tsx
+++ b/packages/@smolitux/layout/src/components/DashboardLayout/__tests__/DashboardLayout.test.tsx
@@ -22,7 +22,7 @@ jest.mock('../../Container/Container', () => ({
 describe('DashboardLayout', () => {
   it('renders children inside container', () => {
     const { getByText } = render(
-      <DashboardLayout header={{ show: false }} sidebar={{ show: false }} footer={{ show: false }}>
+      <DashboardLayout header={{ show: false }} sidebar={{ show: false, items: [] }} footer={{ show: false }}>
         <span>content</span>
       </DashboardLayout>
     );

--- a/packages/@smolitux/layout/src/components/Flex/Flex.a11y.tsx
+++ b/packages/@smolitux/layout/src/components/Flex/Flex.a11y.tsx
@@ -136,8 +136,11 @@ export const FlexA11y = forwardRef<HTMLDivElement, FlexProps>(
       map?: Record<string, string>
     ) => {
       if (prop === undefined) return '';
-      const convert = (value: unknown) => (map ? map[value] || value : value);
-      if (typeof prop === 'object') {
+      const convert = (value: unknown) => {
+        const key = String(value);
+        return map ? map[key] || key : key;
+      };
+      if (typeof prop === 'object' && prop !== null) {
         return Object.entries(prop)
           .map(([bp, val]) => `${bp}:${prefix}-${convert(val)}`)
           .join(' ');

--- a/packages/@smolitux/layout/src/components/Flex/Flex.tsx
+++ b/packages/@smolitux/layout/src/components/Flex/Flex.tsx
@@ -57,8 +57,11 @@ export const Flex = forwardRef<HTMLDivElement, FlexProps>(
       map?: Record<string, string>
     ) => {
       if (prop === undefined) return '';
-      const convert = (value: unknown) => (map ? map[value] || value : value);
-      if (typeof prop === 'object') {
+      const convert = (value: unknown) => {
+        const key = String(value);
+        return map ? map[key] || key : key;
+      };
+      if (typeof prop === 'object' && prop !== null) {
         return Object.entries(prop)
           .map(([bp, val]) => `${bp}:${prefix}-${convert(val)}`)
           .join(' ');

--- a/packages/@smolitux/layout/src/components/Grid/Grid.tsx
+++ b/packages/@smolitux/layout/src/components/Grid/Grid.tsx
@@ -28,11 +28,11 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const gapMap: Record<GridGap, string> = {
   none: '0',
-  xs: '1',
-  sm: '2',
-  md: '4',
-  lg: '6',
-  xl: '8',
+  xs: 'xs',
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+  xl: 'xl',
 };
 
 const justifyMap: Record<GridJustify, string> = {
@@ -55,16 +55,25 @@ const alignMap: Record<GridAlign, string> = {
 const getPrefix = (bp: GridBreakpoint) =>
   bp === 'sm' ? 'sm:' : bp === 'md' ? 'md:' : bp === 'lg' ? 'lg:' : bp === 'xl' ? 'xl:' : '2xl:';
 
-const responsive = (prop: unknown, prefix: string, map: Record<string, string>) => {
+const responsive = (
+  prop: unknown,
+  prefix: string,
+  map: Record<string, string>
+) => {
   if (prop === undefined) return '';
-  if (typeof prop === 'object') {
-    return Object.entries(prop)
-      .map(
-        ([bp, val]) => `${getPrefix(bp as GridBreakpoint)}${prefix}-${map[val as keyof typeof map]}`
-      )
+
+  const convert = (value: unknown) => {
+    const key = String(value);
+    return map[key] ?? key;
+  };
+
+  if (typeof prop === 'object' && prop !== null) {
+    return Object.entries(prop as Record<string, unknown>)
+      .map(([bp, val]) => `${getPrefix(bp as GridBreakpoint)}${prefix}-${convert(val)}`)
       .join(' ');
   }
-  return `${prefix}-${map[prop as keyof typeof map]}`;
+
+  return `${prefix}-${convert(prop)}`;
 };
 
 export const Grid = forwardRef<HTMLDivElement, GridProps>(

--- a/packages/@smolitux/layout/src/components/Grid/__tests__/Grid.a11y.test.tsx
+++ b/packages/@smolitux/layout/src/components/Grid/__tests__/Grid.a11y.test.tsx
@@ -8,13 +8,9 @@ expect.extend(toHaveNoViolations);
 describe('Grid Accessibility', () => {
   test('should have no basic accessibility violations', async () => {
     const { container } = render(
-      <Grid container spacing={2}>
-        <Grid item xs={6}>
-          Item 1
-        </Grid>
-        <Grid item xs={6}>
-          Item 2
-        </Grid>
+      <Grid gap="md">
+        <Grid.Item xs={6}>Item 1</Grid.Item>
+        <Grid.Item xs={6}>Item 2</Grid.Item>
       </Grid>
     );
 
@@ -24,10 +20,10 @@ describe('Grid Accessibility', () => {
 
   test('should handle interactive content without violations', async () => {
     const { container } = render(
-      <Grid container spacing={2}>
-        <Grid item xs={12}>
+      <Grid gap="md">
+        <Grid.Item xs={12}>
           <button>Click me</button>
-        </Grid>
+        </Grid.Item>
       </Grid>
     );
 

--- a/packages/@smolitux/layout/src/components/Grid/__tests__/Grid.snapshot.test.tsx
+++ b/packages/@smolitux/layout/src/components/Grid/__tests__/Grid.snapshot.test.tsx
@@ -5,13 +5,9 @@ import Grid from '../Grid';
 describe('Grid Snapshots', () => {
   it('renders container with two items', () => {
     const { asFragment } = render(
-      <Grid container spacing={2}>
-        <Grid item xs={6}>
-          One
-        </Grid>
-        <Grid item xs={6}>
-          Two
-        </Grid>
+      <Grid gap="md">
+        <Grid.Item xs={6}>One</Grid.Item>
+        <Grid.Item xs={6}>Two</Grid.Item>
       </Grid>
     );
     expect(asFragment()).toMatchSnapshot();

--- a/packages/@smolitux/layout/src/components/Grid/__tests__/__snapshots__/Grid.snapshot.test.tsx.snap
+++ b/packages/@smolitux/layout/src/components/Grid/__tests__/__snapshots__/Grid.snapshot.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Grid Snapshots renders container with two items 1`] = `
+<DocumentFragment>
+  <div
+    class="grid grid-cols-12 gap-md justify-start items-stretch"
+  >
+    <div
+      class="col-span-6"
+    >
+      One
+    </div>
+    <div
+      class="col-span-6"
+    >
+      Two
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
+++ b/packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 // packages/@smolitux/layout/src/components/Sidebar/Sidebar.tsx
 import React, { useState, useEffect, forwardRef } from 'react';
 import { useTheme } from '@smolitux/theme';
-import { breakpoints } from '@smolitux/utils/styling';
+import { breakpoints } from '@smolitux/utils/src/styling';
 
 export interface SidebarItem {
   /** Eindeutige ID des Items */
@@ -59,6 +59,8 @@ export interface SidebarProps {
   collapseBreakpoint?: keyof typeof breakpoints | number;
   /** Footer-Inhalt */
   footer?: React.ReactNode;
+  /** Zusätzliche CSS-Klassen */
+  className?: string;
 }
 
 /**
@@ -98,7 +100,8 @@ export const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(
     },
     ref
   ) => {
-    const { themeMode } = useTheme();
+    // Ensure theme context is initialized
+    useTheme();
     const [isCollapsed, setIsCollapsed] = useState(collapsed);
     const [openSubmenu, setOpenSubmenu] = useState<string | null>(null);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,12 @@
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@smolitux/*": ["packages/@smolitux/*/src"],
+      "@smolitux/*/*": ["packages/@smolitux/*/src/*"]
+    }
   },
   "include": ["packages", "docs"],
   "exclude": [


### PR DESCRIPTION
## Summary
- fix jest config for layout package
- refine responsive utils in Flex and Grid
- tweak Sidebar imports and theme usage
- update test expectations and dashboard layout test
- add TypeScript path mappings

## Testing
- `npx jest packages/@smolitux/layout`

------
https://chatgpt.com/codex/tasks/task_e_6848a2deb0d883248d5971a54821ed1a