### PR TITLE
Fix federation todos

### DIFF
--- a/packages/@smolitux/federation/jest.config.js
+++ b/packages/@smolitux/federation/jest.config.js
@@ -3,5 +3,6 @@ const base = require('../../../jest.config');
 module.exports = {
   ...base,
   rootDir: path.resolve(__dirname, '../../..'),
+  roots: ['<rootDir>/packages/@smolitux/federation'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };


### PR DESCRIPTION
## Summary
- mark federation forwardRef TODOs as complete
- set federation Jest rootDir to repo root
- forward refs & add display names in all federation components
- document federation ref updates
- limit Jest root to the federation package

## Testing
- `bash scripts/analysis/analyze-repo.sh` *(fails: multiple TypeScript and test errors across repo)*
- `npm test --workspace=@smolitux/federation` *(fails: upstream type errors)*
- `npm run lint` *(fails: 1152 problems across repository)*
- `npx tsc --noEmit` *(fails: invalid tsconfig pattern)*
- `bash scripts/validation/validate-build.sh` *(fails: build errors)*


------
https://chatgpt.com/codex/tasks/task_e_6848a8d039fc83248a19cf1c810b9089