### PR TITLE
Enhance FeedItem tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,17 +39,22 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 ### Changed
 
 - `Collapse` component now supports `forwardRef` and exposes the container ref.
+<<<<<<< HEAD
 ## [0.3.7] - 2025-06-10
 ### Changed
 - `AudioPlayer` component now uses `forwardRef` and sets `displayName`.
 ### Fixed
 - Removed obsolete test TODO comments for chart components
 - Updated documentation to reflect existing tests
+
 ## [0.3.7] - 2025-06-19
 ### Changed
 - Updated EthereumProvider typing with generic request results
 - Implemented `forwardRef` for WalletConnect, TokenDisplay and TransactionHistory
 - Simplified tests and added ref forwarding checks
+### Fixed
+- `FeedItem` in `@smolitux/resonance` now forwards refs correctly
+
 ## [0.3.8] - 2025-06-20
 ### Added
 - forwardRef support for `DashboardLayout`
@@ -60,7 +65,6 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 - `NotificationCenter` now forwards refs and exposes a `data-testid`
 - `AudioPlayer` component now uses `forwardRef` and sets `displayName`.
 - `Slide` component now uses `forwardRef` for external ref access and updated tests
-- `FeedItem` in `@smolitux/resonance` now forwards refs correctly
 - Documentation page summarizing common open-source licenses
 ## [0.3.2] - 2025-06-08
 ### Added

--- a/docs/wiki/development/changelog.md
+++ b/docs/wiki/development/changelog.md
@@ -8,8 +8,10 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 
 - Adjusted jest configuration path for `@smolitux/testing`
 - Added named export for `defaultTheme` in theme package
-- `FeedItem` in `@smolitux/resonance` now forwards refs correctly
 - `Slide` component now forwards refs and tests were updated accordingly.
+
+### Fixed
+- `FeedItem` in `@smolitux/resonance` now forwards refs correctly
 
 ## [0.3.1] - 2025-06-08
 

--- a/packages/@smolitux/resonance/src/components/feed/FeedItem.test.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedItem.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { FeedItem, FeedItemData } from './FeedItem';
 
 describe('FeedItem', () => {
@@ -11,6 +11,16 @@ describe('FeedItem', () => {
     content: { text: 'Hello world' },
     stats: { likes: 0, comments: 0, shares: 0, views: 0 },
   };
+
+  it('renders without crashing', () => {
+    render(<FeedItem item={demoItem} />);
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<FeedItem item={demoItem} className="custom" />);
+    expect(screen.getByTestId('card')).toHaveClass('feed-item custom');
+  });
 
   it('forwards ref to root element', () => {
     const ref = React.createRef<HTMLDivElement>();

--- a/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
+++ b/packages/@smolitux/resonance/src/components/feed/FeedItem.tsx
@@ -355,3 +355,5 @@ export const FeedItem = React.forwardRef<HTMLDivElement, FeedItemProps>(
     </Card>
   );
 });
+
+FeedItem.displayName = 'FeedItem';


### PR DESCRIPTION
## Summary
- add `displayName` for `FeedItem`
- expand unit tests for FeedItem to keep coverage

## Testing
- `npm test` *(fails: Slider, Input, Tabs, etc.)*
- `npm run lint` *(fails: voice-control package lint errors)*
- `npx tsc --noEmit` *(fails: invalid tsconfig pattern)*
- `bash scripts/validation/validate-build.sh` *(fails: theme package build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8f8cf108324a4c869e25c80ef1e