### PR TITLE
Add forwardRef to Tooltip and TabView

### DIFF
--- a/packages/@smolitux/utils/src/components/patterns/TabView.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/TabView.tsx
@@ -1,5 +1,4 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, forwardRef } from 'react';
 import { Box } from '../primitives/Box';
 import { Flex } from '../primitives/Flex';
 
@@ -53,7 +52,7 @@ export interface TabViewProps {
  * TabView component for displaying content in tabs.
  * It supports different orientations, sizes, and variants.
  */
-export const TabView: React.FC<TabViewProps> = ({
+export const TabView = forwardRef<HTMLDivElement, TabViewProps>(({ 
   tabs,
   activeTab: controlledActiveTab,
   onChange,
@@ -69,7 +68,7 @@ export const TabView: React.FC<TabViewProps> = ({
   inactiveTabClassName = '',
   className = '',
   children,
-}) => {
+}, ref) => {
   // State for the active tab
   const [activeTab, setActiveTab] = useState<string>(
     controlledActiveTab || (tabs.length > 0 ? tabs[0].id : '')
@@ -225,12 +224,12 @@ export const TabView: React.FC<TabViewProps> = ({
   };
 
   return (
-    <Box className={`tab-view ${className}`}>
+    <Box ref={ref} className={`tab-view ${className}`}>
       {renderTabList()}
       {renderTabPanels()}
       {children}
     </Box>
   );
-};
+});
 
 TabView.displayName = 'TabView';

--- a/packages/@smolitux/utils/src/components/patterns/Tooltip.tsx
+++ b/packages/@smolitux/utils/src/components/patterns/Tooltip.tsx
@@ -1,5 +1,4 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, forwardRef } from 'react';
 import { Box } from '../primitives/Box';
 
 export type TooltipPlacement =
@@ -59,7 +58,7 @@ export interface TooltipProps {
  * Tooltip component for displaying additional information on hover.
  * It supports different placements, delays, and behaviors.
  */
-export const Tooltip: React.FC<TooltipProps> = ({
+export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(({
   content,
   children,
   placement = 'top',
@@ -78,7 +77,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   offset = 8,
   closeOnClick = true,
   closeOnEsc = true,
-}) => {
+}, ref) => {
   // State for tooltip visibility
   const [isOpen, setIsOpen] = useState(defaultIsOpen);
   const [position, setPosition] = useState({ top: 0, left: 0 });
@@ -373,7 +372,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   };
 
   return (
-    <Box className={className}>
+    <Box ref={ref} className={className}>
       {trigger}
       {tooltipIsOpen && (
         <Box
@@ -410,6 +409,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
       )}
     </Box>
   );
-};
+});
 
 Tooltip.displayName = 'Tooltip';


### PR DESCRIPTION
## Summary
- enable ref forwarding in Tooltip
- enable ref forwarding in TabView

## Testing
- `npx eslint packages/@smolitux/utils/src/components/patterns/Tooltip.tsx packages/@smolitux/utils/src/components/patterns/TabView.tsx`
- `npx tsc -p packages/@smolitux/utils/tsconfig.json --noEmit` *(fails: Pattern '@smolitux/*/*' can have at most one '*' character)*
- `bash scripts/validation/validate-build.sh --package utils` *(fails: error occurred in dts build)*
- `npm test --workspace=@smolitux/utils` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6848a92c220c832484463a6e3af876c5