### PR TITLE
Fix import paths in blockchain components

### DIFF
--- a/packages/@smolitux/blockchain/src/components/TokenDisplay/TokenDisplay.tsx
+++ b/packages/@smolitux/blockchain/src/components/TokenDisplay/TokenDisplay.tsx
@@ -2,7 +2,7 @@
 // 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React from 'react';
 import { Card } from '@smolitux/core';
-import { TokenInfo } from '../types';
+import { TokenInfo } from '../../types';
 
 export interface TokenDisplayProps {
   /** Token-Informationen */

--- a/packages/@smolitux/blockchain/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/@smolitux/blockchain/src/components/TransactionHistory/TransactionHistory.tsx
@@ -2,7 +2,7 @@
 // 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button } from '@smolitux/core';
-import { TransactionType, Transaction } from '../types';
+import { TransactionType, Transaction } from '../../types';
 
 export interface TransactionHistoryProps {
   /** Transaktionen */

--- a/packages/@smolitux/blockchain/src/components/WalletConnect/WalletConnect.tsx
+++ b/packages/@smolitux/blockchain/src/components/WalletConnect/WalletConnect.tsx
@@ -2,7 +2,7 @@
 // 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Button, Card } from '@smolitux/core';
-import { EthereumProvider } from '../types';
+import { EthereumProvider } from '../../types';
 
 export interface WalletConnectProps {
   /** Callback bei erfolgreicher Verbindung */


### PR DESCRIPTION
## Summary
- fix incorrect relative import paths to `types.ts` across WalletConnect, TokenDisplay and TransactionHistory components

## Testing
- `npm test --workspace=@smolitux/blockchain -- -t WalletConnect` *(fails: test suite errors)*
- `npm run lint --workspace=@smolitux/blockchain` *(fails: eslint parsing errors)*


------
https://chatgpt.com/codex/tasks/task_e_6848a814b15883249405f06f9908d954