### PR TITLE
Fix AudioPlayer forwardRef

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "types": ["node", "jest"],
     "baseUrl": ".",
     "paths": {
+      "@smolitux/*": ["packages/@smolitux/*/src"],
       "@smolitux/ai": ["packages/@smolitux/ai/src"],
       "@smolitux/ai/*": ["packages/@smolitux/ai/src/*"],
       "@smolitux/blockchain": ["packages/@smolitux/blockchain/src"],
@@ -35,7 +36,7 @@
       "@smolitux/utils": ["packages/@smolitux/utils/src"],
       "@smolitux/utils/*": ["packages/@smolitux/utils/src/*"],
       "@smolitux/voice-control": ["packages/@smolitux/voice-control/src"],
-      "@smolitux/voice-control/*": ["packages/@smolitux/voice-control/src/*"],
+      "@smolitux/voice-control/*": ["packages/@smolitux/voice-control/src/*"]
     }
   },
   "include": ["packages", "docs"],


### PR DESCRIPTION
## Summary
- use `forwardRef` in AudioPlayer and attach `displayName`
- update tests for ref forwarding and metadata loading
- document forwardRef usage in media README
- update changelog and comment log
- fix package Jest config
- simplify TypeScript paths
- revert accidental status and coverage changes

## Testing
- `npm test -- packages/@smolitux/media/src/components/AudioPlayer/__tests__/AudioPlayer.test.tsx`
- `npx eslint packages/@smolitux/media/src/components/AudioPlayer --ext .ts,.tsx`
- `npx tsc --noEmit` *(fails due to voice-control package errors)*
- `bash scripts/validation/validate-build.sh` *(fails: theme build errors)*
- `bash scripts/workflows/generate-coverage-dashboard.sh --package media` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8ebf35c83248dfb8fb3189486e9