### PR TITLE
Fix DashboardLayout ref and add layout a11y tests

### DIFF
--- a/docs/wiki/development/comment-todo-log.md
+++ b/docs/wiki/development/comment-todo-log.md
@@ -90,7 +90,7 @@
 - [ ] `src/components/CrossPlatformShare/CrossPlatformShare.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 
 ## Paket: @layout
-- [ ] `src/components/DashboardLayout/DashboardLayout.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
+- [x] `src/components/DashboardLayout/DashboardLayout.tsx`: 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 - [ ] `src/components/Grid/Grid.tsx`: 🛠 FIXME [Codex]: Props nicht typisiert – Fehlerbehebung erforderlich
 
 ## Paket: @media

--- a/docs/wiki/development/component-status.md
+++ b/docs/wiki/development/component-status.md
@@ -256,7 +256,7 @@ Dieser Bericht wird mit jeder Version aktualisiert, um den Fortschritt bei der T
 | @smolitux/federation | IdentityBridge | ❌ Offen |
 | @smolitux/federation | FederationSettings | ❌ Offen |
 | @smolitux/layout | Container | ✅ Fertig |
-| @smolitux/layout | DashboardLayout | ❌ Offen |
+| @smolitux/layout | DashboardLayout | ✅ Fertig |
 | @smolitux/layout | Flex | ✅ Fertig |
 | @smolitux/layout | Footer | ✅ Fertig |
 | @smolitux/layout | Grid | ✅ Fertig |

--- a/docs/wiki/development/component-todo.md
+++ b/docs/wiki/development/component-todo.md
@@ -250,7 +250,6 @@ _Update 2025-06-09:_ Kommentar-TODOs in Testdateien vereinheitlicht.
 
 | Komponente      | TODOs                 |
 | --------------- | --------------------- |
-| DashboardLayout | forwardRef hinzufügen |
 
 ## @smolitux/media
 

--- a/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.test.tsx
+++ b/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.test.tsx
@@ -4,18 +4,18 @@ import { DashboardLayout } from './DashboardLayout';
 
 describe('DashboardLayout', () => {
   it('renders without crashing', () => {
-    render(<DashboardLayout />);
-    expect(screen.getByRole('button', { name: /DashboardLayout/i })).toBeInTheDocument();
+    render(<DashboardLayout data-testid="layout" />);
+    expect(screen.getByTestId('layout')).toBeInTheDocument();
   });
 
   it('applies custom className', () => {
-    render(<DashboardLayout className="custom-class" />);
-    expect(screen.getByRole('button')).toHaveClass('custom-class');
+    render(<DashboardLayout data-testid="layout" className="custom-class" />);
+    expect(screen.getByTestId('layout')).toHaveClass('custom-class');
   });
 
   it('forwards ref correctly', () => {
-    const ref = React.createRef<HTMLButtonElement>();
+    const ref = React.createRef<HTMLDivElement>();
     render(<DashboardLayout ref={ref} />);
-    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
 });

--- a/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
+++ b/packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
@@ -1,6 +1,5 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 // packages/@smolitux/layout/src/components/DashboardLayout/DashboardLayout.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, forwardRef } from 'react';
 import Header, { HeaderProps } from '../Header/Header';
 import Sidebar, { SidebarProps } from '../Sidebar/Sidebar';
 import Footer, { FooterProps } from '../Footer/Footer';
@@ -39,18 +38,22 @@ export interface DashboardLayoutProps extends React.HTMLAttributes<HTMLDivElemen
  * </DashboardLayout>
  * ```
  */
-export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
-  header = { show: true },
-  sidebar = { show: true },
-  footer = { show: true },
-  children,
-  sidebarCollapsed = false,
-  maxWidth = 'full',
-  contentPadding = true,
-  responsive = true,
-  className = '',
-  ...rest
-}) => {
+export const DashboardLayout = forwardRef<HTMLDivElement, DashboardLayoutProps>(
+  (
+    {
+      header = { show: true },
+      sidebar = { show: true },
+      footer = { show: true },
+      children,
+      sidebarCollapsed = false,
+      maxWidth = 'full',
+      contentPadding = true,
+      responsive = true,
+      className = '',
+      ...rest
+    },
+    ref
+  ) => {
   // State für Sidebar Collapse und Mobile-Layout
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(sidebarCollapsed);
   const [isMobile, setIsMobile] = useState(false);
@@ -161,6 +164,6 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
       )}
     </div>
   );
-};
+});
 
 export default DashboardLayout;

--- a/packages/@smolitux/layout/src/components/DashboardLayout/__tests__/DashboardLayout.test.tsx
+++ b/packages/@smolitux/layout/src/components/DashboardLayout/__tests__/DashboardLayout.test.tsx
@@ -43,4 +43,14 @@ describe('DashboardLayout', () => {
     expect(container.querySelector('aside')).toBeInTheDocument();
     expect(container.querySelector('footer')).toBeInTheDocument();
   });
+
+  it('forwards ref to root element', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(
+      <DashboardLayout ref={ref} header={{ show: false }} sidebar={{ show: false, items: [] }} footer={{ show: false }}>
+        test
+      </DashboardLayout>
+    );
+    expect(ref.current).toBe(container.firstChild);
+  });
 });

--- a/packages/@smolitux/layout/src/components/Footer/__tests__/Footer.a11y.test.tsx
+++ b/packages/@smolitux/layout/src/components/Footer/__tests__/Footer.a11y.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Footer } from '../Footer';
+
+expect.extend(toHaveNoViolations);
+
+describe('Footer Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Footer />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/@smolitux/layout/src/components/Header/__tests__/Header.a11y.test.tsx
+++ b/packages/@smolitux/layout/src/components/Header/__tests__/Header.a11y.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { Header } from '../Header';
+
+expect.extend(toHaveNoViolations);
+
+describe('Header Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Header title="Test" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Summary
- add forwardRef support for DashboardLayout
- update DashboardLayout unit tests
- add a11y tests for Header and Footer
- update TODO log and status docs

## Testing
- `npx jest packages/@smolitux/layout/...` *(fails: could not run full test suite due to repo-wide issues)*
- `npm run lint` *(fails: could not run due to repo-wide issues)*
- `npx tsc --noEmit -p packages/@smolitux/layout/tsconfig.json` *(fails: could not run due to repo-wide issues)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8df04dc8324ba14b7b7853d0568