### PR TITLE
Fix jest configuration for testing package

### DIFF
--- a/packages/@smolitux/testing/jest.config.js
+++ b/packages/@smolitux/testing/jest.config.js
@@ -1,6 +1,9 @@
+const path = require('path');
 const base = require('../../../jest.config');
+
 module.exports = {
   ...base,
-  rootDir: __dirname,
-  setupFilesAfterEnv: ['../../../jest.setup.js'],
+  rootDir: path.resolve(__dirname, '../../..'),
+  roots: ['<rootDir>/packages/@smolitux/testing'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/packages/@smolitux/theme/src/Index.tsx
+++ b/packages/@smolitux/theme/src/Index.tsx
@@ -1,6 +1,6 @@
 // Export all theme related components and utilities
 export * from './types';
-export * from './defaultTheme';
+export * from './Default';
 export * from './themeProvider';
 export * from './themeUtils';
 

--- a/packages/@smolitux/theme/src/index.ts
+++ b/packages/@smolitux/theme/src/index.ts
@@ -7,3 +7,4 @@ export { tokens, type Tokens } from './tokens';
 export { createCssVariables, applyCssVariables } from './utils/cssVariables';
 export type { Theme, ThemeOptions, ColorShades, Colors, Typography, Spacing, BorderRadius, Shadows, Breakpoints, ZIndices } from './theme-types';
 export { ThemeTypen } from './ThemeTypen';
+export { defaultTheme } from './Default';


### PR DESCRIPTION
## Summary
- fix jest config path for @smolitux/testing
- export default theme from theme package

## Testing
- `npm test --workspace=packages/@smolitux/testing` *(fails: TypeScript errors across repository)*
- `npm run lint` *(fails: 1148 errors)
- `npx tsc --noEmit` *(fails: TS5061 pattern issue)*

------
https://chatgpt.com/codex/tasks/task_e_6848a906a6f8832483c2d38fa8bc0b9b