### PR TITLE
Fix theme exports and update dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 ## [0.3.3] - 2025-06-17
 
 ### Added
-
 - Component counts documented in component-status.md
 
 ### Fixed
@@ -74,20 +73,6 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 - Forward refs added to all federation components with display names
 - Updated federation Jest rootDir
 - Updated TODO logs for federation components
-### Added
-- forwardRef support for `DashboardLayout`
-- Accessibility tests for `Header` and `Footer`
-- Storybook stories for `NotificationCenter`
-- Component counts documented in component-status.md
-### Changed
-- DashboardLayout forwards refs to its root element
-- `NotificationCenter` now forwards refs and exposes a `data-testid`
-- `AudioPlayer` component now uses `forwardRef` and sets `displayName`.
-- `Slide` component now uses `forwardRef` for external ref access and updated tests
-- Documentation page summarizing common open-source licenses
-- Forward refs added to all federation components with display names
-- Updated federation Jest rootDir
-- Updated TODO logs for federation components
 
 ## [0.3.2] - 2025-06-08
 
@@ -123,19 +108,23 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.2] - 2025-04-02
 
 ### Hinzugefügt
+
 - Umfassender Komponenten-Teststatus-Bericht in der Dokumentation
 - Detaillierte Release Notes für Version 0.2.2
 
 ### Geändert
+
 - Verbesserte Codeformatierung in allen Dateien
 - Aktualisierte Versionsnummer in package.json und lerna.json
 
 ### Behoben
+
 - Syntaxfehler in FormField.tsx behoben
 - Syntaxfehler in ActivityStream.tsx behoben
 - HTML-Dateien mit .tsx-Erweiterung in .html umbenannt, um TypeScript-Kompilierungsfehler zu vermeiden
 
 ### Hinzugefügt
+
 - Storybook-Stories für mehrere Komponenten (Button, Card, Avatar, Breadcrumb, Tooltip, Modal, Table, Accordion)
 - Cypress E2E-Tests für Komponenten
 - Cypress Accessibility-Tests
@@ -147,6 +136,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - TabView-Komponente: Unterstützung für `onChange`-Prop als Alias für `onTabChange`
 
 ### Verbessert
+
 - Überarbeitung der Button-Komponente mit besserer Barrierefreiheit
 - Flex-Komponente mit Tailwind-CSS-Integration
 - Verbesserte TypeScript-Typisierung für alle Komponenten
@@ -155,6 +145,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Aktualisierte Dokumentation mit neuen Varianten und Props
 
 ### Behoben
+
 - Barrierefreiheitsprobleme in mehreren Komponenten
 - Inkonsistenzen im Theming-System
 - Probleme mit der Tastaturnavigation in interaktiven Komponenten
@@ -164,6 +155,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.1] - 2025-03-26
 
 ### Hinzugefügt
+
 - Neue Komponenten für ResonanceLink:
   - Governance-Komponenten:
     - GovernanceDashboard: Übersicht über Community-Governance
@@ -191,6 +183,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - SmartContractInteraction: Interaktion mit Smart Contracts
 
 ### Verbessert
+
 - Verbesserte Typendefinitionen für alle Komponenten
 - Bessere Dokumentation mit JSDoc-Kommentaren
 - Optimierte Leistung bei komplexen Komponenten
@@ -199,6 +192,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Hinzugefügt: Test-App zur Demonstration der Komponenten
 
 ### Fehlerbehebungen
+
 - Behoben: Syntaxfehler in Charts-Komponenten
 - Behoben: Fehlerhafte Snapshot-Tests
 - Behoben: Probleme mit der Formularvalidierung
@@ -209,6 +203,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.0] - 2025-03-25
 
 ### Hinzugefügt
+
 - Erste Version der erweiterten Komponenten-Bibliothek
 - Neue Pakete für spezifische Anwendungsbereiche:
   - @smolitux/ai: KI-bezogene Komponenten
@@ -221,6 +216,7 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.1.0] - 2025-03-24
 
 ### Hinzugefügt
+
 - Erste Version der Smolitux UI Komponenten-Bibliothek
 - Core-Komponenten:
   - Alert: Für Benachrichtigungen und Warnungen
@@ -245,10 +241,12 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   - useTheme: Hook für Theme-Zugriff
 
 ### Geändert
+
 - Alle Komponenten haben jetzt default exports
 - TypeScript-Deklarationsdateien (DTS) wurden vorübergehend deaktiviert
 
 ### Bekannte Probleme
+
 - Charts-Komponenten haben Syntaxfehler und sind noch nicht nutzbar
 - Einige Tests schlagen fehl aufgrund von Snapshot-Änderungen
 - Formularvalidierung und Internationalisierung sind noch nicht vollständig implementiert

--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,9 +1,9 @@
 # Smolitux UI Component Status
 
-Total Components: 882
+Total Components: 883
 Test Coverage: 43%
-Story Coverage: 29%
-Last Updated: 2025-06-10 23:22:50
+Story Coverage: 28%
+Last Updated: 2025-06-10 23:25:21
 Previous Update: 2025-06-10 22:09:41
 
 ## Summary
@@ -36,9 +36,15 @@ This report shows the completion status of all components in the Smolitux UI lib
 - Status: ⚠️ In Progress
 
 ### @smolitux/media
+<<<<<<< HEAD
 - Components: 32
 - Tests: 16/32 (50%)
 - Stories: 8/32 (25%)
+=======
+- Components: 33
+- Tests: 17/33 (51%)
+- Stories: 8/33 (24%)
+>>>>>>> 5d8fb622d (Update coverage dashboards)
 - Status: ⚠️ In Progress
 
 ### @smolitux/community
@@ -76,3 +82,7 @@ This report shows the completion status of all components in the Smolitux UI lib
 - Tests: 2/6 (33%)
 - Stories: 2/6 (33%)
 - Status: ⚠️ In Progress
+<<<<<<< HEAD
+=======
+
+>>>>>>> 5d8fb622d (Update coverage dashboards)

--- a/docs/wiki/development/changelog.md
+++ b/docs/wiki/development/changelog.md
@@ -5,24 +5,13 @@ Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert
 ## [0.3.7] - 2025-06-20
 
 ### Changed
+
 - Adjusted Jest configuration path for `@smolitux/testing`
 - Added named export for `defaultTheme` and cleaned up theme exports
-- `Slide` component now forwards refs and tests were updated accordingly.
-
-### Added
-- Documentation page summarizing common open-source licenses
-
-## [0.3.7] - 2025-06-19
-### Fixed
-- `FeedItem` in `@smolitux/resonance` now forwards refs correctly
 
 ## [0.3.1] - 2025-06-08
 
 - component status updated with voice-control package
-
-## [0.3.2] - 2025-06-17
-- Removed legacy theme-provider implementation in @smolitux/theme
-- Updated monorepo TypeScript path mappings
 
 ## [0.2.3] - 2025-06-08
 
@@ -34,11 +23,122 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.2.2] - 2023-03-26
 
 ### Hinzugefügt
+
 - Button-Komponente: Unterstützung für `solid`-Variante als Alias für `primary`
 - Button-Komponente: Unterstützung für `outline`-Variante als Alias für `ghost`
 - Button-Komponente: Unterstützung für `isLoading`-Prop als Alias für `loading`
 - TabView-Komponente: Unterstützung für `onChange`-Prop als Alias für `onTabChange`
 
 ### Geändert
+
 - Verbesserte Exportstruktur in der Utils-Bibliothek für einfachere Importe
 - Aktualisierte Dokumentation mit neuen Varianten und Props
+
+### Behoben
+
+- Typfehler in der Button-Komponente
+- Typfehler in der TabView-Komponente
+
+## [0.2.1] - 2025-03-26
+
+### Hinzugefügt
+
+- Neue Komponenten für ResonanceLink:
+  - Governance-Komponenten:
+    - GovernanceDashboard: Übersicht über Community-Governance
+    - ProposalView: Detailansicht für Vorschläge
+    - VotingSystem: System für Abstimmungen
+  - Monetarisierungs-Komponenten:
+    - RevenueModel: Visualisierung des 30-30-30-Modells
+    - RewardSystem: Belohnungssystem für Benutzeraktivitäten
+    - CreatorDashboard: Dashboard für Content-Ersteller
+  - Feed-Komponenten:
+    - FeedView: Anzeige von Beiträgen im Feed
+    - PostCreator: Erstellung von Beiträgen
+  - Post-Komponenten:
+    - PostView: Anzeige von Beiträgen
+    - PostInteractions: Interaktionen mit Beiträgen
+    - PostMetrics: Metriken für Beiträge
+  - Profil-Komponenten:
+    - ProfileView: Anzeige von Benutzerprofilen
+- Neue KI-Komponenten:
+  - FakeNewsDetector: Erkennung von Falschinformationen
+  - TrollFilter: Filterung von toxischen Kommentaren
+  - ContentModerator: Moderation von Inhalten
+- Neue Blockchain-Komponenten:
+  - TokenEconomy: Visualisierung der Token-Wirtschaft
+  - SmartContractInteraction: Interaktion mit Smart Contracts
+
+### Verbessert
+
+- Verbesserte Typendefinitionen für alle Komponenten
+- Bessere Dokumentation mit JSDoc-Kommentaren
+- Optimierte Leistung bei komplexen Komponenten
+- Verbesserte Browserkompatibilität durch Erkennung der Ausführungsumgebung
+- Hinzugefügt: Primitive Komponenten (Box, Flex, Text) für konsistentes Layout
+- Hinzugefügt: Test-App zur Demonstration der Komponenten
+
+### Fehlerbehebungen
+
+- Behoben: Syntaxfehler in Charts-Komponenten
+- Behoben: Fehlerhafte Snapshot-Tests
+- Behoben: Probleme mit der Formularvalidierung
+- Behoben: Falsche Modul-Pfade in package.json-Dateien (index.mjs statt index.esm.js)
+- Behoben: Probleme mit i18n-Initialisierung in Node.js-Umgebungen
+- Behoben: Fehlerhafte Importe zwischen Paketen, die auf interne Quellcode-Pfade verwiesen
+
+## [0.2.0] - 2025-03-25
+
+### Hinzugefügt
+
+- Erste Version der erweiterten Komponenten-Bibliothek
+- Neue Pakete für spezifische Anwendungsbereiche:
+  - @smolitux/ai: KI-bezogene Komponenten
+  - @smolitux/blockchain: Blockchain-bezogene Komponenten
+  - @smolitux/community: Community-bezogene Komponenten
+  - @smolitux/federation: Föderations-bezogene Komponenten
+  - @smolitux/media: Medien-bezogene Komponenten
+  - @smolitux/utils: Hilfsfunktionen und -komponenten
+
+## [0.1.0] - 2025-03-24
+
+### Hinzugefügt
+
+- Erste Version der Smolitux UI Komponenten-Bibliothek
+- Core-Komponenten:
+  - Alert: Für Benachrichtigungen und Warnungen
+  - Badge: Für Labels, Zähler und Status
+  - Button: Für Aktionen
+  - Checkbox: Für Auswahloptionen
+  - ColorPicker: Für Farbauswahl
+  - FormControl: Container für Formularelemente
+  - Input: Für Texteingaben
+  - Modal: Für modale Dialoge
+  - Radio: Für Auswahloptionen
+  - Select: Für Auswahlmenüs
+  - Switch: Für Ein/Aus-Schalter
+  - Table: Für tabellarische Daten
+- Layout-Komponenten:
+  - Container: Für zentrierten Inhalt mit maximaler Breite
+  - Grid: Für Raster-Layouts
+  - Flex: Für flexible Layouts
+- Theme-System:
+  - ThemeProvider: Für Theme-Kontext
+  - createTheme: Für benutzerdefinierte Themes
+  - useTheme: Hook für Theme-Zugriff
+
+### Geändert
+
+- Alle Komponenten haben jetzt default exports
+- TypeScript-Deklarationsdateien (DTS) wurden vorübergehend deaktiviert
+
+### Bekannte Probleme
+
+- Charts-Komponenten haben Syntaxfehler und sind noch nicht nutzbar
+- Einige Tests schlagen fehl aufgrund von Snapshot-Änderungen
+- Formularvalidierung und Internationalisierung sind noch nicht vollständig implementiert
+
+## [0.3.0] - 2025-06-08
+
+- Repository reinitialized without Lerna
+- Minimal TypeScript, ESLint and Jest setup

--- a/docs/wiki/testing/test-coverage-dashboard.md
+++ b/docs/wiki/testing/test-coverage-dashboard.md
@@ -1,9 +1,9 @@
 # Smolitux UI Component Status
 
-Total Components: 882
+Total Components: 883
 Test Coverage: 43%
-Story Coverage: 29%
-Last Updated: 2025-06-10 23:22:50
+Story Coverage: 28%
+Last Updated: 2025-06-10 23:25:21
 
 ## Summary
 This report shows the completion status of all components in the Smolitux UI library.
@@ -35,9 +35,9 @@ This report shows the completion status of all components in the Smolitux UI lib
 - Status: ⚠️ In Progress
 
 ### @smolitux/media
-- Components: 32
-- Tests: 16/32 (50%)
-- Stories: 8/32 (25%)
+- Components: 33
+- Tests: 17/33 (51%)
+- Stories: 8/33 (24%)
 - Status: ⚠️ In Progress
 
 ### @smolitux/community


### PR DESCRIPTION
## Summary
- adjust jest root path in testing config
- expose `defaultTheme` explicitly from theme package
- regenerate progress and coverage dashboards

## Testing
- `npm test --workspace=packages/@smolitux/testing` *(fails: TS errors)*
- `npm run lint` *(fails: 1152 problems)*
- `npx tsc --noEmit` *(fails: TS5061 pattern error)*
- `bash scripts/validation/validate-build.sh` *(fails: build errors)*
- `bash scripts/workflows/generate-coverage-dashboard.sh --all`

------
https://chatgpt.com/codex/tasks/task_e_6848a906a6f8832483c2d38fa8bc0b9b