### PR TITLE
Fix federation components ref forwarding

### DIFF
--- a/packages/@smolitux/federation/jest.config.js
+++ b/packages/@smolitux/federation/jest.config.js
@@ -1,6 +1,7 @@
+const path = require('path');
 const base = require('../../../jest.config');
 module.exports = {
   ...base,
-  rootDir: __dirname,
-  setupFilesAfterEnv: ['../../../jest.setup.js'],
+  rootDir: path.resolve(__dirname, '../../..'),
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityPubViewer/ActivityPubViewer.tsx
@@ -16,9 +16,9 @@ export interface ActivityPubViewerProps {
   className?: string;
 }
 
-export const ActivityPubViewer: React.FC<ActivityPubViewerProps> = ({ activity, className }) => {
+export const ActivityPubViewer = React.forwardRef<HTMLDivElement, ActivityPubViewerProps>(({ activity, className }, ref) => {
   return (
-    <Card className={className} data-testid="activitypub-viewer">
+    <Card ref={ref} className={className} data-testid="activitypub-viewer">
       <h3 className="font-semibold" data-testid="actor">
         {activity.actor}
       </h3>
@@ -29,7 +29,10 @@ export const ActivityPubViewer: React.FC<ActivityPubViewerProps> = ({ activity, 
         </p>
       )}
     </Card>
+
   );
-};
+});
+
+ActivityPubViewer.displayName = 'ActivityPubViewer';
 
 export default ActivityPubViewer;

--- a/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
+++ b/packages/@smolitux/federation/src/components/ActivityStream/ActivityStream.tsx
@@ -1,4 +1,3 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 import { Card, Button, Input } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';
@@ -142,7 +141,7 @@ export interface ActivityStreamProps {
 /**
  * ActivityStream-Komponente für die Anzeige von ActivityPub-Aktivitäten und Interaktionen
  */
-export const ActivityStream: React.FC<ActivityStreamProps> = ({
+export const ActivityStream = React.forwardRef<HTMLDivElement, ActivityStreamProps>(({
   activities,
   pageSize = 10,
   onLoadMore,
@@ -156,7 +155,7 @@ export const ActivityStream: React.FC<ActivityStreamProps> = ({
   hasMore = false,
   showFilters = true,
   defaultFilters = {},
-}) => {
+}, ref) => {
   const [loadingMore, setLoadingMore] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [filters, setFilters] = useState<Record<string, unknown>>(defaultFilters);
@@ -516,7 +515,7 @@ export const ActivityStream: React.FC<ActivityStreamProps> = ({
   };
 
   return (
-    <Card className={`overflow-hidden ${className}`}>
+    <Card ref={ref} className={`overflow-hidden ${className}`}>
       {/* Header */}
       <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">ActivityPub Stream</h3>
@@ -835,4 +834,6 @@ export const ActivityStream: React.FC<ActivityStreamProps> = ({
       </div>
     </Card>
   );
-};
+});
+
+ActivityStream.displayName = 'ActivityStream';

--- a/packages/@smolitux/federation/src/components/CrossPlatformShare/CrossPlatformShare.tsx
+++ b/packages/@smolitux/federation/src/components/CrossPlatformShare/CrossPlatformShare.tsx
@@ -1,4 +1,3 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Checkbox, Tooltip, Alert } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';
@@ -12,14 +11,14 @@ interface CrossPlatformShareProps {
   isOpen: boolean;
 }
 
-export const CrossPlatformShare: React.FC<CrossPlatformShareProps> = ({
+export const CrossPlatformShare = React.forwardRef<HTMLDivElement, CrossPlatformShareProps>(({
   content,
   contentType,
   platforms,
   onShare,
   onClose,
   isOpen,
-}) => {
+}, ref) => {
   const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
   const [isSharing, setIsSharing] = useState(false);
   const [shareResult, setShareResult] = useState<{
@@ -96,7 +95,7 @@ export const CrossPlatformShare: React.FC<CrossPlatformShareProps> = ({
   };
 
   return (
-    <Card className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+    <Card ref={ref} className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <Card className="w-full max-w-lg p-6 mx-4 bg-white rounded-lg shadow-xl">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-semibold">Auf Plattformen teilen</h2>
@@ -187,6 +186,8 @@ export const CrossPlatformShare: React.FC<CrossPlatformShareProps> = ({
       </Card>
     </Card>
   );
-};
+});
+
+CrossPlatformShare.displayName = 'CrossPlatformShare';
 
 export default CrossPlatformShare;

--- a/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
+++ b/packages/@smolitux/federation/src/components/FederatedSearch/FederatedSearch.tsx
@@ -1,4 +1,3 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect, useRef } from 'react';
 import { Input, Button, Card } from '@smolitux/core';
 import { SearchResult, FederatedSearchProps } from '../../types';
@@ -6,7 +5,7 @@ import { SearchResult, FederatedSearchProps } from '../../types';
 /**
  * FederatedSearch-Komponente für die Suche über mehrere föderierte Plattformen
  */
-export const FederatedSearch: React.FC<FederatedSearchProps> = ({
+export const FederatedSearch = React.forwardRef<HTMLDivElement, FederatedSearchProps>(({
   platforms,
   onSearch,
   onResultClick,
@@ -15,7 +14,7 @@ export const FederatedSearch: React.FC<FederatedSearchProps> = ({
   placeholder = 'Suche über föderierte Plattformen...',
   defaultActivePlatforms,
   defaultFilters = {},
-}) => {
+}, ref) => {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [activePlatforms, setActivePlatforms] = useState<string[]>(
@@ -240,7 +239,7 @@ export const FederatedSearch: React.FC<FederatedSearchProps> = ({
   };
 
   return (
-    <div className={className}>
+    <div ref={ref} className={className}>
       {/* Suchleiste */}
       <div className="mb-4">
         <div className="flex">
@@ -670,4 +669,6 @@ export const FederatedSearch: React.FC<FederatedSearchProps> = ({
       ) : null}
     </div>
   );
-};
+});
+
+FederatedSearch.displayName = 'FederatedSearch';

--- a/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.tsx
+++ b/packages/@smolitux/federation/src/components/FederationSettings/FederationSettings.tsx
@@ -8,9 +8,9 @@ export interface FederationSettingsProps {
   className?: string;
 }
 
-export const FederationSettings: React.FC<FederationSettingsProps> = ({ protocols, enabled, onToggle, className }) => {
+export const FederationSettings = React.forwardRef<HTMLDivElement, FederationSettingsProps>(({ protocols, enabled, onToggle, className }, ref) => {
   return (
-    <Card className={className} data-testid="federation-settings">
+    <Card ref={ref} className={className} data-testid="federation-settings">
       <h3 className="font-semibold mb-2">Protocols</h3>
       <div className="space-y-2">
         {protocols.map((p) => (
@@ -26,6 +26,8 @@ export const FederationSettings: React.FC<FederationSettingsProps> = ({ protocol
       </div>
     </Card>
   );
-};
+});
+
+FederationSettings.displayName = 'FederationSettings';
 
 export default FederationSettings;

--- a/packages/@smolitux/federation/src/components/FederationStatus/FederationStatus.tsx
+++ b/packages/@smolitux/federation/src/components/FederationStatus/FederationStatus.tsx
@@ -1,4 +1,3 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState } from 'react';
 import { Card, Button, ProgressBar } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';
@@ -42,7 +41,7 @@ export interface FederationStatusProps {
 /**
  * FederationStatus-Komponente für die Anzeige des Föderationsstatus und der Verbindungen
  */
-export const FederationStatus: React.FC<FederationStatusProps> = ({
+export const FederationStatus = React.forwardRef<HTMLDivElement, FederationStatusProps>(({
   platforms,
   onRefresh,
   onConnect,
@@ -53,7 +52,7 @@ export const FederationStatus: React.FC<FederationStatusProps> = ({
   className = '',
   loading = false,
   federationStatus,
-}) => {
+}, ref) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [expandedPlatformId, setExpandedPlatformId] = useState<string | null>(null);
   const [actionInProgress, setActionInProgress] = useState<string | null>(null);
@@ -236,7 +235,7 @@ export const FederationStatus: React.FC<FederationStatusProps> = ({
   };
 
   return (
-    <Card className={`overflow-hidden ${className}`}>
+    <Card ref={ref} className={`overflow-hidden ${className}`}>
       {/* Header */}
       <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Föderationsstatus</h3>
@@ -537,4 +536,6 @@ export const FederationStatus: React.FC<FederationStatusProps> = ({
       </div>
     </Card>
   );
-};
+});
+
+FederationStatus.displayName = 'FederationStatus';

--- a/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.tsx
+++ b/packages/@smolitux/federation/src/components/IdentityBridge/IdentityBridge.tsx
@@ -12,9 +12,9 @@ export interface IdentityBridgeProps {
   className?: string;
 }
 
-export const IdentityBridge: React.FC<IdentityBridgeProps> = ({ identities, onUnlink, className }) => {
+export const IdentityBridge = React.forwardRef<HTMLDivElement, IdentityBridgeProps>(({ identities, onUnlink, className }, ref) => {
   return (
-    <Card className={className} data-testid="identity-bridge">
+    <Card ref={ref} className={className} data-testid="identity-bridge">
       <h3 className="font-semibold mb-2">Linked Identities</h3>
       <ul className="space-y-1">
         {identities.map((id) => (
@@ -30,6 +30,8 @@ export const IdentityBridge: React.FC<IdentityBridgeProps> = ({ identities, onUn
       </ul>
     </Card>
   );
-};
+});
+
+IdentityBridge.displayName = 'IdentityBridge';
 
 export default IdentityBridge;

--- a/packages/@smolitux/federation/src/components/PlatformSelector/PlatformSelector.tsx
+++ b/packages/@smolitux/federation/src/components/PlatformSelector/PlatformSelector.tsx
@@ -1,4 +1,3 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Input } from '@smolitux/core';
 import { FederatedPlatform } from '../../types';
@@ -37,7 +36,7 @@ export interface PlatformSelectorProps {
 /**
  * PlatformSelector-Komponente für die Auswahl und Konfiguration von Föderationsplattformen
  */
-export const PlatformSelector: React.FC<PlatformSelectorProps> = ({
+export const PlatformSelector = React.forwardRef<HTMLDivElement, PlatformSelectorProps>(({
   platforms,
   selectedPlatforms = [],
   onSelectionChange,
@@ -52,7 +51,7 @@ export const PlatformSelector: React.FC<PlatformSelectorProps> = ({
   showCategoryFilter = true,
   showSearch = true,
   showTrustFilter = true,
-}) => {
+}, ref) => {
   const [selection, setSelection] = useState<string[]>(selectedPlatforms);
   const [searchQuery, setSearchQuery] = useState('');
   const [newPlatformUrl, setNewPlatformUrl] = useState('');
@@ -212,7 +211,7 @@ export const PlatformSelector: React.FC<PlatformSelectorProps> = ({
   };
 
   return (
-    <Card className={`overflow-hidden ${className}`}>
+    <Card ref={ref} className={`overflow-hidden ${className}`}>
       {/* Header */}
       <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -557,4 +556,6 @@ export const PlatformSelector: React.FC<PlatformSelectorProps> = ({
       </div>
     </Card>
   );
-};
+});
+
+PlatformSelector.displayName = 'PlatformSelector';

--- a/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
+++ b/packages/@smolitux/federation/src/components/ProtocolHandler/ProtocolHandler.tsx
@@ -1,4 +1,3 @@
-// 🔧 TODO [Codex]: forwardRef hinzufügen – prüfen & umsetzen
 import React, { useEffect, useState } from 'react';
 import { Card, Button } from '@smolitux/core';
 import {
@@ -13,14 +12,14 @@ interface ConnectionState {
   socket?: WebSocket;
 }
 
-export const ProtocolHandler: React.FC<ProtocolHandlerProps> = ({
+export const ProtocolHandler = React.forwardRef<HTMLDivElement, ProtocolHandlerProps>(({
   protocols,
   onMessage,
   onConnection,
   errorHandling = { retries: 3, retryDelay: 1000 },
   authentication,
   className,
-}) => {
+}, ref) => {
   const [connections, setConnections] = useState<Record<string, ConnectionState>>(
     {}
   );
@@ -85,7 +84,7 @@ export const ProtocolHandler: React.FC<ProtocolHandlerProps> = ({
   };
 
   return (
-    <Card className={className} data-testid="protocol-handler">
+    <Card ref={ref} className={className} data-testid="protocol-handler">
       <h3 className="font-semibold mb-2">Protocol Connections</h3>
       <ul className="space-y-1">
         {protocols.map((p) => (
@@ -107,6 +106,8 @@ export const ProtocolHandler: React.FC<ProtocolHandlerProps> = ({
       </div>
     </Card>
   );
-};
+});
+
+ProtocolHandler.displayName = 'ProtocolHandler';
 
 export default ProtocolHandler;


### PR DESCRIPTION
## Summary
- fix jest config rootDir for `@smolitux/federation`
- implement `forwardRef` for federation components

## Testing
- `npm test --workspace=@smolitux/federation` *(fails: Directory ... in the roots[0] option was not found)*
- `npm run lint` *(fails: 1152 problems)*
- `npx tsc --noEmit` *(fails: pattern errors)*
- `bash scripts/validation/validate-build.sh` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8d039fc83248a19cf1c810b9089