### PR TITLE
feat(core): Button - production ready

### DIFF
--- a/packages/@smolitux/core/src/components/Button/Button.stories.tsx
+++ b/packages/@smolitux/core/src/components/Button/Button.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from './Button';
 
@@ -138,4 +139,11 @@ export const AllVariants: Story = {
       </div>
     </div>
   ),
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [count, setCount] = React.useState(0);
+    return <Button onClick={() => setCount((c) => c + 1)}>Clicked {count} times</Button>;
+  },
 };

--- a/packages/@smolitux/core/src/components/Button/Button.test.tsx
+++ b/packages/@smolitux/core/src/components/Button/Button.test.tsx
@@ -10,7 +10,7 @@ describe('Button', () => {
   // Rendering tests
   it('renders without crashing', () => {
     render(<Button>Test</Button>);
-    expect(screen.getByTestId('Button')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
   it('renders children correctly', () => {
@@ -35,12 +35,19 @@ describe('Button', () => {
     expect(screen.getByTestId('Button')).toHaveClass('smx-button--lg');
   });
 
+  it('uses button element with type attribute', () => {
+    render(<Button>Test</Button>);
+    const element = screen.getByRole('button');
+    expect(element.tagName).toBe('BUTTON');
+    expect(element).toHaveAttribute('type', 'button');
+  });
+
   // Disabled state tests
   it('applies disabled state correctly', () => {
     render(<Button disabled>Test</Button>);
-    const element = screen.getByTestId('Button');
+    const element = screen.getByRole('button');
     expect(element).toHaveClass('smx-button--disabled');
-    expect(element).toHaveAttribute('aria-disabled', 'true');
+    expect(element).toBeDisabled();
   });
 
   // Interaction tests
@@ -48,17 +55,21 @@ describe('Button', () => {
     const user = userEvent.setup();
     const handleClick = jest.fn();
     render(<Button onClick={handleClick}>Test</Button>);
-    
-    await user.click(screen.getByTestId('Button'));
+
+    await user.click(screen.getByRole('button'));
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
   it('does not trigger click when disabled', async () => {
     const user = userEvent.setup();
     const handleClick = jest.fn();
-    render(<Button onClick={handleClick} disabled>Test</Button>);
-    
-    await user.click(screen.getByTestId('Button'));
+    render(
+      <Button onClick={handleClick} disabled>
+        Test
+      </Button>
+    );
+
+    await user.click(screen.getByRole('button'));
     expect(handleClick).not.toHaveBeenCalled();
   });
 

--- a/packages/@smolitux/core/src/components/Button/Button.tsx
+++ b/packages/@smolitux/core/src/components/Button/Button.tsx
@@ -4,23 +4,11 @@ import { clsx } from '@smolitux/utils';
 /**
  * Props for the Button component
  */
-export interface ButtonProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Whether the button is an icon button */
-  isIconButton?: boolean;
-  /** ID of the button */
-  id?: string;
-  /** Content to display inside the component */
-  children?: React.ReactNode;
-  /** Additional CSS classes to apply */
-  className?: string;
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual variant of the component */
   variant?: 'primary' | 'secondary' | 'tertiary' | 'danger';
   /** Size variant of the component */
   size?: 'sm' | 'md' | 'lg';
-  /** Whether the component is disabled */
-  disabled?: boolean;
-  /** Click event handler */
-  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
 /**
@@ -34,7 +22,7 @@ export interface ButtonProps extends React.HTMLAttributes<HTMLDivElement> {
  * <Button variant="primary">Content</Button>
  * ```
  */
-export const Button = forwardRef<HTMLDivElement, ButtonProps>(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       children,
@@ -42,32 +30,28 @@ export const Button = forwardRef<HTMLDivElement, ButtonProps>(
       variant = 'primary',
       size = 'md',
       disabled = false,
-      onClick,
+      type = 'button',
       ...props
     },
     ref
-  ) => {
-    return (
-      <div
-        ref={ref}
-        className={clsx(
-          'smx-button',
-          `smx-button--${variant}`,
-          `smx-button--${size}`,
-          {
-            'smx-button--disabled': disabled,
-          },
-          className
-        )}
-        onClick={disabled ? undefined : onClick}
-        aria-disabled={disabled}
-        data-testid="Button"
-        {...props}
-      >
-        {children}
-      </div>
-    );
-  }
+  ) => (
+    <button
+      ref={ref}
+      type={type}
+      className={clsx(
+        'smx-button',
+        `smx-button--${variant}`,
+        `smx-button--${size}`,
+        { 'smx-button--disabled': disabled },
+        className
+      )}
+      disabled={disabled}
+      data-testid="Button"
+      {...props}
+    >
+      {children}
+    </button>
+  )
 );
 
 Button.displayName = 'Button';

--- a/packages/@smolitux/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/@smolitux/core/src/components/Tooltip/Tooltip.tsx
@@ -162,14 +162,18 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   }, [isVisible]);
 
   // Clone trigger element with event listeners
-  const triggerElement = React.cloneElement(children, {
-    ref: (node: HTMLElement | null) => {
+    const triggerElement = React.cloneElement(children, {
+      ref: (node: HTMLElement | null) => {
       if (node) {
         triggerRef.current = node;
       }
 
       // Forward ref if the original element has one
-      const originalRef = (children as any).ref;
+      const originalRef = (children as React.ReactElement).ref as
+        | ((instance: HTMLElement | null) => void)
+        | React.RefObject<HTMLElement>
+        | null
+        | undefined;
       if (typeof originalRef === 'function') {
         originalRef(node);
       }


### PR DESCRIPTION
## Summary
- implement Button with native button element using forwardRef
- update tests for accessibility and interactions
- document interactive Button story
- fix tooltip ref typing

## Testing
- `npx jest --config packages/@smolitux/core/jest.config.js --testMatch "<rootDir>/packages/@smolitux/core/src/components/Button/Button.test.tsx"`
- `npm run lint --workspace=@smolitux/core` *(fails: hundreds of unrelated lint errors)*
- `npm run build --workspace=@smolitux/core` *(fails: type errors in Motion.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6849a7a961d48324ac68f7219ef82788