### PR TITLE
Fix theme exports and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,17 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 
 > **Hinweis:** Die vollständige Dokumentation finden Sie im [Wiki](/docs/wiki/index.md). Die aktuelle Version des Changelogs finden Sie [hier](/docs/wiki/development/changelog.md).
 
+## [0.3.7] - 2025-06-20
+
+### Changed
+
+- Adjusted jest configuration path for `@smolitux/testing`
+- Added named export for `defaultTheme` in theme package
+
 ## [0.3.3] - 2025-06-17
+
 ### Added
+
 - Component counts documented in component-status.md
 
 ### Fixed
@@ -13,16 +22,22 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 - Updated TypeScript path mappings
 
 ## [0.3.4] - 2025-06-18
+
 ### Changed
+
 - Added forwardRef and data-testid to `Option` component
 - Updated related tests and stories
 
 ## [0.3.5] - 2025-06-18
+
 ### Changed
+
 - `Tooltip` component now uses `forwardRef` for external ref access
 
 ## [0.3.6] - 2025-06-19
+
 ### Changed
+
 - `Collapse` component now supports `forwardRef` and exposes the container ref.
 
 ## [0.3.7] - 2025-06-10
@@ -42,23 +57,30 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 ### Changed
 - `NotificationCenter` now forwards refs and exposes a `data-testid`
 ## [0.3.2] - 2025-06-08
+
 ### Added
+
 - Offline Komponentenscan und TODO-Liste erstellt
 
 ## [0.3.1] - 2025-06-08
 
 ### Added
+
 - component status updated with voice-control package
+
 ## [0.3.0] - 2025-06-08
+
 ### Added
+
 - minimal project setup without Lerna
 - central TypeScript, ESLint and Jest configuration
 
 ## [0.2.3] - 2025-06-08
+
 ### Changed
+
 - updated TypeScript build configuration for docs
 - declared Node.js and Docusaurus module types in root config
-
 
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/),
 und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -66,19 +88,23 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.2] - 2025-04-02
 
 ### Hinzugefügt
+
 - Umfassender Komponenten-Teststatus-Bericht in der Dokumentation
 - Detaillierte Release Notes für Version 0.2.2
 
 ### Geändert
+
 - Verbesserte Codeformatierung in allen Dateien
 - Aktualisierte Versionsnummer in package.json und lerna.json
 
 ### Behoben
+
 - Syntaxfehler in FormField.tsx behoben
 - Syntaxfehler in ActivityStream.tsx behoben
 - HTML-Dateien mit .tsx-Erweiterung in .html umbenannt, um TypeScript-Kompilierungsfehler zu vermeiden
 
 ### Hinzugefügt
+
 - Storybook-Stories für mehrere Komponenten (Button, Card, Avatar, Breadcrumb, Tooltip, Modal, Table, Accordion)
 - Cypress E2E-Tests für Komponenten
 - Cypress Accessibility-Tests
@@ -90,6 +116,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - TabView-Komponente: Unterstützung für `onChange`-Prop als Alias für `onTabChange`
 
 ### Verbessert
+
 - Überarbeitung der Button-Komponente mit besserer Barrierefreiheit
 - Flex-Komponente mit Tailwind-CSS-Integration
 - Verbesserte TypeScript-Typisierung für alle Komponenten
@@ -98,6 +125,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Aktualisierte Dokumentation mit neuen Varianten und Props
 
 ### Behoben
+
 - Barrierefreiheitsprobleme in mehreren Komponenten
 - Inkonsistenzen im Theming-System
 - Probleme mit der Tastaturnavigation in interaktiven Komponenten
@@ -107,6 +135,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.1] - 2025-03-26
 
 ### Hinzugefügt
+
 - Neue Komponenten für ResonanceLink:
   - Governance-Komponenten:
     - GovernanceDashboard: Übersicht über Community-Governance
@@ -134,6 +163,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - SmartContractInteraction: Interaktion mit Smart Contracts
 
 ### Verbessert
+
 - Verbesserte Typendefinitionen für alle Komponenten
 - Bessere Dokumentation mit JSDoc-Kommentaren
 - Optimierte Leistung bei komplexen Komponenten
@@ -142,6 +172,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Hinzugefügt: Test-App zur Demonstration der Komponenten
 
 ### Fehlerbehebungen
+
 - Behoben: Syntaxfehler in Charts-Komponenten
 - Behoben: Fehlerhafte Snapshot-Tests
 - Behoben: Probleme mit der Formularvalidierung
@@ -152,6 +183,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.0] - 2025-03-25
 
 ### Hinzugefügt
+
 - Erste Version der erweiterten Komponenten-Bibliothek
 - Neue Pakete für spezifische Anwendungsbereiche:
   - @smolitux/ai: KI-bezogene Komponenten
@@ -164,6 +196,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.1.0] - 2025-03-24
 
 ### Hinzugefügt
+
 - Erste Version der Smolitux UI Komponenten-Bibliothek
 - Core-Komponenten:
   - Alert: Für Benachrichtigungen und Warnungen
@@ -188,10 +221,12 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - useTheme: Hook für Theme-Zugriff
 
 ### Geändert
+
 - Alle Komponenten haben jetzt default exports
 - TypeScript-Deklarationsdateien (DTS) wurden vorübergehend deaktiviert
 
 ### Bekannte Probleme
+
 - Charts-Komponenten haben Syntaxfehler und sind noch nicht nutzbar
 - Einige Tests schlagen fehl aufgrund von Snapshot-Änderungen
 - Formularvalidierung und Internationalisierung sind noch nicht vollständig implementiert

--- a/docs/wiki/development/changelog.md
+++ b/docs/wiki/development/changelog.md
@@ -2,18 +2,23 @@
 
 Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert.
 
+## [0.3.7] - 2025-06-20
+
+### Changed
+
+- Adjusted jest configuration path for `@smolitux/testing`
+- Added named export for `defaultTheme` in theme package
+
 ## [0.3.1] - 2025-06-08
+
 - component status updated with voice-control package
 
 ## [0.3.2] - 2025-06-17
 - Removed legacy theme-provider implementation in @smolitux/theme
 - Updated monorepo TypeScript path mappings
-
-
 ## [0.2.3] - 2025-06-08
+
 - Updated TypeScript docs configuration
-
-
 
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/),
 und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -21,22 +26,26 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.2] - 2023-03-26
 
 ### Hinzugefügt
+
 - Button-Komponente: Unterstützung für `solid`-Variante als Alias für `primary`
 - Button-Komponente: Unterstützung für `outline`-Variante als Alias für `ghost`
 - Button-Komponente: Unterstützung für `isLoading`-Prop als Alias für `loading`
 - TabView-Komponente: Unterstützung für `onChange`-Prop als Alias für `onTabChange`
 
 ### Geändert
+
 - Verbesserte Exportstruktur in der Utils-Bibliothek für einfachere Importe
 - Aktualisierte Dokumentation mit neuen Varianten und Props
 
 ### Behoben
+
 - Typfehler in der Button-Komponente
 - Typfehler in der TabView-Komponente
 
 ## [0.2.1] - 2025-03-26
 
 ### Hinzugefügt
+
 - Neue Komponenten für ResonanceLink:
   - Governance-Komponenten:
     - GovernanceDashboard: Übersicht über Community-Governance
@@ -64,6 +73,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - SmartContractInteraction: Interaktion mit Smart Contracts
 
 ### Verbessert
+
 - Verbesserte Typendefinitionen für alle Komponenten
 - Bessere Dokumentation mit JSDoc-Kommentaren
 - Optimierte Leistung bei komplexen Komponenten
@@ -72,6 +82,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Hinzugefügt: Test-App zur Demonstration der Komponenten
 
 ### Fehlerbehebungen
+
 - Behoben: Syntaxfehler in Charts-Komponenten
 - Behoben: Fehlerhafte Snapshot-Tests
 - Behoben: Probleme mit der Formularvalidierung
@@ -82,6 +93,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.0] - 2025-03-25
 
 ### Hinzugefügt
+
 - Erste Version der erweiterten Komponenten-Bibliothek
 - Neue Pakete für spezifische Anwendungsbereiche:
   - @smolitux/ai: KI-bezogene Komponenten
@@ -94,6 +106,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.1.0] - 2025-03-24
 
 ### Hinzugefügt
+
 - Erste Version der Smolitux UI Komponenten-Bibliothek
 - Core-Komponenten:
   - Alert: Für Benachrichtigungen und Warnungen
@@ -118,15 +131,17 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - useTheme: Hook für Theme-Zugriff
 
 ### Geändert
+
 - Alle Komponenten haben jetzt default exports
 - TypeScript-Deklarationsdateien (DTS) wurden vorübergehend deaktiviert
 
 ### Bekannte Probleme
+
 - Charts-Komponenten haben Syntaxfehler und sind noch nicht nutzbar
 - Einige Tests schlagen fehl aufgrund von Snapshot-Änderungen
 - Formularvalidierung und Internationalisierung sind noch nicht vollständig implementiert
+
 ## [0.3.0] - 2025-06-08
+
 - Repository reinitialized without Lerna
 - Minimal TypeScript, ESLint and Jest setup
-
-

--- a/packages/@smolitux/theme/src/Index.tsx
+++ b/packages/@smolitux/theme/src/Index.tsx
@@ -1,7 +1,6 @@
 // Export all theme related components and utilities
 export * from './types';
 export * from './Default';
+export { defaultTheme } from './Default';
 export * from './themeProvider';
 export * from './themeUtils';
-
-export default {};

--- a/packages/@smolitux/theme/src/index.ts
+++ b/packages/@smolitux/theme/src/index.ts
@@ -1,10 +1,26 @@
-export { ThemeProvider, useTheme, type ThemeMode, type ThemeConfig } from './providers/ThemeProvider';
+export {
+  ThemeProvider,
+  useTheme,
+  type ThemeMode,
+  type ThemeConfig,
+} from './providers/ThemeProvider';
 export { colors as ColorSystem } from './tokens/colors';
 export { typography as Typography } from './tokens/typography';
 export { spacing as Spacing } from './tokens/spacing';
 export { breakpoints as BreakPoints } from './tokens/breakpoints';
 export { tokens, type Tokens } from './tokens';
 export { createCssVariables, applyCssVariables } from './utils/cssVariables';
-export type { Theme, ThemeOptions, ColorShades, Colors, Typography, Spacing, BorderRadius, Shadows, Breakpoints, ZIndices } from './theme-types';
+export type {
+  Theme,
+  ThemeOptions,
+  ColorShades,
+  Colors,
+  Typography,
+  Spacing,
+  BorderRadius,
+  Shadows,
+  Breakpoints,
+  ZIndices,
+} from './theme-types';
 export { ThemeTypen } from './ThemeTypen';
 export { defaultTheme } from './Default';


### PR DESCRIPTION
## Summary
- export `defaultTheme` in the theme package index files
- remove empty default export from theme Index
- document latest changes in CHANGELOGs

## Testing
- `npm test --workspace=packages/@smolitux/testing` *(fails: TS errors)*
- `npm run lint` *(fails: numerous lint errors)*
- `npx tsc --noEmit` *(fails: TS5061 pattern issue)*
- `bash scripts/validation/validate-build.sh` *(fails: build errors)*
- `bash scripts/workflows/generate-coverage-dashboard.sh --all`

------
https://chatgpt.com/codex/tasks/task_e_6848a906a6f8832483c2d38fa8bc0b9b