### PR TITLE
Add open-source license usage docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 ### Changed
 
 - `Collapse` component now supports `forwardRef` and exposes the container ref.
-
-<<<<<<< HEAD
 ## [0.3.7] - 2025-06-10
 ### Fixed
 - Removed obsolete test TODO comments for chart components
@@ -61,6 +59,7 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 - `AudioPlayer` component now uses `forwardRef` and sets `displayName`.
 - `Slide` component now uses `forwardRef` for external ref access and updated tests
 - `FeedItem` in `@smolitux/resonance` now forwards refs correctly
+- Documentation page summarizing common open-source licenses
 ## [0.3.2] - 2025-06-08
 ### Added
 - Storybook stories for `NotificationCenter`

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Beiträge sind willkommen! Siehe [CONTRIBUTING.md](CONTRIBUTING.md) für Details
 ## 📄 License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for more information.
+For an overview of third-party licenses used in this project, see [Open-Source Licenses](docs/wiki/guides/open-source-licenses.md).
 
 ---
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -144,6 +144,7 @@ Our component library is organized into functional categories for easy navigatio
 - **[Internationalization](guides/internationalization.md)** - Multi-language support
 - **[Migration Guide](guides/migration-guide.md)** - Migrating between versions
 - **[Voice Control Guide](guides/voice-control-guide.md)** - Sprachsteuerung in der Praxis
+- **[Open-Source Licenses](guides/open-source-licenses.md)** - Overview of licenses used in dependencies
 - **[Examples](examples/form-examples.md)** - Code examples:
   - [Form Examples](examples/form-examples.md)
   - [Layout Examples](examples/layout-examples.md)


### PR DESCRIPTION
## Summary
- link new open-source licenses guide from README and wiki index
- record addition in CHANGELOG

## Testing
- `npm run lint` *(fails: various unused variables and type errors)*
- `npm test` *(fails: numerous test and type errors)*
- `npx tsc --noEmit` *(fails: invalid path patterns in tsconfig)*
- `bash scripts/validation/validate-build.sh` *(fails: missing theme files and invalid tsconfig patterns)*
- `bash scripts/workflows/generate-coverage-dashboard.sh --all`


------
https://chatgpt.com/codex/tasks/task_e_6848a7e4a6dc8324841c3bcab9e0d54e