### PR TITLE
Fix AudioPlayer forwardRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 
 - `Collapse` component now supports `forwardRef` and exposes the container ref.
 ## [0.3.7] - 2025-06-10
+### Changed
+- `AudioPlayer` component now uses `forwardRef` and sets `displayName`.
 ### Fixed
 - Removed obsolete test TODO comments for chart components
 - Updated documentation to reflect existing tests

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,8 +35,6 @@
       "@smolitux/utils": ["packages/@smolitux/utils/src"],
       "@smolitux/utils/*": ["packages/@smolitux/utils/src/*"],
       "@smolitux/voice-control": ["packages/@smolitux/voice-control/src"],
-      "@smolitux/voice-control/*": ["packages/@smolitux/voice-control/src/*"]
-      "@smolitux/voice-control": ["packages/@smolitux/voice-control/src"],
       "@smolitux/voice-control/*": ["packages/@smolitux/voice-control/src/*"],
       "@smolitux/*": ["packages/@smolitux/*/src"]
     }


### PR DESCRIPTION
## Summary
- use `forwardRef` and `displayName` in AudioPlayer
- update tests for AudioPlayer to load metadata
- fix jest config for media package
- clean up tsconfig path mapping

## Testing
- `npm test -- packages/@smolitux/media/src/components/AudioPlayer/__tests__/AudioPlayer.test.tsx`
- `npx eslint packages/@smolitux/media/src/components/AudioPlayer --ext .ts,.tsx`
- `npx tsc --noEmit` *(fails: errors in voice-control package)*
- `bash scripts/validation/validate-build.sh` *(fails: theme build errors)*
- `bash scripts/workflows/generate-coverage-dashboard.sh --package media`


------
https://chatgpt.com/codex/tasks/task_e_6848a8ebf35c83248dfb8fb3189486e9